### PR TITLE
Feature/cvxif coprocessors

### DIFF
--- a/core/rb_cva6_copro_crc/README.md
+++ b/core/rb_cva6_copro_crc/README.md
@@ -16,10 +16,7 @@ The design flow is also run on the copro from this repository, if needed.
 
 This repository is structured according to the standard EIY folder structure :
 * rtl_v : contains RTL files
-* test_c : contains C files used for tests **(To be filled)**
-* tb_v : contains testbench files **(To be filled)**
-* scripts : Makefiles to run the testbenches **(To be filled)**
-* saxo : Makefile and setup scripts for packaging with the SAXO tool, in particular for xcelium_check **(To be filled)**
+
 
 ## Links and resources <a name="links-resources"></a>
 * [EU TRISTAN project description](https://cordis.europa.eu/project/id/101095947)

--- a/core/rb_cva6_copro_crc/README.md
+++ b/core/rb_cva6_copro_crc/README.md
@@ -1,0 +1,61 @@
+# TRISTAN/rb_cva6_cropro_crc
+This repository is holding the source RTL for the copro CRC designed by Bosch, in the contest of the TRISTAN project.
+Additionnaly, some testbenches are available.
+The design flow is also run on the copro from this repository, if needed.
+
+## Table of Contents <!-- omit in toc -->
+- [How to use this repo](#howto)
+- [Directory Structure](#directory-structure)
+- [Links and resources](#links-resources)
+- [About](#about)
+  - [Maintainers](#maintainers)
+
+## How to use this repo <a name="howto"></a>
+
+This repository cannot be used standalone and require a tada environment and other associated repos.
+To setup a working environment do the following
+```
+tada -new my/tristan_fe/my_workspace
+repoinit
+repo sync
+## This is needed to load the module tools as it is not done automatically during the tada creation
+tada -exit
+tada my/tristan_fe/my_workspace
+libgen.sh
+```
+By default, it is the master branch that is available. All changes should be done
+on a branch, derived from the develop branch. A branch should be limited to one bugfix or improvement/modification.
+Develop and master branches can only be modified through pull request with a review process.
+A more detailed explanation of the branching model is available on [Docupedia](https://inside-docupedia.bosch.com/confluence/display/TRISTAN/TRISTAN+Home)
+
+To work on a feature on this repository :
+```
+git fetch
+git checkout -b my_feature bitbucket/my_feature
+```
+
+## Directory Structure <a name="directory-structure"></a>
+
+This repository is structured according to the standard EIY folder structure :
+* rtl_v : contains RTL files
+* test_c : contains C files used for tests **(To be filled)**
+* tb_v : contains testbench files **(To be filled)**
+* scripts : Makefiles to run the testbenches **(To be filled)**
+* saxo : Makefile and setup scripts for packaging with the SAXO tool, in particular for xcelium_check **(To be filled)**
+
+## Links and resources <a name="links-resources"></a>
+* [EU TRISTAN project description](https://cordis.europa.eu/project/id/101095947)
+* [Getting started with git and bitbucket](https://inside-docupedia.bosch.com/confluence/x/CArpCw)
+* [TRISTAN docupedia](https://inside-docupedia.bosch.com/confluence/display/TRISTAN/TRISTAN+Home)
+* [TRISTAN bitbucket](https://sourcecode.socialcoding.bosch.com/projects/TRISTAN)
+* [CRC Copro specification](https://sourcecode.socialcoding.bosch.com/projects/TRISTAN/repos/repo_tristan/browse/Specs/CV32a6_embedded_WI2.4.5/documents/design_specification)
+
+## About <a name="about"></a>
+Together for RISc-V Technology and ApplicatioNs (TRISTAN) is a project financed partly by the Europan Union and involving multiple companies.
+Some of the activities done by BOSCH will by open-sourced while other aspects will stay closed source.
+
+### Maintainers <a name="maintainers"></a>
+
+* [ALLIOUX Coralie](coralie.allioux@fr.bosch.com)
+* [BETSCHI Olivier](olivier.betschi@fr.bosch.com)
+* [BLANCHARD Ludovic](ludovic.blanchard@fr.bosch.com)

--- a/core/rb_cva6_copro_crc/README.md
+++ b/core/rb_cva6_copro_crc/README.md
@@ -10,29 +10,7 @@ The design flow is also run on the copro from this repository, if needed.
 - [About](#about)
   - [Maintainers](#maintainers)
 
-## How to use this repo <a name="howto"></a>
 
-This repository cannot be used standalone and require a tada environment and other associated repos.
-To setup a working environment do the following
-```
-tada -new my/tristan_fe/my_workspace
-repoinit
-repo sync
-## This is needed to load the module tools as it is not done automatically during the tada creation
-tada -exit
-tada my/tristan_fe/my_workspace
-libgen.sh
-```
-By default, it is the master branch that is available. All changes should be done
-on a branch, derived from the develop branch. A branch should be limited to one bugfix or improvement/modification.
-Develop and master branches can only be modified through pull request with a review process.
-A more detailed explanation of the branching model is available on [Docupedia](https://inside-docupedia.bosch.com/confluence/display/TRISTAN/TRISTAN+Home)
-
-To work on a feature on this repository :
-```
-git fetch
-git checkout -b my_feature bitbucket/my_feature
-```
 
 ## Directory Structure <a name="directory-structure"></a>
 
@@ -45,10 +23,6 @@ This repository is structured according to the standard EIY folder structure :
 
 ## Links and resources <a name="links-resources"></a>
 * [EU TRISTAN project description](https://cordis.europa.eu/project/id/101095947)
-* [Getting started with git and bitbucket](https://inside-docupedia.bosch.com/confluence/x/CArpCw)
-* [TRISTAN docupedia](https://inside-docupedia.bosch.com/confluence/display/TRISTAN/TRISTAN+Home)
-* [TRISTAN bitbucket](https://sourcecode.socialcoding.bosch.com/projects/TRISTAN)
-* [CRC Copro specification](https://sourcecode.socialcoding.bosch.com/projects/TRISTAN/repos/repo_tristan/browse/Specs/CV32a6_embedded_WI2.4.5/documents/design_specification)
 
 ## About <a name="about"></a>
 Together for RISc-V Technology and ApplicatioNs (TRISTAN) is a project financed partly by the Europan Union and involving multiple companies.
@@ -56,6 +30,4 @@ Some of the activities done by BOSCH will by open-sourced while other aspects wi
 
 ### Maintainers <a name="maintainers"></a>
 
-* [ALLIOUX Coralie](coralie.allioux@fr.bosch.com)
-* [BETSCHI Olivier](olivier.betschi@fr.bosch.com)
-* [BLANCHARD Ludovic](ludovic.blanchard@fr.bosch.com)
+* [Nicolas TRIBIE](nicolas.tribie___at__@fr.bosch.com)

--- a/core/rb_cva6_copro_crc/rtl_v/crc32_loop8.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/crc32_loop8.sv
@@ -1,0 +1,38 @@
+module crc32_loop8 (
+    input  logic        xor_en,    // 1: do the 1st XOR , 0: bypass it
+    input  logic [31:0] data,      // incoming data
+    input  logic [31:0] crc_in,    // incoming CRC
+    input  logic [31:0] crc_poly,  // polynomial
+    input  logic [ 1:0] fb_pos,    // feedbak position : 00:8 01:16 1X:32
+    output logic [31:0] crc_out    // updated CRC
+);
+
+  logic [32:0] crc[9];
+  logic [ 7:0] fb;
+  integer i, j;
+
+  always_comb begin
+
+    if (xor_en) crc[0] = data ^ crc_in;
+    else crc[0] = crc_in;
+
+    for (i = 0; i < 8; i = i + 1) begin
+      if (fb[i]) crc[i+1] = (crc[i] << 1) ^ (crc_poly);
+      else crc[i+1] = crc[i] << 1;
+    end
+  end
+
+
+  always_comb begin
+    for (j = 0; j < 8; j = j + 1) begin
+      case (fb_pos)
+        2'b01:   fb[j] = crc[j][7];
+        2'b10:   fb[j] = crc[j][15];
+        2'b11:   fb[j] = crc[j][31];
+        default: fb[j] = crc[j][31];
+      endcase
+    end
+  end
+  assign crc_out = crc[8][31:0];
+
+endmodule

--- a/core/rb_cva6_copro_crc/rtl_v/crc_instr_decoder.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/crc_instr_decoder.sv
@@ -1,0 +1,49 @@
+// Copyright 2021 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Guillaume Chauvon (guillaume.chauvon@thalesgroup.com)
+
+module crc_instr_decoder
+  import cvxif_pkg::*;
+#(
+    parameter int                                     NbInstr             = 1,
+    parameter cvxif_crc_instr_pkg::copro_issue_resp_t CoproInstr[NbInstr] = {0}
+) (
+    input  logic          clk_i,
+    input  x_issue_req_t  x_issue_req_i,
+    output x_issue_resp_t x_issue_resp_o
+);
+
+  logic [NbInstr-1:0] sel;
+
+  for (genvar i = 0; i < NbInstr; i++) begin : gen_predecoder_selector
+    assign sel[i] = ((CoproInstr[i].mask & x_issue_req_i.instr) == CoproInstr[i].instr);
+  end
+
+  always_comb begin
+    x_issue_resp_o.accept    = '0;
+    x_issue_resp_o.writeback = '0;
+    x_issue_resp_o.dualwrite = '0;
+    x_issue_resp_o.dualread  = '0;
+    x_issue_resp_o.loadstore = '0;
+    x_issue_resp_o.exc       = '0;
+    for (int unsigned i = 0; i < NbInstr; i++) begin
+      if (sel[i]) begin
+        x_issue_resp_o.accept    = CoproInstr[i].resp.accept;
+        x_issue_resp_o.writeback = CoproInstr[i].resp.writeback;
+        x_issue_resp_o.dualwrite = CoproInstr[i].resp.dualwrite;
+        x_issue_resp_o.dualread  = CoproInstr[i].resp.dualread;
+        x_issue_resp_o.loadstore = CoproInstr[i].resp.loadstore;
+        x_issue_resp_o.exc       = CoproInstr[i].resp.exc;
+      end
+    end
+  end
+
+  assert property (@(posedge clk_i) $onehot0(sel))
+  else $warning("This offloaded instruction is valid for multiple coprocessor instructions !");
+
+endmodule

--- a/core/rb_cva6_copro_crc/rtl_v/cvxif_crc_coprocessor.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/cvxif_crc_coprocessor.sv
@@ -1,0 +1,239 @@
+
+module cvxif_crc_coprocessor
+  import cvxif_pkg::*;
+  import cvxif_crc_instr_pkg::*;
+  import cvxif_crc_coprocessor_pkg::*;
+(
+    input  logic        clk_i,        // Clock
+    input  logic        rst_ni,       // Asynchronous reset active low
+    input  cvxif_req_t  cvxif_req_i,
+    output cvxif_resp_t cvxif_resp_o
+);
+
+  //Compressed interface
+  logic               x_compressed_valid_i;
+  logic               x_compressed_ready_o;
+  x_compressed_req_t  x_compressed_req_i;
+  x_compressed_resp_t x_compressed_resp_o;
+  //Issue interface
+  logic               x_issue_valid_i;
+  logic               x_issue_ready_o;
+  x_issue_req_t       x_issue_req_i;
+  x_issue_resp_t      x_issue_resp_o;
+  //Commit interface
+  logic               x_commit_valid_i;
+  x_commit_t          x_commit_i;
+  //Memory interface
+  logic               x_mem_valid_o;
+  logic               x_mem_ready_i;
+  x_mem_req_t         x_mem_req_o;
+  x_mem_resp_t        x_mem_resp_i;
+  //Memory result interface
+  logic               x_mem_result_valid_i;
+  x_mem_result_t      x_mem_result_i;
+  //Result interface
+  logic               x_result_valid_o;
+  logic               x_result_ready_i;
+  x_result_t          x_result_o;
+
+  assign x_compressed_valid_i            = cvxif_req_i.x_compressed_valid;
+  assign x_compressed_req_i              = cvxif_req_i.x_compressed_req;
+  assign x_issue_valid_i                 = cvxif_req_i.x_issue_valid;
+  assign x_issue_req_i                   = cvxif_req_i.x_issue_req;
+  assign x_commit_valid_i                = cvxif_req_i.x_commit_valid;
+  assign x_commit_i                      = cvxif_req_i.x_commit;
+  assign x_mem_ready_i                   = cvxif_req_i.x_mem_ready;
+  assign x_mem_resp_i                    = cvxif_req_i.x_mem_resp;
+  assign x_mem_result_valid_i            = cvxif_req_i.x_mem_result_valid;
+  assign x_mem_result_i                  = cvxif_req_i.x_mem_result;
+  assign x_result_ready_i                = cvxif_req_i.x_result_ready;
+
+  assign cvxif_resp_o.x_compressed_ready = x_compressed_ready_o;
+  assign cvxif_resp_o.x_compressed_resp  = x_compressed_resp_o;
+  assign cvxif_resp_o.x_issue_ready      = x_issue_ready_o;
+  assign cvxif_resp_o.x_issue_resp       = x_issue_resp_o;
+  assign cvxif_resp_o.x_mem_valid        = x_mem_valid_o;
+  assign cvxif_resp_o.x_mem_req          = x_mem_req_o;
+  assign cvxif_resp_o.x_result_valid     = x_result_valid_o;
+  assign cvxif_resp_o.x_result           = x_result_o;
+
+  //Compressed interface - not used
+  assign x_compressed_ready_o            = '0;
+  assign x_compressed_resp_o.instr       = '0;
+  assign x_compressed_resp_o.accept      = '0;
+
+  crc_instr_decoder #(
+      .NbInstr   (cvxif_crc_instr_pkg::NbInstr),
+      .CoproInstr(cvxif_crc_instr_pkg::CoproInstr)
+  ) instr_decoder_i (
+      .clk_i         (clk_i),
+      .x_issue_req_i ((x_issue_valid_i) ? x_issue_req_i : '0),
+      .x_issue_resp_o(x_issue_resp_o)
+  );
+
+  typedef struct packed {
+    x_issue_req_t  req;
+    x_issue_resp_t resp;
+  } x_issue_t;
+
+  logic fifo_full, fifo_empty;
+  logic x_issue_ready_q;
+  logic instr_push, instr_pop;
+  x_issue_t req_i;
+  x_issue_t req_o;
+
+
+
+  assign instr_push = x_issue_resp_o.accept ? 1 : 0;
+  assign instr_pop = ~fifo_empty && ((x_commit_i.x_commit_kill && x_commit_valid_i) ||
+                                     (x_result_valid_o && x_result_ready_i));
+
+  // if something is in the fifo, the instruction is being processed
+  // so we can't receive anything else
+  assign x_issue_ready_q = ~fifo_full;
+  assign req_i.req = x_issue_req_i;
+  assign req_i.resp = x_issue_resp_o;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : regs
+    if (!rst_ni) begin
+      x_issue_ready_o <= 1;
+    end else begin
+      x_issue_ready_o <= x_issue_ready_q;
+    end
+  end
+
+
+  fifo_v3 #(
+      .FALL_THROUGH(1),         //data_o ready and pop in the same cycle
+      .DATA_WIDTH  (64),
+      .DEPTH       (8),
+      .dtype       (x_issue_t)
+  ) fifo_commit_i (
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .flush_i   (1'b0),
+      .testmode_i(1'b0),
+      .full_o    (fifo_full),
+      .empty_o   (fifo_empty),
+      .usage_o   (),
+      .data_i    (req_i),
+      .push_i    (instr_push),
+      .data_o    (req_o),
+      .pop_i     (instr_pop)
+  );
+
+  // instruction parameters decoding
+  crc_size_e crc_size;
+  crc_mask_e crc_mask;
+  logic crc_in_sel, data_in_sel;
+  logic [3:0] xor_en;
+  logic [31:0] crc_poly;
+  logic [31:0] crc_in;
+  logic [31:0] data_in;
+  logic [31:0] data_in_swapped;
+  logic [31:0] crc_out;
+
+
+  riscv::instruction_t instr;
+  assign instr = riscv::instruction_t'(req_o.req.instr);
+  assign crc_size = crc_size_e'(instr.r4type.funct2);
+  assign crc_mask = crc_mask_e'(instr.r4type.funct3);
+  assign crc_poly = req_o.req.rs[2];  // RS3 = polynomial
+  assign data_in = req_o.req.rs[1];  // RS2 = incoming message data
+  assign crc_in = req_o.req.rs[0];  // RS1 = current CRC
+
+
+  // input data endianness swap
+  always_comb begin
+    if (CRC_ENDIAN_SWAP) begin
+      case (crc_size)
+        CRC8: data_in_swapped = {data_in[7:0], data_in[15:8], data_in[23:16], data_in[31:24]};
+        CRC16: data_in_swapped = {data_in[15:0], data_in[31:16]};
+        CRC32: data_in_swapped = data_in;
+        default: data_in_swapped = data_in;
+      endcase
+    end else data_in_swapped = data_in;
+  end
+
+  // control FSM
+  cvxif_crc_coprocessor_ctrl cvxif_crc_coprocessor_ctrl_i (
+      .clk_i        (clk_i),
+      .rst_ni       (rst_ni),
+      .req_valid_i  (~fifo_empty),
+      .crc_size_i   (crc_size),
+      .crc_mask_i   (crc_mask),
+      .res_valid_o  (x_result_valid_o),
+      .res_ready_i  (x_result_ready_i),
+      .crc_in_sel_o (crc_in_sel),
+      .data_in_sel_o(data_in_sel),
+      .xor_en_o     (xor_en)
+
+  );
+
+
+  // Datapath
+
+  // change to do CRC8 in 2 cycles, 1 pipeline stage in the middle
+
+  cvxif_crc_coprocessor_dp cvxif_crc_coprocessor_dp_i (
+      .clk_i(clk_i),  // Clock
+      .rst_ni(rst_ni),  // Asynchronous reset active low
+      .crc_size_i(crc_size),  // size configuration , must be kept stable during instruction
+      .crc_poly_i(crc_poly),  // CRC polynomial
+      .data_i(data_in_swapped),  // incoming msg data , stable during the instruciton execution
+      .data_sel_i(data_in_sel),
+      .xor_en_i(xor_en),
+      .crc_i(crc_in),
+      .crc_sel_i(crc_in_sel),
+      .res_valid_i(x_result_valid_o),
+      .crc_o(crc_out)
+
+  );
+
+  //result selection according to size and mask
+  always_comb begin
+    case (crc_size)
+      CRC8:
+      case (crc_mask)
+        MASK0:   x_result_o.data = {24'b0, crc_out[7:0]};
+        MASK1:   x_result_o.data = {24'b0, crc_out[15:8]};
+        MASK2:   x_result_o.data = {24'b0, crc_out[7:0]};
+        MASK3:   x_result_o.data = {24'b0, crc_out[15:8]};
+        default: x_result_o.data = {24'b0, crc_out[7:0]};
+      endcase
+
+      CRC16: x_result_o.data = {16'b0, crc_out[15:00]};
+
+      CRC32:   x_result_o.data = crc_out;
+      default: x_result_o.data = crc_out;
+    endcase
+  end
+
+  always_comb begin
+    x_result_o.id      = req_o.req.id;
+    x_result_o.rd      = req_o.req.instr[11:7];
+    x_result_o.we      = req_o.resp.writeback & x_result_valid_o;
+    x_result_o.exc     = 0;
+    x_result_o.exccode = 0;
+  end
+
+
+
+  ///////////////////////////////////////////////////////
+  // assertions
+  ///////////////////////////////////////////////////////
+
+  //pragma translate_off
+`ifndef VERILATOR
+
+  initial begin
+    // assert wrong parameterizations
+    assert (X_NUM_RS == 3)
+    else $fatal(1, "CRC coprocessor needs X_NUM_RS ==3 ");
+
+  end
+
+`endif
+  //pragma translate_on
+
+endmodule

--- a/core/rb_cva6_copro_crc/rtl_v/cvxif_crc_coprocessor_ctrl.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/cvxif_crc_coprocessor_ctrl.sv
@@ -1,0 +1,141 @@
+
+
+
+
+module cvxif_crc_coprocessor_ctrl
+  import cvxif_pkg::*;
+  import cvxif_crc_instr_pkg::*;
+  import cvxif_crc_coprocessor_pkg::*;
+(
+    input  logic            clk_i,         // Clock
+    input  logic            rst_ni,        // Asynchronous reset active low
+    input  logic            req_valid_i,
+    input  crc_size_e       crc_size_i,
+    input  crc_mask_e       crc_mask_i,
+    input  logic            res_ready_i,
+    output logic            res_valid_o,
+    output logic      [3:0] xor_en_o,
+    output logic            crc_in_sel_o,
+    output logic            data_in_sel_o
+);
+
+
+  crc_coprocessor_state_e state_d, state_q;
+
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if (!rst_ni) state_q <= IDLE;
+    else state_q <= state_d;
+  end
+
+  /* xor_en :
+  CRC8 :
+    1 1 1 1 cycle 1
+    1 1 1 1 cycle 2
+
+  CRC16:
+    1 0 0 0 Cycle 1
+    1 0 0 0 Cycle 2
+
+  CRC32:
+    1 0 0 0 Cycle 1
+    0 0 0 0 Cycle 2
+  */
+
+  always_comb begin : p_fsm
+    // default assignment
+    state_d       = state_q;
+    xor_en_o      = 4'b1111;
+    res_valid_o   = 1'b0;
+    crc_in_sel_o  = 1'b0;
+    data_in_sel_o = 1'b0;
+    // FSM states definitns es
+    case (state_q)
+      //////////////////////////////////
+      // wait for an incoming request
+      IDLE:
+      if (req_valid_i) begin
+        case (crc_size_i)
+          CRC8: state_d = CRC8_1;
+          CRC16: state_d = CRC16_1;
+          CRC32: state_d = CRC32_1;
+          default: state_d = CRC32_1;
+        endcase
+
+        case (crc_size_i)
+          CRC8: xor_en_o = 4'b1111;
+          CRC16: xor_en_o = 4'b1101;
+          CRC32: xor_en_o = 4'b1101;
+          default: xor_en_o = 4'b1111;
+        endcase
+      end
+
+      //CRC8, cycle 1
+      CRC8_1: begin
+        xor_en_o      = 4'b1111;
+        crc_in_sel_o  = 1'b1;  // loop CRC_out reg => CRC_in
+        data_in_sel_o = 1'b1;
+        if (crc_mask_i == MASK0 || crc_mask_i == MASK1) begin  // done for 8 and 16 bits
+          res_valid_o = 1;
+          if (res_ready_i) begin
+            state_d = IDLE;
+          end
+        end else begin
+          state_d = CRC8_2;
+        end
+      end
+
+      //CRC8, cycle 2 for 3*8 bits or 4*8bits
+      CRC8_2: begin
+        xor_en_o = 4'b1111;
+        res_valid_o = 1;
+        if (res_ready_i) begin
+          state_d = IDLE;
+        end
+      end
+
+      //CRC16, cycle1
+      CRC16_1: begin
+        xor_en_o      = 4'b1101;
+        crc_in_sel_o  = 1'b1;  // loop CRC_out reg => CRC_in
+        data_in_sel_o = 1'b1;
+        if (crc_mask_i == MASK1) begin  // done for 16 bits
+          res_valid_o = 1;
+          if (res_ready_i) begin
+            state_d = IDLE;
+          end
+        end else begin
+          state_d = CRC16_2;
+        end
+      end
+
+      //CRC16, cycle2
+      CRC16_2: begin
+        res_valid_o = 1;
+        if (res_ready_i) begin
+          state_d = IDLE;
+        end
+      end
+
+      //CRC32, cycle1
+      CRC32_1: begin
+        xor_en_o     = 4'b1100;
+        crc_in_sel_o = 1'b1;  // loop CRC_out reg => CRC_in
+        state_d      = CRC32_2;
+      end
+
+      //CRC32, cycle2
+      CRC32_2: begin
+        res_valid_o  = 1;
+        crc_in_sel_o = 1'b0;
+        xor_en_o     = 4'b1100;
+        if (res_ready_i) begin
+          state_d = IDLE;
+        end
+      end
+
+      // Default case : should not occur
+      default: state_d = IDLE;
+    endcase  // state_q
+  end
+endmodule

--- a/core/rb_cva6_copro_crc/rtl_v/cvxif_crc_coprocessor_dp.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/cvxif_crc_coprocessor_dp.sv
@@ -1,0 +1,93 @@
+module cvxif_crc_coprocessor_dp
+  import cvxif_pkg::*;
+  import cvxif_crc_instr_pkg::*;
+  import cvxif_crc_coprocessor_pkg::*;
+(
+    input logic clk_i,  // Clock
+    input logic rst_ni, // Asynchronous reset active low
+
+    input cvxif_crc_coprocessor_pkg::crc_size_e crc_size_i,  // CRC size configuration
+    input logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] crc_poly_i,  // crc polynomial
+    input logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] data_i,  // incoming data
+    input logic [3:0] xor_en_i,
+    input logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] crc_i,
+    input logic crc_sel_i,
+    input logic data_sel_i,
+    input logic res_valid_i,
+    output logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] crc_o
+);
+
+
+  logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] crc_out0, crc_out1;
+  logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] data_in_mux0, data_in_mux1;
+  logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] crc_in_mux;
+  logic [cvxif_crc_coprocessor_pkg::MAX_CRC_SIZE-1:0] crc_d, crc_q;
+
+  // data in selection
+  assign data_in_mux0 = data_sel_i ? {16'b0, data_i[31:16]} : data_i;
+
+
+  // crc in selection
+  always_comb begin
+    if (crc_sel_i == 1'b1)
+      if (crc_size_i == CRC8) crc_in_mux = {24'b0, crc_q[15:8]};
+      else crc_in_mux = crc_q;
+    else crc_in_mux = crc_i;
+  end
+
+
+  // 1st 32x8 XOR array
+  crc32_loop8 crc32_i0 (
+      .xor_en  (xor_en_i[0]),   // 1: do the 1st XOR , 0: bypass it // TBD
+      .data    (data_in_mux0),  // incoming data
+      .crc_in  (crc_in_mux),    // incoming crc
+      .crc_poly(crc_poly_i),    // polynomial
+      .fb_pos  (crc_size_i),    // feedbak ouput position : 00:8 01:16 1X:32
+      .crc_out (crc_out0)       // updated crc
+  );
+
+  // 2nd array data selection
+  always_comb begin
+    case (crc_size_i)
+      CRC8: data_in_mux1 = {24'b0, data_in_mux0[16:8]};
+      CRC16: data_in_mux1 = data_in_mux0;
+      CRC32: data_in_mux1 = data_in_mux0;
+      default data_in_mux1 = data_in_mux0;
+    endcase
+  end
+
+
+  // 2nd 32x8 XOR array
+  crc32_loop8 crc32_i1 (
+      .xor_en  (xor_en_i[1]),   // 1: do the 1st XOR , 0: bypass it // TBD
+      .data    (data_in_mux1),  // incoming data
+      .crc_in  (crc_out0),      // incoming crc
+      .crc_poly(crc_poly_i),    // polynomial
+      .fb_pos  (crc_size_i),    // feedbak position : 00:8 01:16 1X:32
+      .crc_out (crc_out1)       // updated crc
+  );
+
+
+  // registers 2*16 bits, can be used as final 4*8 bit, pipeline+acc 2*16 bits,  "acc" intermediate 32 bits
+
+  always_comb begin
+    case (crc_size_i)
+      CRC8: crc_d = {crc_q[15:0], crc_out1[7:0], crc_out0[7:0]};
+      CRC16: crc_d = {crc_q[15:0], crc_out1[15:0]};
+      CRC32: crc_d = crc_out1;
+      default: crc_d = crc_out1;
+    endcase
+    if (res_valid_i) crc_d = crc_q;
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : crc_reg
+    if (!rst_ni) begin
+      crc_q <= 32'h0;
+    end else begin
+      crc_q <= crc_d;
+    end
+  end
+
+  assign crc_o = crc_q;
+
+endmodule

--- a/core/rb_cva6_copro_crc/rtl_v/fifo_v3.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/fifo_v3.sv
@@ -1,0 +1,187 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+module fifo_v3 #(
+    parameter bit FALL_THROUGH = 1'b0,  // fifo is in fall-through mode
+    parameter int unsigned DATA_WIDTH = 32,  // default data width if the fifo is of type logic
+    parameter int unsigned DEPTH = 8,  // depth can be arbitrary from 0 to 2**32
+    parameter type dtype = logic [DATA_WIDTH-1:0],
+    // DO NOT OVERWRITE THIS PARAMETER
+    parameter int unsigned ADDR_DEPTH = (DEPTH > 1) ? $clog2(DEPTH) : 1
+) (
+    input  logic                  clk_i,       // Clock
+    input  logic                  rst_ni,      // Asynchronous reset active low
+    input  logic                  flush_i,     // flush the queue
+    input  logic                  testmode_i,  // test_mode to bypass clock gating
+    // status flags
+    output logic                  full_o,      // queue is full
+    output logic                  empty_o,     // queue is empty
+    output logic [ADDR_DEPTH-1:0] usage_o,     // fill pointer
+    // as long as the queue is not full we can push new data
+    input  dtype                  data_i,      // data to push into the queue
+    input  logic                  push_i,      // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    output dtype                  data_o,      // output data
+    input  logic                  pop_i        // pop head from queue
+);
+  // local parameter
+  // FIFO depth - handle the case of pass-through, synthesizer will do constant propagation
+  localparam int unsigned FifoDepth = (DEPTH > 0) ? DEPTH : 1;
+  // clock gating control
+  logic gate_clock;
+  // pointer to the read and write section of the queue
+  logic [ADDR_DEPTH - 1:0] read_pointer_n, read_pointer_q, write_pointer_n, write_pointer_q;
+  // keep a counter to keep track of the current queue status
+  // this integer will be truncated by the synthesis tool
+  logic [ADDR_DEPTH:0] status_cnt_n, status_cnt_q;
+  // actual memory
+  dtype [FifoDepth - 1:0] mem_n, mem_q;
+
+  // fifo ram signals for fpga target
+  logic fifo_ram_we;
+  logic [ADDR_DEPTH-1:0] fifo_ram_read_address;
+  logic [ADDR_DEPTH-1:0] fifo_ram_write_address;
+  logic [$bits(dtype)-1:0] fifo_ram_wdata;
+  logic [$bits(dtype)-1:0] fifo_ram_rdata;
+
+  assign usage_o = status_cnt_q[ADDR_DEPTH-1:0];
+
+  if (DEPTH == 0) begin : gen_pass_through
+    assign empty_o = ~push_i;
+    assign full_o  = ~pop_i;
+  end else begin : gen_fifo
+    assign full_o  = (status_cnt_q == FifoDepth[ADDR_DEPTH:0]);
+    assign empty_o = (status_cnt_q == 0) & ~(FALL_THROUGH & push_i);
+  end
+  // status flags
+
+  // read and write queue logic
+  always_comb begin : read_write_comb
+    // default assignment
+    read_pointer_n  = read_pointer_q;
+    write_pointer_n = write_pointer_q;
+    status_cnt_n    = status_cnt_q;
+    if (ariane_pkg::FPGA_EN) begin
+      fifo_ram_we            = '0;
+      fifo_ram_read_address  = read_pointer_q;
+      fifo_ram_write_address = '0;
+      fifo_ram_wdata         = '0;
+      data_o                 = (DEPTH == 0) ? data_i : fifo_ram_rdata;
+    end else begin
+      data_o     = (DEPTH == 0) ? data_i : mem_q[read_pointer_q];
+      mem_n      = mem_q;
+      gate_clock = 1'b1;
+    end
+
+    // push a new element to the queue
+    if (push_i && ~full_o) begin
+      if (ariane_pkg::FPGA_EN) begin
+        fifo_ram_we = 1'b1;
+        fifo_ram_write_address = write_pointer_q;
+        fifo_ram_wdata = data_i;
+      end else begin
+        // push the data onto the queue
+        mem_n[write_pointer_q] = data_i;
+        // un-gate the clock, we want to write something
+        gate_clock = 1'b0;
+      end
+
+      // increment the write counter
+      if (write_pointer_q == FifoDepth[ADDR_DEPTH-1:0] - 1) write_pointer_n = '0;
+      else write_pointer_n = write_pointer_q + 1;
+      // increment the overall counter
+      status_cnt_n = status_cnt_q + 1;
+    end
+
+    if (pop_i && ~empty_o) begin
+      // read from the queue is a default assignment
+      // but increment the read pointer...
+      if (read_pointer_n == FifoDepth[ADDR_DEPTH-1:0] - 1) read_pointer_n = '0;
+      else read_pointer_n = read_pointer_q + 1;
+      // ... and decrement the overall count
+      status_cnt_n = status_cnt_q - 1;
+    end
+
+    // keep the count pointer stable if we push and pop at the same time
+    if (push_i && pop_i && ~full_o && ~empty_o) status_cnt_n = status_cnt_q;
+
+    // FIFO is in pass through mode -> do not change the pointers
+    if (FALL_THROUGH && (status_cnt_q == 0) && push_i) begin
+      data_o = data_i;
+      if (pop_i) begin
+        status_cnt_n = status_cnt_q;
+        read_pointer_n = read_pointer_q;
+        write_pointer_n = write_pointer_q;
+      end
+    end
+  end
+
+  // sequential process
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      read_pointer_q  <= '0;
+      write_pointer_q <= '0;
+      status_cnt_q    <= '0;
+    end else begin
+      if (flush_i) begin
+        read_pointer_q  <= '0;
+        write_pointer_q <= '0;
+        status_cnt_q    <= '0;
+      end else begin
+        read_pointer_q  <= read_pointer_n;
+        write_pointer_q <= write_pointer_n;
+        status_cnt_q    <= status_cnt_n;
+      end
+    end
+  end
+
+  if (ariane_pkg::FPGA_EN) begin : gen_fpga_queue
+    AsyncDpRam #(
+        .ADDR_WIDTH(ADDR_DEPTH),
+        .DATA_DEPTH(DEPTH),
+        .DATA_WIDTH($bits(dtype))
+    ) fifo_ram (
+        .Clk_CI   (clk_i),
+        .WrEn_SI  (fifo_ram_we),
+        .RdAddr_DI(fifo_ram_read_address),
+        .WrAddr_DI(fifo_ram_write_address),
+        .WrData_DI(fifo_ram_wdata),
+        .RdData_DO(fifo_ram_rdata)
+    );
+  end else begin : gen_asic_queue
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (~rst_ni) begin
+        mem_q <= '0;
+      end else if (!gate_clock) begin
+        mem_q <= mem_n;
+      end
+    end
+  end
+
+  // pragma translate_off
+`ifndef VERILATOR
+  initial begin
+    assert (DEPTH > 0)
+    else $error("DEPTH must be greater than 0.");
+  end
+
+  full_write :
+  assert property (@(posedge clk_i) disable iff (~rst_ni) (full_o |-> ~push_i))
+  else $fatal(1, "Trying to push new data although the FIFO is full.");
+
+  empty_read :
+  assert property (@(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
+  else $fatal(1, "Trying to pop data although the FIFO is empty.");
+`endif
+  // pragma translate_on
+
+endmodule  // fifo_v3

--- a/core/rb_cva6_copro_crc/rtl_v/include/cvxif_crc_coprocessor_pkg.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/include/cvxif_crc_coprocessor_pkg.sv
@@ -1,0 +1,33 @@
+// CRC definition
+
+package cvxif_crc_coprocessor_pkg;
+  parameter int unsigned MAX_CRC_SIZE = 32;
+  parameter bit CRC_ENDIAN_SWAP = 1;
+  // supported CRC sizes : 8, 16 ,32
+  // --------------------
+  typedef enum logic [1:0] {
+    CRC8  = 2'b01,
+    CRC16 = 2'b10,
+    CRC32 = 2'b11
+  } crc_size_e;
+
+  typedef enum logic [1:0] {
+    MASK0 = 2'b00,  // ......NN
+    MASK1 = 2'b01,  // ....NNNN
+    MASK2 = 2'b10,  // ..NNNNNN
+    MASK3 = 2'b11   // NNNNNNNN
+  } crc_mask_e;
+
+  typedef enum logic [2:0] {
+    IDLE,
+    CRC8_1,
+    CRC8_2,
+    CRC16_1,
+    CRC16_2,
+    CRC32_1,
+    CRC32_2
+  } crc_coprocessor_state_e;
+
+
+endpackage
+

--- a/core/rb_cva6_copro_crc/rtl_v/include/cvxif_crc_instr_pkg.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/include/cvxif_crc_instr_pkg.sv
@@ -1,0 +1,55 @@
+
+package cvxif_crc_instr_pkg;
+
+  typedef struct packed {
+    logic [31:0]              instr;
+    logic [31:0]              mask;
+    cvxif_pkg::x_issue_resp_t resp;
+  } copro_issue_resp_t;
+
+  // 3 Possible RISCV instructions for CRC  Coprocessor
+  parameter int unsigned NbInstr = 3;
+  parameter copro_issue_resp_t CoproInstr[NbInstr] = '{
+      '{
+          instr: // custom1 opcode for CRC8, func2 = 01
+          32'b00000_01_00000_00000_0_00_00000_0101011,
+          mask: 32'b00000_11_00000_00000_0_00_00000_1111111,
+          resp : '{
+              accept : 1'b1,
+              writeback : 1'b1,
+              dualwrite : 1'b0,
+              dualread : 1'b0,
+              loadstore : 1'b0,
+              exc : 1'b0
+          }
+      },
+      '{
+          instr: // custom1 opcode for CRC16, func2 = 10, func3 = 001 or 011
+          32'b 00000_10_00000_00000_0_01_00000_0101011,
+          mask: 32'b00000_11_00000_00000_0_01_00000_1111111,
+          resp : '{
+              accept : 1'b1,
+              writeback : 1'b1,
+              dualwrite : 1'b0,
+              dualread : 1'b0,
+              loadstore : 1'b0,
+              exc : 1'b0
+          }
+      },
+      '{
+          instr: // custom1 opcode for CRC32, func2 = 11, func3 = 011
+          32'b 00000_11_00000_00000_0_11_00000_0101011,
+          mask: 32'b00000_11_00000_00000_0_11_00000_1111111,
+          resp : '{
+              accept : 1'b1,
+              writeback : 1'b1,
+              dualwrite : 1'b0,
+              dualread : 1'b0,
+              loadstore : 1'b0,
+              exc : 1'b0
+          }
+      }
+  };
+
+
+endpackage

--- a/core/rb_cva6_copro_crc/rtl_v/instr_decoder.sv
+++ b/core/rb_cva6_copro_crc/rtl_v/instr_decoder.sv
@@ -1,0 +1,48 @@
+// Copyright 2021 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Guillaume Chauvon (guillaume.chauvon@thalesgroup.com)
+
+module instr_decoder import cvxif_pkg::*; #(
+   parameter int                                  NbInstr             = 1,
+   parameter cvxif_instr_pkg::copro_issue_resp_t  CoproInstr[NbInstr] = {0}
+)
+(
+    input   logic              clk_i,
+    input   x_issue_req_t      x_issue_req_i,
+    output  x_issue_resp_t     x_issue_resp_o
+);
+
+  logic [NbInstr-1:0] sel;
+
+  for (genvar i = 0; i < NbInstr; i++) begin : gen_predecoder_selector
+    assign sel[i] =
+      ((CoproInstr[i].mask & x_issue_req_i.instr) == CoproInstr[i].instr);
+  end
+
+  always_comb begin
+    x_issue_resp_o.accept     = '0;
+    x_issue_resp_o.writeback  = '0;
+    x_issue_resp_o.dualwrite  = '0;
+    x_issue_resp_o.dualread   = '0;
+    x_issue_resp_o.loadstore  = '0;
+    x_issue_resp_o.exc        = '0;
+    for (int unsigned i = 0; i < NbInstr; i++) begin
+      if (sel[i]) begin
+        x_issue_resp_o.accept     = CoproInstr[i].resp.accept;
+        x_issue_resp_o.writeback  = CoproInstr[i].resp.writeback;
+        x_issue_resp_o.dualwrite  = CoproInstr[i].resp.dualwrite;
+        x_issue_resp_o.dualread   = CoproInstr[i].resp.dualread;
+        x_issue_resp_o.loadstore  = CoproInstr[i].resp.loadstore;
+        x_issue_resp_o.exc        = CoproInstr[i].resp.exc;
+      end
+    end
+  end
+
+  assert property( @(posedge clk_i) $onehot0(sel)) else $warning("This offloaded instruction is valid for multiple coprocessor instructions !");
+
+endmodule

--- a/core/rb_cva6_copro_exp/README.md
+++ b/core/rb_cva6_copro_exp/README.md
@@ -1,0 +1,53 @@
+# TRISTAN/rb_cva6_cropro_exp
+This repository is holding the source RTL for  EXP coprocessor designed by Bosch, in the context of the TRISTAN project.
+
+This EXPonential coprocessor, computes exp(-x) in fixed point , where : 
+  - x is in Q5.26 (i.e in [0,32[  ,
+  - exp(-x) in  Q0.31 in ]0,1[ 
+
+
+Additionnaly, some testbenches are available.
+
+## Table of Contents <!-- omit in toc -->
+- [How to use this repo](#howto)
+- [Directory Structure](#directory-structure)
+- [Links and resources](#links-resources)
+- [About](#about)
+  - [Maintainers](#maintainers)
+
+An example implementation of a CRC and EXP coprocessor wrapper on the CVX-F interface is given below .:
+
+```
+ 
+  // ---------------
+  // EXP Coprocessor
+  // ---------------
+
+ 
+    cvxif_exp_coprocessor i_cvxif_exp_coprocessor0 (
+      .clk_i                ( clk                  ),
+      .rst_ni               ( sys_rst_n             ),     
+      .cvxif_req_i          ( cvxif_req             ),
+      .cvxif_resp_o         ( cvxif_resp            )
+    );
+ 
+ 
+```
+
+
+## Directory Structure <a name="directory-structure"></a>
+
+This repository is structured according to the standard EIY folder structure :
+* rtl_v : contains RTL files
+
+
+## Links and resources <a name="links-resources"></a>
+* [EU TRISTAN project description](https://cordis.europa.eu/project/id/101095947)
+
+## About <a name="about"></a>
+Together for RISc-V Technology and ApplicatioNs (TRISTAN) is a project financed partly by the Europan Union and involving multiple companies.
+Some of the activities done by BOSCH will by open-sourced while other aspects will stay closed source.
+
+### Maintainers <a name="maintainers"></a>
+
+* [Nicolas TRIBIE](nicolas.tribie___at__@fr.bosch.com)

--- a/core/rb_cva6_copro_exp/rtl_v/commit_filter.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/commit_filter.sv
@@ -1,0 +1,114 @@
+// Original Author: Maxime TRAVAILLARD (fixed-term.maxime.travaillard@fr.bosch.com)
+
+// Module to handle commit signals and send instr or not to the executing fifo
+
+module commit_filter
+  import cvxif_pkg::*;
+(
+    input  logic         clk_i,           // Clock
+    input  logic         rst_ni,          // Asynchronous reset active low
+    input  x_issue_req_t issue_req_i,
+    input  logic         commit_valid_i,
+    input  x_commit_t    commit_i,
+    input  logic         sfifo_empty_i,   // speculative FIFO or sFIFO
+    input  logic         efifo_full_i,    // executive FIFO or eFIFO
+    output logic         pop_o,           // poping issue in sFIFO
+    output x_issue_req_t issue_req_o,     // issue that need ot be executed
+    output logic         push_o           // pushing issue in eFIFO
+);
+
+  // youngest id that need to be executed
+  logic [cva6_config_pkg::CVA6ConfigNrScoreboardEntries-1:0] id_searched_q, id_searched_d;
+
+  // state definition
+  typedef enum {
+    Init,
+    InstrToDo,
+    InstrToBeKilled,
+    InstrToKill
+  } commit_filter_state_e;
+
+  commit_filter_state_e commit_filter_state_d, commit_filter_state_q;
+
+  // Combinational of the state
+  always_comb begin
+    commit_filter_state_d = commit_filter_state_q;
+    id_searched_d = id_searched_q;
+    pop_o = '0;
+    issue_req_o = '0;
+    push_o = 'b0;
+    case (commit_filter_state_q)
+      Init: begin
+        id_searched_d = 0;
+        if (commit_valid_i) begin
+          id_searched_d = commit_i.id;
+          if (!commit_i.x_commit_kill) begin
+            if (~efifo_full_i) begin
+              if (issue_req_i.id == id_searched_d) begin
+                // id searched is oldest id in FIFO, just pop and send and don't change state
+                issue_req_o = (~sfifo_empty_i) ? issue_req_i : '0;
+                push_o = ~sfifo_empty_i;
+                pop_o = ~sfifo_empty_i;
+                commit_filter_state_d = Init;
+              end else begin
+                issue_req_o = (~sfifo_empty_i) ? issue_req_i : '0;
+                push_o = ~sfifo_empty_i;
+                pop_o = ~sfifo_empty_i;
+                commit_filter_state_d = InstrToDo;
+              end
+            end else begin
+              commit_filter_state_d = InstrToDo;
+            end
+          end else begin
+            commit_filter_state_d = InstrToBeKilled;
+          end
+        end
+      end
+
+      InstrToDo: begin
+        if (~efifo_full_i) begin
+          issue_req_o = (~sfifo_empty_i) ? issue_req_i : '0;
+          push_o = ~sfifo_empty_i;
+          pop_o = ~sfifo_empty_i;
+          if (issue_req_i.id == id_searched_d) begin
+            commit_filter_state_d = Init;
+          end
+        end
+      end
+
+      InstrToBeKilled: begin
+        if (commit_valid_i) begin
+          id_searched_d = commit_i.id;
+          commit_filter_state_d = InstrToKill;
+        end
+      end
+
+      InstrToKill: begin
+        pop_o = ~sfifo_empty_i;
+        if (issue_req_i.id == id_searched_d) begin
+          // id searched correspond to a valid instr so it is sent.
+          issue_req_o = (~sfifo_empty_i) ? issue_req_i : '0;
+          push_o = ~sfifo_empty_i;
+          commit_filter_state_d = Init;
+        end
+      end
+
+      default: begin
+        commit_filter_state_d = Init;
+      end
+    endcase
+
+  end
+
+  // state register
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (!rst_ni | sfifo_empty_i) begin
+      commit_filter_state_q <= Init;
+      id_searched_q <= 0;
+    end else begin
+      commit_filter_state_q <= commit_filter_state_d;
+      id_searched_q <= id_searched_d;
+    end
+  end
+
+endmodule

--- a/core/rb_cva6_copro_exp/rtl_v/cvxif_exp_coprocessor.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/cvxif_exp_coprocessor.sv
@@ -1,0 +1,245 @@
+module cvxif_exp_coprocessor
+  import cvxif_pkg::*;
+  import cvxif_exp_instr_pkg::*;
+  import cvxif_exp_coprocessor_pkg::*;
+(
+    input  logic        clk_i,        // Clock
+    input  logic        rst_ni,       // Asynchronous reset active low
+    input  cvxif_req_t  cvxif_req_i,
+    output cvxif_resp_t cvxif_resp_o
+);
+
+  // Compressed interface
+  logic               x_compressed_valid_i;
+  logic               x_compressed_ready_o;
+  x_compressed_req_t  x_compressed_req_i;
+  x_compressed_resp_t x_compressed_resp_o;
+  // Issue interface
+  logic               x_issue_valid_i;
+  logic               x_issue_ready_o;
+  x_issue_req_t       x_issue_req_i;
+  x_issue_resp_t      x_issue_resp_o;
+  // Commit interface
+  logic               x_commit_valid_i;
+  x_commit_t          x_commit_i;
+  // Memory interface
+  logic               x_mem_valid_o;
+  logic               x_mem_ready_i;
+  x_mem_req_t         x_mem_req_o;
+  x_mem_resp_t        x_mem_resp_i;
+  // Memory result interface
+  logic               x_mem_result_valid_i;
+  x_mem_result_t      x_mem_result_i;
+  // Result interface
+  logic               x_result_valid_o;
+  logic               x_result_ready_i;
+  x_result_t          x_result_o;
+
+
+  // Speculative FIFO
+  logic               sfifo_full;
+  logic               sfifo_empty;
+  x_issue_req_t       sfifo_issue_req;
+
+  // Commit filter
+  logic               cf_pop;
+  logic               cf_push;
+  x_issue_req_t       cf_issue_req;
+
+  // Executive FIFO
+  logic               efifo_full;
+  logic               efifo_empty;
+  x_issue_req_t       efifo_issue_req;
+
+  // FSM
+  logic [3:0] add_counter_q, m_counter_q;
+  logic                   mc_enable;  // Mult counter
+  logic                   M_mux;
+  logic [            1:0] Add_mux;
+  logic                   ac_enable;  // Add counter
+  logic                   we_reg;
+  logic                   pop_efifo;
+
+  // Datapath
+  logic [            6:0] x_int;
+  logic [riscv::XLEN-1:0] x_fract;
+  logic [riscv::XLEN-1:0] mult_result;
+  logic [riscv::XLEN-1:0] x_result_data_d, x_result_data_q;  //reg
+
+  assign x_compressed_valid_i = cvxif_req_i.x_compressed_valid;
+  assign x_compressed_req_i = cvxif_req_i.x_compressed_req;
+  assign x_issue_valid_i = cvxif_req_i.x_issue_valid;
+  assign x_issue_req_i = cvxif_req_i.x_issue_req;
+  assign x_commit_valid_i = cvxif_req_i.x_commit_valid;
+  assign x_commit_i = cvxif_req_i.x_commit;
+  assign x_mem_ready_i = cvxif_req_i.x_mem_ready;
+  assign x_mem_resp_i = cvxif_req_i.x_mem_resp;
+  assign x_mem_result_valid_i = cvxif_req_i.x_mem_result_valid;
+  assign x_mem_result_i = cvxif_req_i.x_mem_result;
+  assign x_result_ready_i = cvxif_req_i.x_result_ready;
+
+  assign cvxif_resp_o.x_compressed_ready = x_compressed_ready_o;
+  assign cvxif_resp_o.x_compressed_resp = x_compressed_resp_o;
+  assign cvxif_resp_o.x_issue_ready = x_issue_ready_o;
+  assign cvxif_resp_o.x_issue_resp = x_issue_resp_o;
+  assign cvxif_resp_o.x_mem_valid = x_mem_valid_o;
+  assign cvxif_resp_o.x_mem_req = x_mem_req_o;
+  assign cvxif_resp_o.x_result_valid = x_result_valid_o;
+  assign cvxif_resp_o.x_result = x_result_o;
+
+  // Compressed interface - not used 
+  assign x_compressed_ready_o = '0;
+  assign x_compressed_resp_o.instr = '0;
+  assign x_compressed_resp_o.accept = '0;
+
+  // Memory interface  - not used
+  assign x_mem_valid_o = 0;
+  assign x_mem_req_o = '0;
+
+  assign x_int = efifo_issue_req.rs[0][riscv::XLEN-1:riscv::XLEN-7];  // x_int in [31:0] with 2 bits for float
+  assign x_fract = {3'b0, efifo_issue_req.rs[0][riscv::XLEN-8:0], 4'b0};  // x_fract in [0:1[
+
+  assign x_issue_ready_o = ~efifo_full & ~sfifo_full;
+
+  exp_instr_decoder #(
+      .NbInstr   (cvxif_exp_instr_pkg::NbInstr),
+      .CoproInstr(cvxif_exp_instr_pkg::CoproInstr)
+  ) instr_decoder_i (
+      .clk_i         (clk_i),
+      .x_issue_req_i ((x_issue_valid_i & x_issue_ready_o) ? x_issue_req_i : '0),
+      .x_issue_resp_o(x_issue_resp_o)
+  );
+
+  // Speculative FIFO :
+  fifo_v3 #(
+      .FALL_THROUGH(1),  //data_o ready and pop in the same cycle
+      .DEPTH(cva6_config_pkg::CVA6ConfigNrScoreboardEntries),  // CVA6 scoreboard size
+      .dtype(x_issue_req_t)
+  ) sFIFO (  // need to check parameter ( bit width )
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .flush_i   (1'b0),
+      .testmode_i(1'b0),
+      .full_o    (sfifo_full),             // used by decoder to not push when full
+      .empty_o   (sfifo_empty),            // used by commit filter to not pop when empty
+      .usage_o   (),
+      .data_i    (x_issue_req_i),
+      .push_i    (x_issue_resp_o.accept),
+      .data_o    (sfifo_issue_req),
+      .pop_i     (cf_pop)
+  );
+
+  // Commit Filter :
+  commit_filter exp_commit_filter (
+      .clk_i         (clk_i),
+      .rst_ni        (rst_ni),
+      .issue_req_i   (sfifo_issue_req),
+      .commit_valid_i(x_commit_valid_i),
+      .commit_i      (x_commit_i),
+      .sfifo_empty_i (sfifo_empty),
+      .efifo_full_i  (efifo_full),
+      .pop_o         (cf_pop),
+      .issue_req_o   (cf_issue_req),
+      .push_o        (cf_push)
+  );
+
+  // Executive FIFO :
+  fifo_v3 #(
+      .FALL_THROUGH(1),  //data_o ready and pop in the same cycle
+      .DEPTH(cva6_config_pkg::CVA6ConfigNrScoreboardEntries),  // CVA6 scoreboard size
+      .dtype(x_issue_req_t)
+  ) eFIFO (  // need to check parameter ( bit width )
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .flush_i   (1'b0),
+      .testmode_i(1'b0),
+      .full_o    (efifo_full),       // used by decoder to not push when full
+      .empty_o   (efifo_empty),      // used by commit filter to not pop when empty
+      .usage_o   (),
+      .data_i    (cf_issue_req),
+      .push_i    (cf_push),
+      .data_o    (efifo_issue_req),
+      .pop_i     (pop_efifo)
+  );
+
+
+  // Control path :
+  cvxif_exp_coprocessor_ctrl exp_ctrl (
+      .clk_i         (clk_i),
+      .rst_ni        (rst_ni),
+      .x_int         (x_int),
+      .efifo_empty   (efifo_empty),
+      .x_result_ready(x_result_ready_i),
+      .add_counter   (add_counter_q),
+      .m_counter     (m_counter_q),
+      .x_result_valid(x_result_valid_o),
+      .M_mux         (M_mux),
+      .mc_enable     (mc_enable),
+      .Add_mux       (Add_mux),
+      .ac_enable     (ac_enable),
+      .we_reg        (we_reg),
+      .pop_efifo     (pop_efifo)
+  );
+
+  // Counter for Mult :
+  always_ff @(posedge clk_i or negedge rst_ni) begin : m_counter_gen
+    if (!rst_ni) m_counter_q <= '0;
+    else m_counter_q <= (mc_enable) ? m_counter_q + 1 : 0;
+  end
+
+  // Counter for Add :
+  always_ff @(posedge clk_i or negedge rst_ni) begin : add_counter_gen
+    if (!rst_ni) add_counter_q <= '0;
+    else add_counter_q <= (ac_enable) ? add_counter_q + 1 : 0;
+  end
+
+  // Data Path :
+  // Multiplier :
+  exp_multiplier exp_mult (
+      .data_a(M_mux ? (x_int[m_counter_q] ? ExpIntLut[m_counter_q] : 1) : x_fract),
+      .data_b(x_result_data_q),
+      .M_mux (M_mux),
+      .data_o(mult_result)
+  );
+
+
+  // Adder : 
+  exp_adder adder (
+      .exp_poly_i(ExpPolyLUT[add_counter_q]),
+      .exp_mult_i(mult_result),
+      .add_mux_i (Add_mux),
+      .add_o     (x_result_data_d)
+  );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : data_path_reg
+    if (!rst_ni) x_result_data_q <= '0;
+    else x_result_data_q <= (we_reg) ? x_result_data_d : x_result_data_q;
+  end
+
+  always_comb begin
+    x_result_o.data    = ~efifo_empty ? x_result_data_q : 0;
+    x_result_o.id      = ~efifo_empty ? efifo_issue_req.id : 0;
+    x_result_o.rd      = ~efifo_empty ? efifo_issue_req.instr[11:7] : 0;
+    x_result_o.we      = ~efifo_empty ? x_result_valid_o : 0;
+    x_result_o.exc     = 0;
+    x_result_o.exccode = 0;
+  end
+
+  ///////////////////////////////////////////////////////
+  // assertions
+  ///////////////////////////////////////////////////////
+
+  //pragma translate_off
+`ifndef VERILATOR
+
+  initial begin
+    // assert wrong parameterizations
+    assert (riscv::XLEN == 32)
+    else $fatal(1, "Expneg coprocessor needs XLEN = 32 ");
+
+  end
+
+`endif
+  //pragma translate_on
+
+endmodule

--- a/core/rb_cva6_copro_exp/rtl_v/cvxif_exp_coprocessor_ctrl.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/cvxif_exp_coprocessor_ctrl.sv
@@ -1,0 +1,86 @@
+import cvxif_exp_coprocessor_pkg::*;
+
+module cvxif_exp_coprocessor_ctrl (
+    input logic clk_i,
+    input logic rst_ni,
+    input logic [6:0] x_int,  // integer part of x
+    input logic efifo_empty,  // Indicate if their is an insturction to execute
+    input logic x_result_ready,
+    input logic [3:0] add_counter,  // counter for addition (polynomial calculation)
+    input logic [3:0] m_counter,  // counter for multiplication (calculation with integer part)
+    output logic x_result_valid,
+    output logic M_mux,  // Multiplexor for multiplication (0 : x_fract; 1 : ExpIntLUT)
+    output logic mc_enable,  // enable m_counter
+    output logic [1:0] Add_mux, // Multiplexor for addition (0 : ExpPolyLut; 1 : a+b; 2 : data from mult)
+    output logic ac_enable,  // enable add_counter
+    output logic we_reg,  // write enable for data_o register
+    output logic pop_efifo
+);
+
+  exp_coprocessor_state_e state_d, state_q;
+
+  // Combinational of the state
+  always_comb begin
+    state_d = state_q;
+    x_result_valid = 0;
+    M_mux = 0;
+    Add_mux = '0;
+    we_reg = 0;
+    pop_efifo = 0;
+    mc_enable = 0;
+    ac_enable = 0;
+
+    case (state_q)
+      IDLE: begin
+        if (!efifo_empty) begin
+          we_reg    = 1;
+          M_mux     = 0;
+          Add_mux   = 0;
+          ac_enable = 1;
+          state_d   = P_LOOP;
+        end
+      end
+
+      P_LOOP: begin
+        we_reg    = 1;
+        M_mux     = 0;
+        Add_mux   = 1;
+        ac_enable = 1;
+        state_d   = (add_counter == 4) ? P_TO_EXP : P_LOOP;
+      end
+
+      P_TO_EXP: begin
+        we_reg    = 1;
+        M_mux     = 1;
+        Add_mux   = 2;
+        mc_enable = 1;
+        state_d   = EXP_LOOP;
+      end
+
+      EXP_LOOP: begin
+        we_reg    = 1;
+        M_mux     = 1;
+        Add_mux   = 2;
+        mc_enable = 1;
+        state_d   = (m_counter == 6) ? EXP_END : EXP_LOOP;
+      end
+
+      EXP_END: begin
+        we_reg         = 0;
+        x_result_valid = 1;
+        if (x_result_ready) begin
+          pop_efifo = 1;
+          state_d   = IDLE;
+        end
+      end
+    endcase
+  end
+
+
+  // state register
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) state_q <= IDLE;
+    else state_q <= state_d;
+  end
+
+endmodule

--- a/core/rb_cva6_copro_exp/rtl_v/exp_adder.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/exp_adder.sv
@@ -1,0 +1,20 @@
+module exp_adder (
+    input logic [riscv::XLEN-1:0] exp_poly_i,
+    input logic [riscv::XLEN-1:0] exp_mult_i,
+    input logic [1:0] add_mux_i,
+    output logic [riscv::XLEN-1:0] add_o
+);
+
+  always_comb begin
+    case (add_mux_i)
+      2'b00: add_o = exp_poly_i;
+
+      2'b01: add_o = exp_poly_i + exp_mult_i;
+
+      2'b10: add_o = exp_mult_i;
+
+      default: add_o = exp_poly_i + exp_mult_i;
+    endcase
+  end
+
+endmodule

--- a/core/rb_cva6_copro_exp/rtl_v/exp_instr_decoder.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/exp_instr_decoder.sv
@@ -1,0 +1,49 @@
+// Copyright 2021 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Guillaume Chauvon (guillaume.chauvon@thalesgroup.com)
+
+module exp_instr_decoder
+  import cvxif_pkg::*;
+#(
+    parameter int                                     NbInstr             = 1,
+    parameter cvxif_exp_instr_pkg::copro_issue_resp_t CoproInstr[NbInstr] = {0}
+) (
+    input  logic          clk_i,
+    input  x_issue_req_t  x_issue_req_i,
+    output x_issue_resp_t x_issue_resp_o
+);
+
+  logic [NbInstr-1:0] sel;
+
+  for (genvar i = 0; i < NbInstr; i++) begin : gen_predecoder_selector
+    assign sel[i] = ((CoproInstr[i].mask & x_issue_req_i.instr) == CoproInstr[i].instr);
+  end
+
+  always_comb begin
+    x_issue_resp_o.accept    = '0;
+    x_issue_resp_o.writeback = '0;
+    x_issue_resp_o.dualwrite = '0;
+    x_issue_resp_o.dualread  = '0;
+    x_issue_resp_o.loadstore = '0;
+    x_issue_resp_o.exc       = '0;
+    for (int unsigned i = 0; i < NbInstr; i++) begin
+      if (sel[i]) begin
+        x_issue_resp_o.accept    = CoproInstr[i].resp.accept;
+        x_issue_resp_o.writeback = CoproInstr[i].resp.writeback;
+        x_issue_resp_o.dualwrite = CoproInstr[i].resp.dualwrite;
+        x_issue_resp_o.dualread  = CoproInstr[i].resp.dualread;
+        x_issue_resp_o.loadstore = CoproInstr[i].resp.loadstore;
+        x_issue_resp_o.exc       = CoproInstr[i].resp.exc;
+      end
+    end
+  end
+
+  assert property (@(posedge clk_i) $onehot0(sel))
+  else $warning("This offloaded instruction is valid for multiple coprocessor instructions !");
+
+endmodule

--- a/core/rb_cva6_copro_exp/rtl_v/exp_multiplier.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/exp_multiplier.sv
@@ -1,0 +1,22 @@
+
+module exp_multiplier (
+    input  logic [riscv::XLEN-1:0] data_a,
+    input  logic [riscv::XLEN-1:0] data_b,
+    input  logic                   M_mux,
+    output logic [riscv::XLEN-1:0] data_o
+);
+
+  // intermediary data on 64 bits
+  logic [2*riscv::XLEN-1:0] data_c;
+
+  always_comb begin
+    if (data_a == 1) begin
+      data_c = 0;
+      data_o = data_b;
+    end else begin
+      data_c = $signed(data_a) * $signed(data_b);
+      data_o = data_c >>> riscv::XLEN - 1;
+    end
+  end
+
+endmodule

--- a/core/rb_cva6_copro_exp/rtl_v/fifo_v3.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/fifo_v3.sv
@@ -1,0 +1,192 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+module fifo_v3 #(
+    parameter bit          FALL_THROUGH = 1'b0, // fifo is in fall-through mode
+    parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
+    parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
+    parameter type dtype                = logic [DATA_WIDTH-1:0],
+    parameter bit          FPGA_EN      = 1'b0,
+    // DO NOT OVERWRITE THIS PARAMETER
+    parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
+)(
+    input  logic  clk_i,            // Clock
+    input  logic  rst_ni,           // Asynchronous reset active low
+    input  logic  flush_i,          // flush the queue
+    input  logic  testmode_i,       // test_mode to bypass clock gating
+    // status flags
+    output logic  full_o,           // queue is full
+    output logic  empty_o,          // queue is empty
+    output logic  [ADDR_DEPTH-1:0] usage_o,     // fill pointer
+    // as long as the queue is not full we can push new data
+    input  dtype  data_i,           // data to push into the queue
+    input  logic  push_i,           // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    output dtype  data_o,           // output data
+    input  logic  pop_i             // pop head from queue
+);
+    // local parameter
+    // FIFO depth - handle the case of pass-through, synthesizer will do constant propagation
+    localparam int unsigned FifoDepth = (DEPTH > 0) ? DEPTH : 1;
+    // clock gating control
+    logic gate_clock;
+    // pointer to the read and write section of the queue
+    logic [ADDR_DEPTH - 1:0] read_pointer_n, read_pointer_q, write_pointer_n, write_pointer_q;
+    // keep a counter to keep track of the current queue status
+    // this integer will be truncated by the synthesis tool
+    logic [ADDR_DEPTH:0] status_cnt_n, status_cnt_q;
+    // actual memory
+    dtype [FifoDepth - 1:0] mem_n, mem_q;
+
+    // fifo ram signals for fpga target
+    logic   fifo_ram_we;
+    logic   [ADDR_DEPTH-1:0] fifo_ram_read_address;
+    logic   [ADDR_DEPTH-1:0] fifo_ram_write_address;
+    logic   [$bits(dtype)-1:0] fifo_ram_wdata;
+    logic   [$bits(dtype)-1:0] fifo_ram_rdata;
+
+    assign usage_o = status_cnt_q[ADDR_DEPTH-1:0];
+
+    if (DEPTH == 0) begin : gen_pass_through
+        assign empty_o     = ~push_i;
+        assign full_o      = ~pop_i;
+    end else begin : gen_fifo
+        assign full_o       = (status_cnt_q == FifoDepth[ADDR_DEPTH:0]);
+        assign empty_o      = (status_cnt_q == 0) & ~(FALL_THROUGH & push_i);
+    end
+    // status flags
+
+    // read and write queue logic
+    always_comb begin : read_write_comb
+        // default assignment
+        read_pointer_n  = read_pointer_q;
+        write_pointer_n = write_pointer_q;
+        status_cnt_n    = status_cnt_q;
+        if (FPGA_EN) begin
+             fifo_ram_we             = '0;
+             fifo_ram_read_address   = read_pointer_q;
+             fifo_ram_write_address  = '0;
+             fifo_ram_wdata          = '0;
+             data_o = (DEPTH == 0) ? data_i : fifo_ram_rdata;
+        end else begin
+            data_o          = (DEPTH == 0) ? data_i : mem_q[read_pointer_q];
+            mem_n           = mem_q;
+            gate_clock      = 1'b1;
+        end
+
+        // push a new element to the queue
+        if (push_i && ~full_o) begin
+            if (FPGA_EN) begin
+                fifo_ram_we = 1'b1;
+                fifo_ram_write_address = write_pointer_q;
+                fifo_ram_wdata = data_i;
+            end else begin
+                // push the data onto the queue
+                mem_n[write_pointer_q] = data_i;
+                // un-gate the clock, we want to write something
+                gate_clock = 1'b0;
+            end
+            
+            // increment the write counter
+            if (write_pointer_q == FifoDepth[ADDR_DEPTH-1:0] - 1)
+                write_pointer_n = '0;
+            else
+                write_pointer_n = write_pointer_q + 1;
+            // increment the overall counter
+            status_cnt_n    = status_cnt_q + 1;
+        end
+
+        if (pop_i && ~empty_o) begin
+            // read from the queue is a default assignment
+            // but increment the read pointer...
+            if (read_pointer_n == FifoDepth[ADDR_DEPTH-1:0] - 1)
+                read_pointer_n = '0;
+            else
+                read_pointer_n = read_pointer_q + 1;
+            // ... and decrement the overall count
+            status_cnt_n   = status_cnt_q - 1;
+        end
+
+        // keep the count pointer stable if we push and pop at the same time
+        if (push_i && pop_i &&  ~full_o && ~empty_o)
+            status_cnt_n   = status_cnt_q;
+
+        // FIFO is in pass through mode -> do not change the pointers
+        if (FALL_THROUGH && (status_cnt_q == 0) && push_i) begin
+            data_o = data_i;
+            if (pop_i) begin
+                status_cnt_n = status_cnt_q;
+                read_pointer_n = read_pointer_q;
+                write_pointer_n = write_pointer_q;
+            end
+        end
+    end
+
+    // sequential process
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(~rst_ni) begin
+            read_pointer_q  <= '0;
+            write_pointer_q <= '0;
+            status_cnt_q    <= '0;
+        end else begin
+            if (flush_i) begin
+                read_pointer_q  <= '0;
+                write_pointer_q <= '0;
+                status_cnt_q    <= '0;
+             end else begin
+                read_pointer_q  <= read_pointer_n;
+                write_pointer_q <= write_pointer_n;
+                status_cnt_q    <= status_cnt_n;
+            end
+        end
+    end
+
+    if (FPGA_EN) begin : gen_fpga_queue
+        AsyncDpRam #(
+            .ADDR_WIDTH (ADDR_DEPTH),
+            .DATA_DEPTH (DEPTH),
+            .DATA_WIDTH ($bits(dtype))
+        ) fifo_ram (
+            .Clk_CI      ( clk_i                   ),  
+            .WrEn_SI     ( fifo_ram_we             ),
+            .RdAddr_DI   ( fifo_ram_read_address   ),
+            .WrAddr_DI   ( fifo_ram_write_address  ),
+            .WrData_DI   ( fifo_ram_wdata          ),
+            .RdData_DO   ( fifo_ram_rdata          )
+        );
+    end else begin : gen_asic_queue
+        always_ff @(posedge clk_i or negedge rst_ni) begin
+            if(~rst_ni) begin
+                mem_q <= '0;
+            end else if (!gate_clock) begin
+                mem_q <= mem_n;
+            end
+        end
+    end
+
+// pragma translate_off
+`ifndef VERILATOR
+    initial begin
+        assert (DEPTH > 0)             else $error("DEPTH must be greater than 0.");
+    end
+
+    full_write : assert property(
+        @(posedge clk_i) disable iff (~rst_ni) (full_o |-> ~push_i))
+        else $fatal (1, "Trying to push new data although the FIFO is full.");
+
+    empty_read : assert property(
+        @(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
+        else $fatal (1, "Trying to pop data although the FIFO is empty.");
+`endif
+// pragma translate_on
+
+endmodule // fifo_v3

--- a/core/rb_cva6_copro_exp/rtl_v/include/ariane_pkg.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/include/ariane_pkg.sv
@@ -1,0 +1,810 @@
+/* Copyright 2018 ETH Zurich and University of Bologna.
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the “License”); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * File:   ariane_pkg.sv
+ * Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+ * Date:   8.4.2017
+ *
+ * Description: Contains all the necessary defines for Ariane
+ *              in one package.
+ */	
+
+// this is needed to propagate the
+// configuration in case Ariane is
+// instantiated in OpenPiton
+`ifdef PITON_ARIANE
+`include "l15.tmp.h"
+`endif
+
+/// This package contains `functions` and global defines for CVA6.
+/// *Note*: There are some parameters here as well which will eventually be
+/// moved out to favour a fully parameterizable core.
+package ariane_pkg;
+
+  // TODO: Slowly move those parameters to the new system.
+  localparam BITS_SATURATION_COUNTER = 2;
+
+  localparam ISSUE_WIDTH = 1;
+
+  // depth of store-buffers, this needs to be a power of two
+  localparam logic [2:0] DEPTH_SPEC = 'd4;
+
+  localparam int unsigned DCACHE_TYPE = int'(cva6_config_pkg::CVA6ConfigDcacheType);
+  // if DCACHE_TYPE = cva6_config_pkg::WT
+  // we can use a small commit queue since we have a write buffer in the dcache
+  // we could in principle do without the commit queue in this case, but the timing degrades if we do that due
+  // to longer paths into the commit stage
+  // if DCACHE_TYPE = cva6_config_pkg::WB
+  // allocate more space for the commit buffer to be on the save side, this needs to be a power of two
+  localparam logic [2:0] DEPTH_COMMIT = 'd4;
+
+  localparam bit RVC = cva6_config_pkg::CVA6ConfigCExtEn;  // Is C extension configuration
+
+  // Transprecision float unit
+  localparam int unsigned LAT_COMP_FP32 = 'd2;
+  localparam int unsigned LAT_COMP_FP64 = 'd3;
+  localparam int unsigned LAT_COMP_FP16 = 'd1;
+  localparam int unsigned LAT_COMP_FP16ALT = 'd1;
+  localparam int unsigned LAT_COMP_FP8 = 'd1;
+  localparam int unsigned LAT_DIVSQRT = 'd2;
+  localparam int unsigned LAT_NONCOMP = 'd1;
+  localparam int unsigned LAT_CONV = 'd2;
+
+  localparam logic [31:0] OPENHWGROUP_MVENDORID = 32'h0602;
+  localparam logic [31:0] ARIANE_MARCHID = 32'd3;
+
+  // 32 registers
+  localparam REG_ADDR_SIZE = 5;
+
+  // Read ports for general purpose register files
+  localparam NR_RGPR_PORTS = 3;
+
+  // static debug hartinfo
+  // debug causes
+  localparam logic [2:0] CauseBreakpoint = 3'h1;
+  localparam logic [2:0] CauseTrigger = 3'h2;
+  localparam logic [2:0] CauseRequest = 3'h3;
+  localparam logic [2:0] CauseSingleStep = 3'h4;
+  // amount of data count registers implemented
+  localparam logic [3:0] DataCount = 4'h2;
+
+  // address where data0-15 is shadowed or if shadowed in a CSR
+  // address of the first CSR used for shadowing the data
+  localparam logic [11:0] DataAddr = 12'h380;  // we are aligned with Rocket here
+  typedef struct packed {
+    logic [31:24] zero1;
+    logic [23:20] nscratch;
+    logic [19:17] zero0;
+    logic         dataaccess;
+    logic [15:12] datasize;
+    logic [11:0]  dataaddr;
+  } hartinfo_t;
+
+  localparam hartinfo_t DebugHartInfo = '{
+      zero1: '0,
+      nscratch: 2,  // Debug module needs at least two scratch regs
+      zero0: '0,
+      dataaccess: 1'b1,  // data registers are memory mapped in the debugger
+      datasize: DataCount,
+      dataaddr: DataAddr
+  };
+
+  // enables a commit log which matches spikes commit log format for easier trace comparison
+  localparam bit ENABLE_SPIKE_COMMIT_LOG = 1'b1;
+
+  // ------------- Dangerous -------------
+  // if set to zero a flush will not invalidate the cache-lines, in a single core environment
+  // where coherence is not necessary this can improve performance. This needs to be switched on
+  // when more than one core is in a system
+  localparam logic INVALIDATE_ON_FLUSH = 1'b1;
+
+`ifdef SPIKE_TANDEM
+  // Spike still places 0 in TVAL for ENV_CALL_* exceptions.
+  // This may eventually go away when Spike starts to handle TVAL for *all* exceptions.
+  localparam bit ZERO_TVAL = 1'b1;
+`else
+  localparam bit ZERO_TVAL = 1'b0;
+`endif
+
+  // read mask for SSTATUS over MMSTATUS
+  function automatic logic [63:0] smode_status_read_mask(config_pkg::cva6_cfg_t Cfg);
+    return riscv::SSTATUS_UIE
+    | riscv::SSTATUS_SIE
+    | riscv::SSTATUS_SPIE
+    | riscv::SSTATUS_SPP
+    | riscv::SSTATUS_FS
+    | riscv::SSTATUS_XS
+    | riscv::SSTATUS_SUM
+    | riscv::SSTATUS_MXR
+    | riscv::SSTATUS_UPIE
+    | riscv::SSTATUS_SPIE
+    | riscv::SSTATUS_UXL
+    | riscv::sstatus_sd(Cfg.IS_XLEN64);
+  endfunction
+
+  localparam logic [63:0] SMODE_STATUS_WRITE_MASK = riscv::SSTATUS_SIE
+                                                    | riscv::SSTATUS_SPIE
+                                                    | riscv::SSTATUS_SPP
+                                                    | riscv::SSTATUS_FS
+                                                    | riscv::SSTATUS_SUM
+                                                    | riscv::SSTATUS_MXR;
+
+  localparam logic [63:0] HSTATUS_WRITE_MASK      = riscv::HSTATUS_VSBE
+                                                    | riscv::HSTATUS_GVA
+                                                    | riscv::HSTATUS_SPV
+                                                    | riscv::HSTATUS_SPVP
+                                                    | riscv::HSTATUS_HU
+                                                    | riscv::HSTATUS_VTVM
+                                                    | riscv::HSTATUS_VTW
+                                                    | riscv::HSTATUS_VTSR;
+
+  // hypervisor delegable interrupts
+  function automatic logic [31:0] hs_deleg_interrupts(config_pkg::cva6_cfg_t Cfg);
+    return riscv::MIP_VSSIP | riscv::MIP_VSTIP | riscv::MIP_VSEIP;
+  endfunction
+
+  // virtual supervisor delegable interrupts
+  function automatic logic [31:0] vs_deleg_interrupts(config_pkg::cva6_cfg_t Cfg);
+    return riscv::MIP_VSSIP | riscv::MIP_VSTIP | riscv::MIP_VSEIP;
+  endfunction
+
+  // ---------------
+  // AXI
+  // ---------------
+
+  typedef enum logic {
+    SINGLE_REQ,
+    CACHE_LINE_REQ
+  } ad_req_t;
+
+  // ---------------
+  // Fetch Stage
+  // ---------------
+
+  // leave as is (fails with >8 entries and wider fetch width)
+  localparam int unsigned FETCH_FIFO_DEPTH = 4;
+
+  typedef enum logic [2:0] {
+    NoCF,    // No control flow prediction
+    Branch,  // Branch
+    Jump,    // Jump to address from immediate
+    JumpR,   // Jump to address from registers
+    Return   // Return Address Prediction
+  } cf_t;
+
+  typedef struct packed {
+    logic valid;
+    logic taken;
+  } bht_prediction_t;
+
+  typedef struct packed {
+    logic       valid;
+    logic [1:0] saturation_counter;
+  } bht_t;
+
+  typedef enum logic [3:0] {
+    NONE,       // 0
+    LOAD,       // 1
+    STORE,      // 2
+    ALU,        // 3
+    CTRL_FLOW,  // 4
+    MULT,       // 5
+    CSR,        // 6
+    FPU,        // 7
+    FPU_VEC,    // 8
+    CVXIF,      // 9
+    ACCEL       // 10
+  } fu_t;
+
+  localparam EXC_OFF_RST = 8'h80;
+
+  localparam SupervisorIrq = 1;
+  localparam MachineIrq = 0;
+
+  // ---------------
+  // Cache config
+  // ---------------
+
+  // for usage in OpenPiton we have to propagate the openpiton L15 configuration from l15.h
+`ifdef PITON_ARIANE
+
+`ifndef CONFIG_L1I_CACHELINE_WIDTH
+  `define CONFIG_L1I_CACHELINE_WIDTH 128
+`endif
+
+`ifndef CONFIG_L1I_ASSOCIATIVITY
+  `define CONFIG_L1I_ASSOCIATIVITY 4
+`endif
+
+`ifndef CONFIG_L1I_SIZE
+  `define CONFIG_L1I_SIZE 16*1024
+`endif
+
+`ifndef CONFIG_L1D_CACHELINE_WIDTH
+  `define CONFIG_L1D_CACHELINE_WIDTH 128
+`endif
+
+`ifndef CONFIG_L1D_ASSOCIATIVITY
+  `define CONFIG_L1D_ASSOCIATIVITY 8
+`endif
+
+`ifndef CONFIG_L1D_SIZE
+  `define CONFIG_L1D_SIZE 32*1024
+`endif
+
+`ifndef L15_THREADID_WIDTH
+  `define L15_THREADID_WIDTH 3
+`endif
+
+  // I$
+  localparam int unsigned ICACHE_LINE_WIDTH = `CONFIG_L1I_CACHELINE_WIDTH;
+  localparam int unsigned ICACHE_SET_ASSOC = `CONFIG_L1I_ASSOCIATIVITY;
+  localparam int unsigned ICACHE_INDEX_WIDTH = $clog2(`CONFIG_L1I_SIZE / ICACHE_SET_ASSOC);
+  localparam int unsigned ICACHE_TAG_WIDTH = riscv::PLEN - ICACHE_INDEX_WIDTH;
+  localparam int unsigned ICACHE_USER_LINE_WIDTH = (AXI_USER_WIDTH == 1) ? 4 : 128;  // in bit
+  // D$
+  localparam int unsigned DCACHE_LINE_WIDTH = `CONFIG_L1D_CACHELINE_WIDTH;
+  localparam int unsigned DCACHE_SET_ASSOC = `CONFIG_L1D_ASSOCIATIVITY;
+  localparam int unsigned DCACHE_INDEX_WIDTH = $clog2(`CONFIG_L1D_SIZE / DCACHE_SET_ASSOC);
+  localparam int unsigned DCACHE_TAG_WIDTH = riscv::PLEN - DCACHE_INDEX_WIDTH;
+  localparam int unsigned DCACHE_USER_LINE_WIDTH = (AXI_USER_WIDTH == 1) ? 4 : 128;  // in bit
+  localparam int unsigned DCACHE_USER_WIDTH = cva6_config_pkg::CVA6ConfigDataUserWidth;
+
+  localparam int unsigned MEM_TID_WIDTH = `L15_THREADID_WIDTH;
+`endif
+
+  localparam int unsigned DCACHE_TID_WIDTH = cva6_config_pkg::CVA6ConfigDcacheIdWidth;
+
+  localparam int unsigned WT_DCACHE_WBUF_DEPTH = cva6_config_pkg::CVA6ConfigWtDcacheWbufDepth;
+
+  // ---------------
+  // EX Stage
+  // ---------------
+
+  typedef enum logic [7:0] {  // basic ALU op
+    ADD,
+    SUB,
+    ADDW,
+    SUBW,
+    // logic operations
+    XORL,
+    ORL,
+    ANDL,
+    // shifts
+    SRA,
+    SRL,
+    SLL,
+    SRLW,
+    SLLW,
+    SRAW,
+    // comparisons
+    LTS,
+    LTU,
+    GES,
+    GEU,
+    EQ,
+    NE,
+    // jumps
+    JALR,
+    BRANCH,
+    // set lower than operations
+    SLTS,
+    SLTU,
+    // CSR functions
+    MRET,
+    SRET,
+    DRET,
+    ECALL,
+    WFI,
+    FENCE,
+    FENCE_I,
+    SFENCE_VMA,
+    HFENCE_VVMA,
+    HFENCE_GVMA,
+    CSR_WRITE,
+    CSR_READ,
+    CSR_SET,
+    CSR_CLEAR,
+    // LSU functions
+    LD,
+    SD,
+    LW,
+    LWU,
+    SW,
+    LH,
+    LHU,
+    SH,
+    LB,
+    SB,
+    LBU,
+    // Hypervisor Virtual-Machine Load and Store Instructions
+    HLV_B,
+    HLV_BU,
+    HLV_H,
+    HLV_HU,
+    HLVX_HU,
+    HLV_W,
+    HLVX_WU,
+    HSV_B,
+    HSV_H,
+    HSV_W,
+    HLV_WU,
+    HLV_D,
+    HSV_D,
+    // Atomic Memory Operations
+    AMO_LRW,
+    AMO_LRD,
+    AMO_SCW,
+    AMO_SCD,
+    AMO_SWAPW,
+    AMO_ADDW,
+    AMO_ANDW,
+    AMO_ORW,
+    AMO_XORW,
+    AMO_MAXW,
+    AMO_MAXWU,
+    AMO_MINW,
+    AMO_MINWU,
+    AMO_SWAPD,
+    AMO_ADDD,
+    AMO_ANDD,
+    AMO_ORD,
+    AMO_XORD,
+    AMO_MAXD,
+    AMO_MAXDU,
+    AMO_MIND,
+    AMO_MINDU,
+    // Multiplications
+    MUL,
+    MULH,
+    MULHU,
+    MULHSU,
+    MULW,
+    // Divisions
+    DIV,
+    DIVU,
+    DIVW,
+    DIVUW,
+    REM,
+    REMU,
+    REMW,
+    REMUW,
+    // Floating-Point Load and Store Instructions
+    FLD,
+    FLW,
+    FLH,
+    FLB,
+    FSD,
+    FSW,
+    FSH,
+    FSB,
+    // Floating-Point Computational Instructions
+    FADD,
+    FSUB,
+    FMUL,
+    FDIV,
+    FMIN_MAX,
+    FSQRT,
+    FMADD,
+    FMSUB,
+    FNMSUB,
+    FNMADD,
+    // Floating-Point Conversion and Move Instructions
+    FCVT_F2I,
+    FCVT_I2F,
+    FCVT_F2F,
+    FSGNJ,
+    FMV_F2X,
+    FMV_X2F,
+    // Floating-Point Compare Instructions
+    FCMP,
+    // Floating-Point Classify Instruction
+    FCLASS,
+    // Vectorial Floating-Point Instructions that don't directly map onto the scalar ones
+    VFMIN,
+    VFMAX,
+    VFSGNJ,
+    VFSGNJN,
+    VFSGNJX,
+    VFEQ,
+    VFNE,
+    VFLT,
+    VFGE,
+    VFLE,
+    VFGT,
+    VFCPKAB_S,
+    VFCPKCD_S,
+    VFCPKAB_D,
+    VFCPKCD_D,
+    // Offload Instructions to be directed into cv_x_if
+    OFFLOAD,
+    // Or-Combine and REV8
+    ORCB,
+    REV8,
+    // Bitwise Rotation
+    ROL,
+    ROLW,
+    ROR,
+    RORI,
+    RORIW,
+    RORW,
+    // Sign and Zero Extend
+    SEXTB,
+    SEXTH,
+    ZEXTH,
+    // Count population
+    CPOP,
+    CPOPW,
+    // Count Leading/Training Zeros
+    CLZ,
+    CLZW,
+    CTZ,
+    CTZW,
+    // Carry less multiplication Op's
+    CLMUL,
+    CLMULH,
+    CLMULR,
+    // Single bit instructions Op's
+    BCLR,
+    BCLRI,
+    BEXT,
+    BEXTI,
+    BINV,
+    BINVI,
+    BSET,
+    BSETI,
+    // Integer minimum/maximum
+    MAX,
+    MAXU,
+    MIN,
+    MINU,
+    // Shift with Add Unsigned Word and Unsigned Word Op's (Bitmanip)
+    SH1ADDUW,
+    SH2ADDUW,
+    SH3ADDUW,
+    ADDUW,
+    SLLIUW,
+    // Shift with Add (Bitmanip)
+    SH1ADD,
+    SH2ADD,
+    SH3ADD,
+    // Bitmanip Logical with negate op (Bitmanip)
+    ANDN,
+    ORN,
+    XNOR,
+    // Accelerator operations
+    ACCEL_OP,
+    ACCEL_OP_FS1,
+    ACCEL_OP_FD,
+    ACCEL_OP_LOAD,
+    ACCEL_OP_STORE,
+    // Zicond instruction
+    CZERO_EQZ,
+    CZERO_NEZ
+  } fu_op;
+
+  function automatic logic op_is_branch(input fu_op op);
+    unique case (op) inside
+      EQ, NE, LTS, GES, LTU, GEU: return 1'b1;
+      default:                    return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // -------------------------------
+  // Extract Src/Dst FP Reg from Op
+  // -------------------------------
+  // function used in instr_trace svh
+  // is_rs1_fpr function is kept to allow cva6 compilation with instr_trace feature
+  function automatic logic is_rs1_fpr(input fu_op op);
+    unique case (op) inside
+      [FMUL : FNMADD],  // Computational Operations (except ADD/SUB)
+      FCVT_F2I,  // Float-Int Casts
+      FCVT_F2F,  // Float-Float Casts
+      FSGNJ,  // Sign Injections
+      FMV_F2X,  // FPR-GPR Moves
+      FCMP,  // Comparisons
+      FCLASS,  // Classifications
+      [VFMIN : VFCPKCD_D],  // Additional Vectorial FP ops
+      ACCEL_OP_FS1:
+      return 1'b1;  // Accelerator instructions
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // function used in instr_trace svh
+  // is_rs2_fpr function is kept to allow cva6 compilation with instr_trace feature
+  function automatic logic is_rs2_fpr(input fu_op op);
+    unique case (op) inside
+      [FSD : FSB],  // FP Stores
+      [FADD : FMIN_MAX],  // Computational Operations (no sqrt)
+      [FMADD : FNMADD],  // Fused Computational Operations
+      FCVT_F2F,  // Vectorial F2F Conversions requrie target
+      [FSGNJ : FMV_F2X],  // Sign Injections and moves mapped to SGNJ
+      FCMP,  // Comparisons
+      [VFMIN : VFCPKCD_D]:
+      return 1'b1;  // Additional Vectorial FP ops
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // function used in instr_trace svh
+  // is_imm_fpr function is kept to allow cva6 compilation with instr_trace feature
+  // ternary operations encode the rs3 address in the imm field, also add/sub
+  function automatic logic is_imm_fpr(input fu_op op);
+    unique case (op) inside
+      [FADD : FSUB],  // ADD/SUB need inputs as Operand B/C
+      [FMADD : FNMADD],  // Fused Computational Operations
+      [VFCPKAB_S : VFCPKCD_D]:
+      return 1'b1;  // Vectorial FP cast and pack ops
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // function used in instr_trace svh
+  // is_rd_fpr function is kept to allow cva6 compilation with instr_trace feature
+  function automatic logic is_rd_fpr(input fu_op op);
+    unique case (op) inside
+      [FLD : FLB],  // FP Loads
+      [FADD : FNMADD],  // Computational Operations
+      FCVT_I2F,  // Int-Float Casts
+      FCVT_F2F,  // Float-Float Casts
+      FSGNJ,  // Sign Injections
+      FMV_X2F,  // GPR-FPR Moves
+      [VFMIN : VFSGNJX],  // Vectorial MIN/MAX and SGNJ
+      [VFCPKAB_S : VFCPKCD_D],  // Vectorial FP cast and pack ops
+      ACCEL_OP_FD:
+      return 1'b1;  // Accelerator instructions
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  function automatic logic is_amo(fu_op op);
+    case (op) inside
+      [AMO_LRW : AMO_MINDU]: begin
+        return 1'b1;
+      end
+      default: return 1'b0;
+    endcase
+  endfunction
+
+  // ---------------
+  // MMU instanciation
+  // ---------------
+  localparam bit MMU_PRESENT = cva6_config_pkg::CVA6ConfigMmuPresent;
+
+  localparam int unsigned INSTR_TLB_ENTRIES = cva6_config_pkg::CVA6ConfigInstrTlbEntries;
+  localparam int unsigned DATA_TLB_ENTRIES = cva6_config_pkg::CVA6ConfigDataTlbEntries;
+
+  // -------------------
+  // Performance counter
+  // -------------------
+  localparam bit PERF_COUNTER_EN = cva6_config_pkg::CVA6ConfigPerfCounterEn;
+  localparam int unsigned MHPMCounterNum = 6;
+
+  // --------------------
+  // Atomics
+  // --------------------
+  typedef enum logic [3:0] {
+    AMO_NONE = 4'b0000,
+    AMO_LR   = 4'b0001,
+    AMO_SC   = 4'b0010,
+    AMO_SWAP = 4'b0011,
+    AMO_ADD  = 4'b0100,
+    AMO_AND  = 4'b0101,
+    AMO_OR   = 4'b0110,
+    AMO_XOR  = 4'b0111,
+    AMO_MAX  = 4'b1000,
+    AMO_MAXU = 4'b1001,
+    AMO_MIN  = 4'b1010,
+    AMO_MINU = 4'b1011,
+    AMO_CAS1 = 4'b1100,  // unused, not part of riscv spec, but provided in OpenPiton
+    AMO_CAS2 = 4'b1101   // unused, not part of riscv spec, but provided in OpenPiton
+  } amo_t;
+
+  // Bits required for representation of physical address space as 4K pages
+  // (e.g. 27*4K == 39bit address space).
+  localparam PPN4K_WIDTH = 38;
+
+  typedef struct packed {
+    logic             valid;    // valid flag
+    logic             is_4M;    //
+    logic [20-1:0]    vpn;      //VPN (32bits) = 20bits + 12bits offset
+    logic [9-1:0]     asid;     //ASID length = 9 for Sv32 mmu
+    riscv::pte_sv32_t content;
+  } tlb_update_sv32_t;
+
+  typedef enum logic [1:0] {
+    FE_NONE,
+    FE_INSTR_ACCESS_FAULT,
+    FE_INSTR_PAGE_FAULT,
+    FE_INSTR_GUEST_PAGE_FAULT
+  } frontend_exception_t;
+
+  // AMO request going to cache. this request is unconditionally valid as soon
+  // as request goes high.
+  // Furthermore, those signals are kept stable until the response indicates
+  // completion by asserting ack.
+  typedef struct packed {
+    logic        req;        // this request is valid
+    amo_t        amo_op;     // atomic memory operation to perform
+    logic [1:0]  size;       // 2'b10 --> word operation, 2'b11 --> double word operation
+    logic [63:0] operand_a;  // address
+    logic [63:0] operand_b;  // data as layouted in the register
+  } amo_req_t;
+
+  // AMO response coming from cache.
+  typedef struct packed {
+    logic        ack;     // response is valid
+    logic [63:0] result;  // sign-extended, result
+  } amo_resp_t;
+
+  localparam RVFI = cva6_config_pkg::CVA6ConfigRvfiTrace;
+
+  // ----------------------
+  // Arithmetic Functions
+  // ----------------------
+  function automatic logic [63:0] sext32to64(logic [31:0] operand);
+    return {{32{operand[31]}}, operand[31:0]};
+  endfunction
+
+  // ----------------------
+  // LSU Functions
+  // ----------------------
+  // generate byte enable mask
+  function automatic logic [7:0] be_gen(logic [2:0] addr, logic [1:0] size);
+    case (size)
+      2'b11: begin
+        return 8'b1111_1111;
+      end
+      2'b10: begin
+        case (addr[2:0])
+          3'b000:  return 8'b0000_1111;
+          3'b001:  return 8'b0001_1110;
+          3'b010:  return 8'b0011_1100;
+          3'b011:  return 8'b0111_1000;
+          3'b100:  return 8'b1111_0000;
+          default: ;  // Do nothing
+        endcase
+      end
+      2'b01: begin
+        case (addr[2:0])
+          3'b000:  return 8'b0000_0011;
+          3'b001:  return 8'b0000_0110;
+          3'b010:  return 8'b0000_1100;
+          3'b011:  return 8'b0001_1000;
+          3'b100:  return 8'b0011_0000;
+          3'b101:  return 8'b0110_0000;
+          3'b110:  return 8'b1100_0000;
+          default: ;  // Do nothing
+        endcase
+      end
+      2'b00: begin
+        case (addr[2:0])
+          3'b000: return 8'b0000_0001;
+          3'b001: return 8'b0000_0010;
+          3'b010: return 8'b0000_0100;
+          3'b011: return 8'b0000_1000;
+          3'b100: return 8'b0001_0000;
+          3'b101: return 8'b0010_0000;
+          3'b110: return 8'b0100_0000;
+          3'b111: return 8'b1000_0000;
+        endcase
+      end
+    endcase
+    return 8'b0;
+  endfunction
+
+  function automatic logic [3:0] be_gen_32(logic [1:0] addr, logic [1:0] size);
+    case (size)
+      2'b10: begin
+        return 4'b1111;
+      end
+      2'b01: begin
+        case (addr[1:0])
+          2'b00:   return 4'b0011;
+          2'b01:   return 4'b0110;
+          2'b10:   return 4'b1100;
+          default: ;  // Do nothing
+        endcase
+      end
+      2'b00: begin
+        case (addr[1:0])
+          2'b00: return 4'b0001;
+          2'b01: return 4'b0010;
+          2'b10: return 4'b0100;
+          2'b11: return 4'b1000;
+        endcase
+      end
+      default: return 4'b0;
+    endcase
+    return 4'b0;
+  endfunction
+
+  // ----------------------
+  // Extract Bytes from Op
+  // ----------------------
+  function automatic logic [1:0] extract_transfer_size(fu_op op);
+    case (op)
+      LD, HLV_D, SD, HSV_D, FLD, FSD,
+            AMO_LRD,   AMO_SCD,
+            AMO_SWAPD, AMO_ADDD,
+            AMO_ANDD,  AMO_ORD,
+            AMO_XORD,  AMO_MAXD,
+            AMO_MAXDU, AMO_MIND,
+            AMO_MINDU: begin
+        return 2'b11;
+      end
+      LW, LWU, HLV_W, HLV_WU, HLVX_WU,
+            SW, HSV_W, FLW, FSW,
+            AMO_LRW,   AMO_SCW,
+            AMO_SWAPW, AMO_ADDW,
+            AMO_ANDW,  AMO_ORW,
+            AMO_XORW,  AMO_MAXW,
+            AMO_MAXWU, AMO_MINW,
+            AMO_MINWU: begin
+        return 2'b10;
+      end
+      LH, LHU, HLV_H, HLV_HU, HLVX_HU, SH, HSV_H, FLH, FSH: return 2'b01;
+      LB, LBU, HLV_B, HLV_BU, SB, HSV_B, FLB, FSB:          return 2'b00;
+      default:                                              return 2'b11;
+    endcase
+  endfunction
+  // ----------------------
+  // MMU Functions
+  // ----------------------
+
+  // checks if final translation page size is 1G when H-extension is enabled
+  function automatic logic is_trans_1G(input logic s_st_enbl, input logic g_st_enbl,
+                                       input logic is_s_1G, input logic is_g_1G);
+    return (((is_s_1G && s_st_enbl) || !s_st_enbl) && ((is_g_1G && g_st_enbl) || !g_st_enbl));
+  endfunction : is_trans_1G
+
+  // checks if final translation page size is 2M when H-extension is enabled
+  function automatic logic is_trans_2M(input logic s_st_enbl, input logic g_st_enbl,
+                                       input logic is_s_1G, input logic is_s_2M,
+                                       input logic is_g_1G, input logic is_g_2M);
+    return  (s_st_enbl && g_st_enbl) ? 
+                ((is_s_2M && (is_g_1G || is_g_2M)) || (is_g_2M && (is_s_1G || is_s_2M))) :
+                ((is_s_2M && s_st_enbl) || (is_g_2M && g_st_enbl));
+  endfunction : is_trans_2M
+
+  // computes the paddr based on the page size, ppn and offset
+  function automatic logic [40:0] make_gpaddr(input logic s_st_enbl, input logic is_1G,
+                                              input logic is_2M, input logic [63:0] vaddr,
+                                              input riscv::pte_t pte);
+    logic [40:0] gpaddr;
+    if (s_st_enbl) begin
+      gpaddr = {pte.ppn[28:0], vaddr[11:0]};
+      // Giga page
+      if (is_1G) gpaddr[29:12] = vaddr[29:12];
+      // Mega page
+      if (is_2M) gpaddr[20:12] = vaddr[20:12];
+    end else begin
+      gpaddr = vaddr[40:0];
+    end
+    return gpaddr;
+  endfunction : make_gpaddr
+
+  // computes the final gppn based on the guest physical address
+  function automatic logic [28:0] make_gppn(input logic s_st_enbl, input logic is_1G,
+                                            input logic is_2M, input logic [28:0] vpn,
+                                            input riscv::pte_t pte);
+    logic [28:0] gppn;
+    if (s_st_enbl) begin
+      gppn = pte.ppn[28:0];
+      if (is_2M) gppn[8:0] = vpn[8:0];
+      if (is_1G) gppn[17:0] = vpn[17:0];
+    end else begin
+      gppn = vpn;
+    end
+    return gppn;
+  endfunction : make_gppn
+
+endpackage

--- a/core/rb_cva6_copro_exp/rtl_v/include/config_pkg.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/include/config_pkg.sv
@@ -1,0 +1,373 @@
+// Copyright 2023 Thales DIS France SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON - Thales
+
+package config_pkg;
+
+  // ---------------
+  // Global Config
+  // ---------------
+  localparam int unsigned ILEN = 32;
+  localparam int unsigned NRET = 1;
+
+  /// The NoC type is a top-level parameter, hence we need a bit more
+  /// information on what protocol those type parameters are supporting.
+  /// Currently two values are supported"
+  typedef enum {
+    /// The "classic" AXI4 protocol.
+    NOC_TYPE_AXI4_ATOP,
+    /// In the OpenPiton setting the WT cache is connected to the L15.
+    NOC_TYPE_L15_BIG_ENDIAN,
+    NOC_TYPE_L15_LITTLE_ENDIAN
+  } noc_type_e;
+
+  /// Cache type parameter
+  typedef enum logic [1:0] {
+    WB = 0,
+    WT = 1,
+    HPDCACHE = 2
+  } cache_type_t;
+
+  /// Data and Address length
+  typedef enum logic [3:0] {
+    ModeOff  = 0,
+    ModeSv32 = 1,
+    ModeSv39 = 8,
+    ModeSv48 = 9,
+    ModeSv57 = 10,
+    ModeSv64 = 11
+  } vm_mode_t;
+
+  localparam NrMaxRules = 16;
+
+  typedef struct packed {
+    // General Purpose Register Size (in bits)
+    int unsigned                 XLEN;
+    // Atomic RISC-V extension
+    bit                          RVA;
+    // Bit manipulation RISC-V extension
+    bit                          RVB;
+    // Vector RISC-V extension
+    bit                          RVV;
+    // Compress RISC-V extension
+    bit                          RVC;
+    // Hypervisor RISC-V extension
+    bit                          RVH;
+    // Zcb RISC-V extension
+    bit                          RVZCB;
+    // Zcmp RISC-V extension
+    bit                          RVZCMP;
+    // Zicond RISC-V extension
+    bit                          RVZiCond;
+    // Floating Point
+    bit                          FpuEn;
+    // Non standard 16bits Floating Point extension
+    bit                          XF16;
+    // Non standard 16bits Floating Point Alt extension
+    bit                          XF16ALT;
+    // Non standard 8bits Floating Point extension
+    bit                          XF8;
+    // Non standard Vector Floating Point extension
+    bit                          XFVec;
+    // Supervisor mode
+    bit                          RVS;
+    // User mode
+    bit                          RVU;
+    // Debug support
+    bit                          DebugEn;
+    // Base address of the debug module
+    logic [63:0]                 DmBaseAddress;
+    // Address to jump when halt request
+    logic [63:0]                 HaltAddress;
+    // Address to jump when exception
+    logic [63:0]                 ExceptionAddress;
+    // Tval Support Enable
+    bit                          TvalEn;
+    // PMP entries number
+    int unsigned                 NrPMPEntries;
+    // PMP CSR configuration reset values
+    logic [15:0][63:0]           PMPCfgRstVal;
+    // PMP CSR address reset values
+    logic [15:0][63:0]           PMPAddrRstVal;
+    // PMP CSR read-only bits
+    bit [15:0]                   PMPEntryReadOnly;
+    // PMA non idempotent rules number
+    int unsigned                 NrNonIdempotentRules;
+    // PMA NonIdempotent region base address
+    logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
+    // PMA NonIdempotent region length
+    logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
+    // PMA regions with execute rules number
+    int unsigned                 NrExecuteRegionRules;
+    // PMA Execute region base address
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
+    // PMA Execute region address base
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
+    // PMA regions with cache rules number
+    int unsigned                 NrCachedRegionRules;
+    // PMA cache region base address
+    logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
+    // PMA cache region rules
+    logic [NrMaxRules-1:0][63:0] CachedRegionLength;
+    // CV-X-IF coprocessor interface enable
+    bit                          CvxifEn;
+    // NOC bus type
+    noc_type_e                   NOCType;
+    // AXI address width
+    int unsigned                 AxiAddrWidth;
+    // AXI data width
+    int unsigned                 AxiDataWidth;
+    // AXI ID width
+    int unsigned                 AxiIdWidth;
+    // AXI User width
+    int unsigned                 AxiUserWidth;
+    // AXI burst in write
+    bit                          AxiBurstWriteEn;
+    // TODO
+    int unsigned                 MemTidWidth;
+    // Instruction cache size (in bytes)
+    int unsigned                 IcacheByteSize;
+    // Instruction cache associativity (number of ways)
+    int unsigned                 IcacheSetAssoc;
+    // Instruction cache line width
+    int unsigned                 IcacheLineWidth;
+    // Data cache size (in bytes)
+    int unsigned                 DcacheByteSize;
+    // Data cache associativity (number of ways)
+    int unsigned                 DcacheSetAssoc;
+    // Data cache line width
+    int unsigned                 DcacheLineWidth;
+    // User field on data bus enable
+    int unsigned                 DataUserEn;
+    // User field on fetch bus enable
+    int unsigned                 FetchUserEn;
+    // Width of fetch user field
+    int unsigned                 FetchUserWidth;
+    // Is FPGA optimization of CV32A6
+    bit                          FpgaEn;
+    // Number of commit ports
+    int unsigned                 NrCommitPorts;
+    // Scoreboard length
+    int unsigned                 NrScoreboardEntries;
+    // Load buffer entry buffer
+    int unsigned                 NrLoadBufEntries;
+    // Maximum number of outstanding stores
+    int unsigned                 MaxOutstandingStores;
+    // Return address stack depth
+    int unsigned                 RASDepth;
+    // Branch target buffer entries
+    int unsigned                 BTBEntries;
+    // Branch history entries
+    int unsigned                 BHTEntries;
+    /// Enable PMP without MMU
+    bit                          PmpPresent;
+    /// Set Data scratchpad
+    bit                          DataScrPresent;
+    int unsigned                 DataScrBase;
+    int unsigned                 DataScrSize;
+    /// Set Instruction scratchpad
+    bit InstrScrPresent;
+    int unsigned                 InstrScrBase;
+    int unsigned                 InstrScrSize;
+    /// Set AHB peripheral bus
+    bit                          AHBPeriphPresent;
+    logic [63:0]                 AHBPeriphSystemBase;
+    int unsigned                 AHBPeriphSystemSize;
+    logic [63:0]                 AHBPeriphPrivateBase;
+    int unsigned                 AHBPeriphPrivateSize;
+  } cva6_user_cfg_t;
+
+  typedef struct packed {
+    int unsigned XLEN;
+    int unsigned VLEN;
+    int unsigned PLEN;
+    int unsigned GPLEN;
+    bit IS_XLEN32;
+    bit IS_XLEN64;
+    int unsigned XLEN_ALIGN_BYTES;
+    int unsigned ASID_WIDTH;
+    int unsigned VMID_WIDTH;
+
+    bit          FpgaEn;
+    /// Number of commit ports, i.e., maximum number of instructions that the
+    /// core can retire per cycle. It can be beneficial to have more commit
+    /// ports than issue ports, for the scoreboard to empty out in case one
+    /// instruction stalls a little longer.
+    int unsigned NrCommitPorts;
+    /// AXI parameters.
+    int unsigned AxiAddrWidth;
+    int unsigned AxiDataWidth;
+    int unsigned AxiIdWidth;
+    int unsigned AxiUserWidth;
+    int unsigned MEM_TID_WIDTH;
+    int unsigned NrLoadBufEntries;
+    bit          FpuEn;
+    bit          XF16;
+    bit          XF16ALT;
+    bit          XF8;
+    bit          RVA;
+    bit          RVB;
+    bit          RVV;
+    bit          RVC;
+    bit          RVH;
+    bit          RVZCB;
+    bit          RVZCMP;
+    bit          XFVec;
+    bit          CvxifEn;
+    bit          RVZiCond;
+
+    int unsigned NR_SB_ENTRIES;
+    int unsigned TRANS_ID_BITS;
+
+    bit          RVF;
+    bit          RVD;
+    bit          FpPresent;
+    bit          NSX;
+    int unsigned FLen;
+    bit          RVFVec;
+    bit          XF16Vec;
+    bit          XF16ALTVec;
+    bit          XF8Vec;
+    int unsigned NrRgprPorts;
+    int unsigned NrWbPorts;
+    bit          EnableAccelerator;
+    bit          RVS;                //Supervisor mode
+    bit          RVU;                //User mode
+
+    logic [63:0]                 HaltAddress;
+    logic [63:0]                 ExceptionAddress;
+    int unsigned                 RASDepth;
+    int unsigned                 BTBEntries;
+    int unsigned                 BHTEntries;
+    logic [63:0]                 DmBaseAddress;
+    bit                          TvalEn;
+    int unsigned                 NrPMPEntries;
+    logic [15:0][63:0]           PMPCfgRstVal;
+    logic [15:0][63:0]           PMPAddrRstVal;
+    bit [15:0]                   PMPEntryReadOnly;
+    noc_type_e                   NOCType;
+    int unsigned                 NrNonIdempotentRules;
+    logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
+    logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
+    int unsigned                 NrExecuteRegionRules;
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
+    int unsigned                 NrCachedRegionRules;
+    logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
+    logic [NrMaxRules-1:0][63:0] CachedRegionLength;
+    int unsigned                 MaxOutstandingStores;
+    bit                          DebugEn;
+    bit                          NonIdemPotenceEn;       // Currently only used by V extension (Ara)
+    bit                          AxiBurstWriteEn;
+
+    int unsigned ICACHE_SET_ASSOC;
+    int unsigned ICACHE_SET_ASSOC_WIDTH;
+    int unsigned ICACHE_INDEX_WIDTH;
+    int unsigned ICACHE_TAG_WIDTH;
+    int unsigned ICACHE_LINE_WIDTH;
+    int unsigned ICACHE_USER_LINE_WIDTH;
+    int unsigned DCACHE_SET_ASSOC;
+    int unsigned DCACHE_SET_ASSOC_WIDTH;
+    int unsigned DCACHE_INDEX_WIDTH;
+    int unsigned DCACHE_TAG_WIDTH;
+    int unsigned DCACHE_LINE_WIDTH;
+    int unsigned DCACHE_USER_LINE_WIDTH;
+    int unsigned DCACHE_USER_WIDTH;
+    int unsigned DCACHE_OFFSET_WIDTH;
+    int unsigned DCACHE_NUM_WORDS;
+
+    int unsigned DCACHE_MAX_TX;
+
+    int unsigned DATA_USER_EN;
+    int unsigned FETCH_USER_WIDTH;
+    int unsigned FETCH_USER_EN;
+    int unsigned AXI_USER_EN;
+
+    int unsigned FETCH_WIDTH;
+    int unsigned INSTR_PER_FETCH;
+    int unsigned LOG2_INSTR_PER_FETCH;
+
+    int unsigned ModeW;
+    int unsigned ASIDW;
+    int unsigned VMIDW;
+    int unsigned PPNW;
+    int unsigned GPPNW;
+    vm_mode_t MODE_SV;
+    int unsigned SV;
+    int unsigned SVX;
+
+    bit PmpPresent;
+    bit DataScrPresent;
+    int unsigned DataScrBase;
+    int unsigned DataScrSize;
+    bit InstrScrPresent;
+    int unsigned InstrScrBase;
+    int unsigned InstrScrSize;
+    bit AHBPeriphPresent;
+    logic [63:0] AHBPeriphSystemBase;
+    int unsigned AHBPeriphSystemSize;
+    logic [63:0] AHBPeriphPrivateBase;
+    int unsigned AHBPeriphPrivateSize;
+  } cva6_cfg_t;
+
+  /// Empty configuration to sanity check proper parameter passing. Whenever
+  /// you develop a module that resides within the core, assign this constant.
+  localparam cva6_cfg_t cva6_cfg_empty = '0;
+
+  /// Utility function being called to check parameters. Not all values make
+  /// sense for all parameters, here is the place to sanity check them.
+  function automatic void check_cfg(cva6_cfg_t Cfg);
+    // pragma translate_off
+`ifndef VERILATOR
+    assert (Cfg.RASDepth > 0);
+    assert (Cfg.BTBEntries == 0 || (2 ** $clog2(Cfg.BTBEntries) == Cfg.BTBEntries));
+    assert (Cfg.BHTEntries == 0 || (2 ** $clog2(Cfg.BHTEntries) == Cfg.BHTEntries));
+    assert (Cfg.NrNonIdempotentRules <= NrMaxRules);
+    assert (Cfg.NrExecuteRegionRules <= NrMaxRules);
+    assert (Cfg.NrCachedRegionRules <= NrMaxRules);
+    assert (Cfg.NrPMPEntries <= 16);
+`endif
+    // pragma translate_on
+  endfunction
+
+  function automatic logic range_check(logic [63:0] base, logic [63:0] len, logic [63:0] address);
+    // if len is a power of two, and base is properly aligned, this check could be simplified
+    // Extend base by one bit to prevent an overflow.
+    return (address >= base) && (({1'b0, address}) < (65'(base) + len));
+  endfunction : range_check
+
+
+  function automatic logic is_inside_nonidempotent_regions(cva6_cfg_t Cfg, logic [63:0] address);
+    logic [NrMaxRules-1:0] pass;
+    pass = '0;
+    for (int unsigned k = 0; k < Cfg.NrNonIdempotentRules; k++) begin
+      pass[k] = range_check(Cfg.NonIdempotentAddrBase[k], Cfg.NonIdempotentLength[k], address);
+    end
+    return |pass;
+  endfunction : is_inside_nonidempotent_regions
+
+  function automatic logic is_inside_execute_regions(cva6_cfg_t Cfg, logic [63:0] address);
+    // if we don't specify any region we assume everything is accessible
+    logic [NrMaxRules-1:0] pass;
+    pass = '0;
+    for (int unsigned k = 0; k < Cfg.NrExecuteRegionRules; k++) begin
+      pass[k] = range_check(Cfg.ExecuteRegionAddrBase[k], Cfg.ExecuteRegionLength[k], address);
+    end
+    return |pass;
+  endfunction : is_inside_execute_regions
+
+  function automatic logic is_inside_cacheable_regions(cva6_cfg_t Cfg, logic [63:0] address);
+    automatic logic [NrMaxRules-1:0] pass;
+    pass = '0;
+    for (int unsigned k = 0; k < Cfg.NrCachedRegionRules; k++) begin
+      pass[k] = range_check(Cfg.CachedRegionAddrBase[k], Cfg.CachedRegionLength[k], address);
+    end
+    return |pass;
+  endfunction : is_inside_cacheable_regions
+
+endpackage

--- a/core/rb_cva6_copro_exp/rtl_v/include/cv32a6_scratchpad_config_pkg.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/include/cv32a6_scratchpad_config_pkg.sv
@@ -1,0 +1,162 @@
+package cva6_config_pkg;
+
+  localparam CVA6ConfigXlen = 32;
+
+  localparam CVA6ConfigFpuEn = 1;
+  localparam CVA6ConfigF16En = 0;
+  localparam CVA6ConfigF16AltEn = 0;
+  localparam CVA6ConfigF8En = 0;
+  localparam CVA6ConfigFVecEn = 0;
+
+  localparam CVA6ConfigCvxifEn = 1;
+  localparam CVA6ConfigCExtEn = 1;
+  localparam CVA6ConfigZcbExtEn = 1;
+  localparam CVA6ConfigZcmpExtEn = 0;
+  localparam CVA6ConfigAExtEn = 1;
+  localparam CVA6ConfigHExtEn = 0;  // always disabled
+  localparam CVA6ConfigBExtEn = 1; // To be inserted in spec
+  localparam CVA6ConfigVExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
+
+  localparam CVA6ConfigAxiIdWidth = 4;
+  localparam CVA6ConfigAxiAddrWidth = 32;
+  localparam CVA6ConfigAxiDataWidth = 64;
+  localparam CVA6ConfigFetchUserEn = 0; // Not compatible with current implemention, set to DISABLED
+  localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen; // Not compatible with current implemention, set to XLEN
+  localparam CVA6ConfigDataUserEn = 0; // Not compatible with current implemention, DISABLED
+  localparam CVA6ConfigDataUserWidth = CVA6ConfigXlen; // Not compatible with current implemention, set to XLEN
+
+  localparam CVA6ConfigIcacheByteSize = 16384;
+  localparam CVA6ConfigIcacheSetAssoc = 4;
+  localparam CVA6ConfigIcacheLineWidth = 128;
+  localparam CVA6ConfigDcacheByteSize = 32768; // To be inserted in spec
+  localparam CVA6ConfigDcacheSetAssoc = 4;
+  localparam CVA6ConfigDcacheLineWidth = 128; // To be inserted in spec
+
+  localparam CVA6ConfigDcacheIdWidth = 1; // To be inserted in spec
+  localparam CVA6ConfigMemTidWidth = 4; // To be inserted in spec
+
+  localparam CVA6ConfigWtDcacheWbufDepth = 2;
+
+  localparam CVA6ConfigNrCommitPorts = 2;
+  localparam CVA6ConfigNrScoreboardEntries = 4;
+
+  localparam CVA6ConfigFpgaEn = 0;
+
+  localparam CVA6ConfigNrLoadPipeRegs = 0;
+  localparam CVA6ConfigNrStorePipeRegs = 0;
+  localparam CVA6ConfigNrLoadBufEntries = 2; // To be inserted in spec
+
+  localparam CVA6ConfigInstrTlbEntries = 0; // To be inserted in spec
+  localparam CVA6ConfigDataTlbEntries = 0; // To be inserted in spec
+
+  localparam CVA6ConfigRASDepth = 2;
+  localparam CVA6ConfigBTBEntries = 32;
+  localparam CVA6ConfigBHTEntries = 128;
+
+  localparam CVA6ConfigTvalEn = 0;
+
+  localparam CVA6ConfigNrPMPEntries = 16;
+
+  localparam CVA6ConfigPerfCounterEn = 1;
+
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::HPDCACHE;
+
+  localparam CVA6ConfigMmuPresent = 0;
+  localparam CVA6ConfigPmpPresent = 1;
+
+  localparam CVA6ConfigRvfiTrace = 1; // To be inserted in spec
+  
+  
+  localparam CVA6ConfigDataScrPresent = 1;
+  localparam CVA6ConfigDataScrBase = 64'h20_0000;
+  localparam CVA6ConfigDataScrSize = 64'h1_0000; // num of words, 256KB, 65536 words
+  
+  localparam CVA6ConfigInstrScrPresent = 1;
+  localparam CVA6ConfigInstrScrBase = 64'h0;
+  localparam CVA6ConfigInstrScrSize = 64'h8000; // num of words, 128KB, 32768 words
+  
+  localparam CVA6ConfigAHBPeriphPresent = 1;
+  localparam CVA6ConfigAHBPeriphSystemBase = 64'h4000_0000;
+  localparam CVA6ConfigAHBPeriphSystemSize = 64'h7000; // num of words
+  localparam CVA6ConfigAHBPeriphPrivateBase = 64'hE000_0000;
+  localparam CVA6ConfigAHBPeriphPrivateSize = 64'h400_1000; // num of words
+  
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
+      XLEN: unsigned'(CVA6ConfigXlen),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      MemTidWidth: unsigned'(CVA6ConfigMemTidWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVH: bit'(CVA6ConfigHExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      RVZCMP: bit'(CVA6ConfigZcmpExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
+      NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
+      RVS: bit'(0),
+      RVU: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth: unsigned'(CVA6ConfigRASDepth),
+      BTBEntries: unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries: unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'hF0000000,
+      TvalEn: bit'(CVA6ConfigTvalEn),
+      NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
+      PMPCfgRstVal: {16{64'h0}},
+      PMPAddrRstVal: {16{64'h0}},
+      PMPEntryReadOnly: 16'd0,
+      NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region: CLINT / PLIC
+      NrNonIdempotentRules: unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'hE000_0000, 64'hE000_0000}),
+      NonIdempotentLength: 1024'({64'h1000, 64'h100_0000}),
+      // execute region: Debug Module
+      NrExecuteRegionRules: unsigned'(1),
+      ExecuteRegionAddrBase: 1024'({64'hF000_0000}),
+      ExecuteRegionLength: 1024'({64'h4000}),
+      // cached region
+      NrCachedRegionRules: unsigned'(1),
+      CachedRegionAddrBase: 1024'({64'h0}),
+      CachedRegionLength: 1024'({64'hE000_0000}),
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1),
+      AxiBurstWriteEn: bit'(0),
+      IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
+      IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
+      IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
+      DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
+      DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),
+      DataUserEn: unsigned'(CVA6ConfigDataUserEn),
+      FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
+      FetchUserEn: unsigned'(CVA6ConfigFetchUserEn),
+      PmpPresent: bit'(CVA6ConfigPmpPresent),
+      DataScrPresent: bit'(CVA6ConfigDataScrPresent),
+      DataScrBase: 64'(CVA6ConfigDataScrBase),
+      DataScrSize: unsigned'(CVA6ConfigDataScrSize),
+      InstrScrPresent: bit'(CVA6ConfigInstrScrPresent),
+      InstrScrBase: 64'(CVA6ConfigInstrScrBase),
+      InstrScrSize: unsigned'(CVA6ConfigInstrScrSize),
+      AHBPeriphPresent: bit'(CVA6ConfigAHBPeriphPresent),
+      AHBPeriphSystemBase: 64'(CVA6ConfigAHBPeriphSystemBase),
+      AHBPeriphSystemSize: unsigned'(CVA6ConfigAHBPeriphSystemSize),
+      AHBPeriphPrivateBase: 64'(CVA6ConfigAHBPeriphPrivateBase),
+      AHBPeriphPrivateSize: unsigned'(CVA6ConfigAHBPeriphPrivateSize)
+  };
+
+endpackage

--- a/core/rb_cva6_copro_exp/rtl_v/include/cvxif_exp_coprocessor_pkg.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/include/cvxif_exp_coprocessor_pkg.sv
@@ -1,0 +1,19 @@
+package cvxif_exp_coprocessor_pkg;
+
+  logic [riscv::XLEN-1:0] ExpIntLut[6:0] = {
+    32'hF1, 32'hAFE10, 32'h2582AB7, 32'h1152AAA3, 32'h2F16AC6C, 32'h4DA2CBF1, 32'h63AFBE7A
+  };
+
+  logic [riscv::XLEN-1:0] ExpPolyLUT[4:0] = {
+    32'h7FFFFFFF, 32'h80000001, 32'h3FFCCA80, 32'hEACD510F, 32'h04B5C29A
+  };
+
+  typedef enum logic [2:0] {
+    IDLE,
+    P_LOOP,
+    P_TO_EXP,
+    EXP_LOOP,
+    EXP_END
+  } exp_coprocessor_state_e;
+
+endpackage

--- a/core/rb_cva6_copro_exp/rtl_v/include/cvxif_exp_instr_pkg.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/include/cvxif_exp_instr_pkg.sv
@@ -1,0 +1,26 @@
+package cvxif_exp_instr_pkg;
+
+  typedef struct packed {
+    logic [31:0]              instr;
+    logic [31:0]              mask;
+    cvxif_pkg::x_issue_resp_t resp;
+  } copro_issue_resp_t;
+
+  // 1 Possible RISCV instructions for Exp Coprocessor
+  parameter int unsigned NbInstr = 1;
+  parameter copro_issue_resp_t CoproInstr[NbInstr] = '{
+      '{
+          instr: 32'b00000_00_00000_00000_000_00000_0001011,  // custom0 opcode (func2 : 00)
+          mask: 32'b00000_11_00000_00000_000_00000_1111111,
+          resp : '{
+              accept : 1'b1,
+              writeback : 1'b1,
+              dualwrite : 1'b0,
+              dualread : 1'b0,
+              loadstore : 1'b0,
+              exc : 1'b0
+          }
+      }
+  };
+
+endpackage

--- a/core/rb_cva6_copro_exp/rtl_v/include/cvxif_pkg.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/include/cvxif_pkg.sv
@@ -1,0 +1,114 @@
+// Copyright 2021 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Guillaume CHAUVON (guillaume.chauvon@thalesgroup.com)
+
+// Package for the CoreV-X-Interface for the CVA6
+
+package cvxif_pkg;
+  import config_pkg::*;
+  import cva6_config_pkg::*;
+  import riscv::*;
+  import ariane_pkg::*;
+
+  localparam X_DATAWIDTH = riscv::XLEN;
+  localparam X_NUM_RS = ariane_pkg::NR_RGPR_PORTS;  //2 or 3
+  localparam X_ID_WIDTH = $clog2(cva6_config_pkg::CVA6ConfigNrScoreboardEntries);
+  localparam X_MEM_WIDTH = 64;
+  localparam X_RFR_WIDTH = riscv::XLEN;
+  localparam X_RFW_WIDTH = riscv::XLEN;
+
+  typedef struct packed {
+    logic [15:0]           instr;
+    logic [1:0]            mode;
+    logic [X_ID_WIDTH-1:0] id;
+  } x_compressed_req_t;
+
+  typedef struct packed {
+    logic [31:0] instr;
+    logic        accept;
+  } x_compressed_resp_t;
+
+  typedef struct packed {
+    logic [31:0]                          instr;
+    logic [1:0]                           mode;
+    logic [X_ID_WIDTH-1:0]                id;
+    logic [X_NUM_RS-1:0][X_RFR_WIDTH-1:0] rs;
+    logic [X_NUM_RS-1:0]                  rs_valid;
+  } x_issue_req_t;
+
+  typedef struct packed {
+    logic accept;
+    logic writeback;
+    logic dualwrite;
+    logic dualread;
+    logic loadstore;
+    logic exc;
+  } x_issue_resp_t;
+
+  typedef struct packed {
+    logic [X_ID_WIDTH-1:0] id;
+    logic                  x_commit_kill;
+  } x_commit_t;
+
+  typedef struct packed {
+    logic [X_ID_WIDTH-1:0]  id;
+    logic [31:0]            addr;
+    logic [1:0]             mode;
+    logic                   we;
+    logic [1:0]             size;
+    logic [X_MEM_WIDTH-1:0] wdata;
+    logic                   last;
+    logic                   spec;
+  } x_mem_req_t;
+
+  typedef struct packed {
+    logic       exc;
+    logic [5:0] exccode;
+  } x_mem_resp_t;
+
+  typedef struct packed {
+    logic [X_ID_WIDTH-1:0]  id;
+    logic [X_MEM_WIDTH-1:0] rdata;
+    logic                   err;
+  } x_mem_result_t;
+
+  typedef struct packed {
+    logic [X_ID_WIDTH-1:0]  id;
+    logic [X_RFW_WIDTH-1:0] data;
+    logic [4:0]             rd;
+    logic                   we;
+    logic                   exc;
+    logic [5:0]             exccode;
+  } x_result_t;
+
+  typedef struct packed {
+    logic              x_compressed_valid;
+    x_compressed_req_t x_compressed_req;
+    logic              x_issue_valid;
+    x_issue_req_t      x_issue_req;
+    logic              x_commit_valid;
+    x_commit_t         x_commit;
+    logic              x_mem_ready;
+    x_mem_resp_t       x_mem_resp;
+    logic              x_mem_result_valid;
+    x_mem_result_t     x_mem_result;
+    logic              x_result_ready;
+  } cvxif_req_t;
+
+  typedef struct packed {
+    logic               x_compressed_ready;
+    x_compressed_resp_t x_compressed_resp;
+    logic               x_issue_ready;
+    x_issue_resp_t      x_issue_resp;
+    logic               x_mem_valid;
+    x_mem_req_t         x_mem_req;
+    logic               x_result_valid;
+    x_result_t          x_result;
+  } cvxif_resp_t;
+
+endpackage

--- a/core/rb_cva6_copro_exp/rtl_v/include/riscv_pkg.sv
+++ b/core/rb_cva6_copro_exp/rtl_v/include/riscv_pkg.sv
@@ -1,0 +1,944 @@
+/* Copyright 2018 ETH Zurich and University of Bologna.
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the “License”); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * File:   riscv_pkg.sv
+ * Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+ * Date:   30.6.2017
+ *
+ * Description: Common RISC-V definitions.
+ */
+
+package riscv;
+
+  // ----------------------
+  // Import cva6 config from cva6_config_pkg
+  // ----------------------
+  // FIXME stop using them from CoreV-Verif and HPDCache
+  // Then remove them from this package
+  localparam XLEN = cva6_config_pkg::CVA6ConfigXlen;
+  localparam VLEN = (XLEN == 32) ? 32 : 64;
+  localparam PLEN = (XLEN == 32) ? 34 : 56;
+
+  // --------------------
+  // Privilege Spec
+  // --------------------
+  typedef enum logic [1:0] {
+    PRIV_LVL_M  = 2'b11,
+    PRIV_LVL_HS = 2'b10,
+    PRIV_LVL_S  = 2'b01,
+    PRIV_LVL_U  = 2'b00
+  } priv_lvl_t;
+
+  // type which holds xlen
+  typedef enum logic [1:0] {
+    XLEN_32  = 2'b01,
+    XLEN_64  = 2'b10,
+    XLEN_128 = 2'b11
+  } xlen_e;
+
+  typedef enum logic [1:0] {
+    Off     = 2'b00,
+    Initial = 2'b01,
+    Clean   = 2'b10,
+    Dirty   = 2'b11
+  } xs_t;
+
+  typedef struct packed {
+    logic sd;  // signal dirty state - read-only
+    logic [62:34] wpri6;  // writes preserved reads ignored
+    xlen_e uxl;  // variable user mode xlen - hardwired to zero
+    logic [11:0] wpri5;  // writes preserved reads ignored
+    logic mxr;  // make executable readable
+    logic sum;  // permit supervisor user memory access
+    logic wpri4;  // writes preserved reads ignored
+    xs_t xs;  // extension register - hardwired to zero
+    xs_t fs;  // floating point extension register
+    logic [1:0] wpri3;  // writes preserved reads ignored
+    xs_t vs;  // vector extension register
+    logic spp;  // holds the previous privilege mode up to supervisor
+    logic wpri2;  // writes preserved reads ignored
+    logic mpie;  // machine interrupts enable bit active prior to trap
+    logic         ube;    // UBE controls whether explicit load and store memory accesses made from U-mode are little-endian (UBE=0) or big-endian (UBE=1)
+    logic spie;  // supervisor interrupts enable bit active prior to trap
+    logic [2:0] wpri1;  // writes preserved reads ignored
+    logic sie;  // supervisor interrupts enable
+    logic wpri0;  // writes preserved reads ignored
+  } sstatus_rv_t;
+
+  typedef struct packed {
+    logic [63:34] wpri4;  // writes preserved reads ignored
+    xlen_e        vsxl;   // variable virtual supervisor mode xlen - hardwired to zero
+    logic [8:0]   wpri3;  // floating point extension register
+    logic         vtsr;   // virtual trap sret
+    logic         vtw;    // virtual time wait
+    logic         vtvm;   // virtual trap virtual memory
+    logic [1:0]   wpri2;  // writes preserved reads ignored
+    logic [5:0]   vgein;  // virtual guest external interrupt number
+    logic [1:0]   wpri1;  // writes preserved reads ignored
+    logic         hu;     // virtual-machine load/store instructions enable in U-mode
+    logic         spvp;   // supervisor previous virtual privilege
+    logic         spv;    // supervisor previous virtualization mode
+    logic         gva;    // variable set when trap writes to stval
+    logic         vsbe;   // endianness of explicit memory accesses made from VS-mode
+    logic [4:0]   wpri0;  // writes preserved reads ignored
+  } hstatus_rv_t;
+
+  typedef struct packed {
+    logic sd;  // signal dirty state - read-only
+    logic [62:40] wpri4;  // writes preserved reads ignored
+    logic mpv;  // machine previous virtualization mode
+    logic gva;  // variable set when trap writes to stval
+    logic mbe;  // endianness memory accesses made from M-mode
+    logic sbe;  // endianness memory accesses made from S-mode
+    xlen_e sxl;  // variable supervisor mode xlen - hardwired to zero
+    xlen_e uxl;  // variable user mode xlen - hardwired to zero
+    logic [8:0] wpri3;  // writes preserved reads ignored
+    logic tsr;  // trap sret
+    logic tw;  // time wait
+    logic tvm;  // trap virtual memory
+    logic mxr;  // make executable readable
+    logic sum;  // permit supervisor user memory access
+    logic mprv;  // modify privilege - privilege level for ld/st
+    xs_t xs;  // extension register - hardwired to zero
+    xs_t fs;  // floating point extension register
+    priv_lvl_t mpp;  // holds the previous privilege mode up to machine
+    xs_t vs;  // vector extension register
+    logic spp;  // holds the previous privilege mode up to supervisor
+    logic mpie;  // machine interrupts enable bit active prior to trap
+    logic         ube;    // UBE controls whether explicit load and store memory accesses made from U-mode are little-endian (UBE=0) or big-endian (UBE=1)
+    logic spie;  // supervisor interrupts enable bit active prior to trap
+    logic wpri2;  // writes preserved reads ignored
+    logic mie;  // machine interrupts enable
+    logic wpri1;  // writes preserved reads ignored
+    logic sie;  // supervisor interrupts enable
+    logic wpri0;  // writes preserved reads ignored
+  } mstatus_rv_t;
+
+  typedef struct packed {
+    logic        stce;   // not implemented - requires Sctc extension
+    logic        pbmte;  // not implemented - requires Svpbmt extension
+    logic [61:8] wpri1;  // writes preserved reads ignored
+    logic        cbze;   // not implemented - requires Zicboz extension
+    logic        cbcfe;  // not implemented - requires Zicbom extension
+    logic [1:0]  cbie;   // not implemented - requires Zicbom extension
+    logic [2:0]  wpri0;  // writes preserved reads ignored
+    logic        fiom;   // fence of I/O implies memory
+  } envcfg_rv_t;
+
+  // --------------------
+  // Instruction Types
+  // --------------------
+  typedef struct packed {
+    logic [31:25] funct7;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } rtype_t;
+
+  typedef struct packed {
+    logic [31:27] rs3;
+    logic [26:25] funct2;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } r4type_t;
+
+  typedef struct packed {
+    logic [31:27] funct5;
+    logic [26:25] fmt;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] rm;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } rftype_t;  // floating-point
+
+  typedef struct packed {
+    logic [31:30] funct2;
+    logic [29:25] vecfltop;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:14] repl;
+    logic [13:12] vfmt;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } rvftype_t;  // vectorial floating-point
+
+  typedef struct packed {
+    logic [31:20] imm;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } itype_t;
+
+  typedef struct packed {
+    logic [31:25] imm;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  imm0;
+    logic [6:0]   opcode;
+  } stype_t;
+
+  typedef struct packed {
+    logic [31:12] imm;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } utype_t;
+
+  // atomic instructions
+  typedef struct packed {
+    logic [31:27] funct5;
+    logic         aq;
+    logic         rl;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } atype_t;
+
+  typedef union packed {
+    logic [31:0] instr;
+    rtype_t      rtype;
+    r4type_t     r4type;
+    rftype_t     rftype;
+    rvftype_t    rvftype;
+    itype_t      itype;
+    stype_t      stype;
+    utype_t      utype;
+    atype_t      atype;
+  } instruction_t;
+
+  // --------------------
+  // Opcodes
+  // --------------------
+  // RV32/64G listings:
+  // Quadrant 0
+  localparam OpcodeLoad = 7'b00_000_11;
+  localparam OpcodeLoadFp = 7'b00_001_11;
+  localparam OpcodeCustom0 = 7'b00_010_11;
+  localparam OpcodeMiscMem = 7'b00_011_11;
+  localparam OpcodeOpImm = 7'b00_100_11;
+  localparam OpcodeAuipc = 7'b00_101_11;
+  localparam OpcodeOpImm32 = 7'b00_110_11;
+  // Quadrant 1
+  localparam OpcodeStore = 7'b01_000_11;
+  localparam OpcodeStoreFp = 7'b01_001_11;
+  localparam OpcodeCustom1 = 7'b01_010_11;
+  localparam OpcodeAmo = 7'b01_011_11;
+  localparam OpcodeOp = 7'b01_100_11;
+  localparam OpcodeLui = 7'b01_101_11;
+  localparam OpcodeOp32 = 7'b01_110_11;
+  // Quadrant 2
+  localparam OpcodeMadd = 7'b10_000_11;
+  localparam OpcodeMsub = 7'b10_001_11;
+  localparam OpcodeNmsub = 7'b10_010_11;
+  localparam OpcodeNmadd = 7'b10_011_11;
+  localparam OpcodeOpFp = 7'b10_100_11;
+  localparam OpcodeVec = 7'b10_101_11;
+  localparam OpcodeCustom2 = 7'b10_110_11;
+  // Quadrant 3
+  localparam OpcodeBranch = 7'b11_000_11;
+  localparam OpcodeJalr = 7'b11_001_11;
+  localparam OpcodeRsrvd2 = 7'b11_010_11;
+  localparam OpcodeJal = 7'b11_011_11;
+  localparam OpcodeSystem = 7'b11_100_11;
+  localparam OpcodeRsrvd3 = 7'b11_101_11;
+  localparam OpcodeCustom3 = 7'b11_110_11;
+
+  // RV64C/RV32C listings:
+  // Quadrant 0
+  localparam OpcodeC0 = 2'b00;
+  localparam OpcodeC0Addi4spn = 3'b000;
+  localparam OpcodeC0Fld = 3'b001;
+  localparam OpcodeC0Lw = 3'b010;
+  localparam OpcodeC0Ld = 3'b011;
+  localparam OpcodeC0Zcb = 3'b100;
+  localparam OpcodeC0Fsd = 3'b101;
+  localparam OpcodeC0Sw = 3'b110;
+  localparam OpcodeC0Sd = 3'b111;
+  // Quadrant 1
+  localparam OpcodeC1 = 2'b01;
+  localparam OpcodeC1Addi = 3'b000;
+  localparam OpcodeC1Addiw = 3'b001;  //for RV64I only
+  localparam OpcodeC1Jal = 3'b001;  //for RV32I only
+  localparam OpcodeC1Li = 3'b010;
+  localparam OpcodeC1LuiAddi16sp = 3'b011;
+  localparam OpcodeC1MiscAlu = 3'b100;
+  localparam OpcodeC1J = 3'b101;
+  localparam OpcodeC1Beqz = 3'b110;
+  localparam OpcodeC1Bnez = 3'b111;
+  // Quadrant 2
+  localparam OpcodeC2 = 2'b10;
+  localparam OpcodeC2Slli = 3'b000;
+  localparam OpcodeC2Fldsp = 3'b001;
+  localparam OpcodeC2Lwsp = 3'b010;
+  localparam OpcodeC2Ldsp = 3'b011;
+  localparam OpcodeC2JalrMvAdd = 3'b100;
+  localparam OpcodeC2Fsdsp = 3'b101;
+  localparam OpcodeC2Swsp = 3'b110;
+  localparam OpcodeC2Sdsp = 3'b111;
+
+  // ----------------------
+  // Virtual Memory
+  // ----------------------
+  // memory management, pte for sv39
+  typedef struct packed {
+    logic [9:0] reserved;
+    logic [44-1:0] ppn;  // PPN length for
+    logic [1:0] rsw;
+    logic d;
+    logic a;
+    logic g;
+    logic u;
+    logic x;
+    logic w;
+    logic r;
+    logic v;
+  } pte_t;
+
+  // memory management, pte for sv32
+  typedef struct packed {
+    logic [22-1:0] ppn;  // PPN length for
+    logic [1:0] rsw;
+    logic d;
+    logic a;
+    logic g;
+    logic u;
+    logic x;
+    logic w;
+    logic r;
+    logic v;
+  } pte_sv32_t;
+
+  // ----------------------
+  // Exception Cause Codes
+  // ----------------------
+  localparam logic [XLEN-1:0] INSTR_ADDR_MISALIGNED = 0;
+  localparam logic [XLEN-1:0] INSTR_ACCESS_FAULT    = 1;  // Illegal access as governed by PMPs and PMAs
+  localparam logic [XLEN-1:0] ILLEGAL_INSTR = 2;
+  localparam logic [XLEN-1:0] BREAKPOINT = 3;
+  localparam logic [XLEN-1:0] LD_ADDR_MISALIGNED = 4;
+  localparam logic [XLEN-1:0] LD_ACCESS_FAULT = 5;  // Illegal access as governed by PMPs and PMAs
+  localparam logic [XLEN-1:0] ST_ADDR_MISALIGNED = 6;
+  localparam logic [XLEN-1:0] ST_ACCESS_FAULT = 7;  // Illegal access as governed by PMPs and PMAs
+  localparam logic [XLEN-1:0] ENV_CALL_UMODE = 8;  // environment call from user mode or virtual user mode
+  localparam logic [XLEN-1:0] ENV_CALL_SMODE = 9;  // environment call from hypervisor-extended supervisor mode
+  localparam logic [XLEN-1:0] ENV_CALL_VSMODE = 10; // environment call from virtual supervisor mode
+  localparam logic [XLEN-1:0] ENV_CALL_MMODE = 11;  // environment call from machine mode
+  localparam logic [XLEN-1:0] INSTR_PAGE_FAULT = 12;  // Instruction page fault
+  localparam logic [XLEN-1:0] LOAD_PAGE_FAULT = 13;  // Load page fault
+  localparam logic [XLEN-1:0] STORE_PAGE_FAULT = 15;  // Store page fault
+  localparam logic [XLEN-1:0] INSTR_GUEST_PAGE_FAULT = 20;  // Instruction guest-page fault
+  localparam logic [XLEN-1:0] LOAD_GUEST_PAGE_FAULT = 21;  // Load guest-page fault
+  localparam logic [XLEN-1:0] VIRTUAL_INSTRUCTION = 22;  // virtual instruction
+  localparam logic [XLEN-1:0] STORE_GUEST_PAGE_FAULT = 23;  // Store guest-page fault
+  localparam logic [XLEN-1:0] DEBUG_REQUEST = 24;  // Debug request
+
+  localparam int unsigned IRQ_S_SOFT = 1;
+  localparam int unsigned IRQ_VS_SOFT = 2;
+  localparam int unsigned IRQ_M_SOFT = 3;
+  localparam int unsigned IRQ_S_TIMER = 5;
+  localparam int unsigned IRQ_VS_TIMER = 6;
+  localparam int unsigned IRQ_M_TIMER = 7;
+  localparam int unsigned IRQ_S_EXT = 9;
+  localparam int unsigned IRQ_VS_EXT = 10;
+  localparam int unsigned IRQ_M_EXT = 11;
+  localparam int unsigned IRQ_HS_EXT = 12;
+
+  localparam logic [31:0] MIP_SSIP = 1 << IRQ_S_SOFT;
+  localparam logic [31:0] MIP_VSSIP = 1 << IRQ_VS_SOFT;
+  localparam logic [31:0] MIP_MSIP = 1 << IRQ_M_SOFT;
+  localparam logic [31:0] MIP_STIP = 1 << IRQ_S_TIMER;
+  localparam logic [31:0] MIP_VSTIP = 1 << IRQ_VS_TIMER;
+  localparam logic [31:0] MIP_MTIP = 1 << IRQ_M_TIMER;
+  localparam logic [31:0] MIP_SEIP = 1 << IRQ_S_EXT;
+  localparam logic [31:0] MIP_VSEIP = 1 << IRQ_VS_EXT;
+  localparam logic [31:0] MIP_MEIP = 1 << IRQ_M_EXT;
+  localparam logic [31:0] MIP_SGEIP = 1 << IRQ_HS_EXT;
+
+  // ----------------------
+  // PseudoInstructions Codes
+  // ----------------------
+  localparam logic [31:0] READ_32_PSEUDOINSTRUCTION = 32'h00002000;
+  localparam logic [31:0] WRITE_32_PSEUDOINSTRUCTION = 32'h00002020;
+  localparam logic [31:0] READ_64_PSEUDOINSTRUCTION = 32'h00003000;
+  localparam logic [31:0] WRITE_64_PSEUDOINSTRUCTION = 32'h00003020;
+
+  // -----
+  // CSRs
+  // -----
+  typedef enum logic [11:0] {
+    // Floating-Point CSRs
+    CSR_FFLAGS           = 12'h001,
+    CSR_FRM              = 12'h002,
+    CSR_FCSR             = 12'h003,
+    CSR_FTRAN            = 12'h800,
+    // Vector CSRs
+    CSR_VSTART           = 12'h008,
+    CSR_VXSAT            = 12'h009,
+    CSR_VXRM             = 12'h00A,
+    CSR_VCSR             = 12'h00F,
+    CSR_VL               = 12'hC20,
+    CSR_VTYPE            = 12'hC21,
+    CSR_VLENB            = 12'hC22,
+    // Virtual Supervisor Mode CSRs
+    CSR_VSSTATUS         = 12'h200,
+    CSR_VSIE             = 12'h204,
+    CSR_VSTVEC           = 12'h205,
+    CSR_VSSCRATCH        = 12'h240,
+    CSR_VSEPC            = 12'h241,
+    CSR_VSCAUSE          = 12'h242,
+    CSR_VSTVAL           = 12'h243,
+    CSR_VSIP             = 12'h244,
+    CSR_VSATP            = 12'h280,
+    // Supervisor Mode CSRs
+    CSR_SSTATUS          = 12'h100,
+    CSR_SIE              = 12'h104,
+    CSR_STVEC            = 12'h105,
+    CSR_SCOUNTEREN       = 12'h106,
+    CSR_SENVCFG          = 12'h10A,
+    CSR_SSCRATCH         = 12'h140,
+    CSR_SEPC             = 12'h141,
+    CSR_SCAUSE           = 12'h142,
+    CSR_STVAL            = 12'h143,
+    CSR_SIP              = 12'h144,
+    CSR_SATP             = 12'h180,
+    // Hypervisor-extended Supervisor Mode CSRs
+    CSR_HSTATUS          = 12'h600,
+    CSR_HEDELEG          = 12'h602,
+    CSR_HIDELEG          = 12'h603,
+    CSR_HIE              = 12'h604,
+    CSR_HCOUNTEREN       = 12'h606,
+    CSR_HGEIE            = 12'h607,
+    CSR_HTVAL            = 12'h643,
+    CSR_HIP              = 12'h644,
+    CSR_HVIP             = 12'h645,
+    CSR_HTINST           = 12'h64A,
+    CSR_HGEIP            = 12'hE12,
+    CSR_HENVCFG          = 12'h60A,
+    CSR_HENVCFGH         = 12'h61A,
+    CSR_HGATP            = 12'h680,
+    CSR_HCONTEXT         = 12'h6A8,
+    CSR_HTIMEDELTA       = 12'h605,
+    CSR_HTIMEDELTAH      = 12'h615,
+    // Machine Mode CSRs
+    CSR_MSTATUS          = 12'h300,
+    CSR_MISA             = 12'h301,
+    CSR_MEDELEG          = 12'h302,
+    CSR_MIDELEG          = 12'h303,
+    CSR_MIE              = 12'h304,
+    CSR_MTVEC            = 12'h305,
+    CSR_MCOUNTEREN       = 12'h306,
+    CSR_MSTATUSH         = 12'h310,
+    CSR_MCOUNTINHIBIT    = 12'h320,
+    CSR_MHPM_EVENT_3     = 12'h323,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_4     = 12'h324,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_5     = 12'h325,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_6     = 12'h326,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_7     = 12'h327,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_8     = 12'h328,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_9     = 12'h329,  //Reserved
+    CSR_MHPM_EVENT_10    = 12'h32A,  //Reserved
+    CSR_MHPM_EVENT_11    = 12'h32B,  //Reserved
+    CSR_MHPM_EVENT_12    = 12'h32C,  //Reserved
+    CSR_MHPM_EVENT_13    = 12'h32D,  //Reserved
+    CSR_MHPM_EVENT_14    = 12'h32E,  //Reserved
+    CSR_MHPM_EVENT_15    = 12'h32F,  //Reserved
+    CSR_MHPM_EVENT_16    = 12'h330,  //Reserved
+    CSR_MHPM_EVENT_17    = 12'h331,  //Reserved
+    CSR_MHPM_EVENT_18    = 12'h332,  //Reserved
+    CSR_MHPM_EVENT_19    = 12'h333,  //Reserved
+    CSR_MHPM_EVENT_20    = 12'h334,  //Reserved
+    CSR_MHPM_EVENT_21    = 12'h335,  //Reserved
+    CSR_MHPM_EVENT_22    = 12'h336,  //Reserved
+    CSR_MHPM_EVENT_23    = 12'h337,  //Reserved
+    CSR_MHPM_EVENT_24    = 12'h338,  //Reserved
+    CSR_MHPM_EVENT_25    = 12'h339,  //Reserved
+    CSR_MHPM_EVENT_26    = 12'h33A,  //Reserved
+    CSR_MHPM_EVENT_27    = 12'h33B,  //Reserved
+    CSR_MHPM_EVENT_28    = 12'h33C,  //Reserved
+    CSR_MHPM_EVENT_29    = 12'h33D,  //Reserved
+    CSR_MHPM_EVENT_30    = 12'h33E,  //Reserved
+    CSR_MHPM_EVENT_31    = 12'h33F,  //Reserved
+    CSR_MSCRATCH         = 12'h340,
+    CSR_MEPC             = 12'h341,
+    CSR_MCAUSE           = 12'h342,
+    CSR_MTVAL            = 12'h343,
+    CSR_MIP              = 12'h344,
+    CSR_MTINST           = 12'h34A,
+    CSR_MTVAL2           = 12'h34B,
+    CSR_MENVCFG          = 12'h30A,
+    CSR_MENVCFGH         = 12'h31A,
+    CSR_PMPCFG0          = 12'h3A0,
+    CSR_PMPCFG1          = 12'h3A1,
+    CSR_PMPCFG2          = 12'h3A2,
+    CSR_PMPCFG3          = 12'h3A3,
+    CSR_PMPADDR0         = 12'h3B0,
+    CSR_PMPADDR1         = 12'h3B1,
+    CSR_PMPADDR2         = 12'h3B2,
+    CSR_PMPADDR3         = 12'h3B3,
+    CSR_PMPADDR4         = 12'h3B4,
+    CSR_PMPADDR5         = 12'h3B5,
+    CSR_PMPADDR6         = 12'h3B6,
+    CSR_PMPADDR7         = 12'h3B7,
+    CSR_PMPADDR8         = 12'h3B8,
+    CSR_PMPADDR9         = 12'h3B9,
+    CSR_PMPADDR10        = 12'h3BA,
+    CSR_PMPADDR11        = 12'h3BB,
+    CSR_PMPADDR12        = 12'h3BC,
+    CSR_PMPADDR13        = 12'h3BD,
+    CSR_PMPADDR14        = 12'h3BE,
+    CSR_PMPADDR15        = 12'h3BF,
+    CSR_MVENDORID        = 12'hF11,
+    CSR_MARCHID          = 12'hF12,
+    CSR_MIMPID           = 12'hF13,
+    CSR_MHARTID          = 12'hF14,
+    CSR_MCONFIGPTR       = 12'hF15,
+    CSR_MCYCLE           = 12'hB00,
+    CSR_MCYCLEH          = 12'hB80,
+    CSR_MINSTRET         = 12'hB02,
+    CSR_MINSTRETH        = 12'hB82,
+    //Performance Counters
+    CSR_MHPM_COUNTER_3   = 12'hB03,
+    CSR_MHPM_COUNTER_4   = 12'hB04,
+    CSR_MHPM_COUNTER_5   = 12'hB05,
+    CSR_MHPM_COUNTER_6   = 12'hB06,
+    CSR_MHPM_COUNTER_7   = 12'hB07,
+    CSR_MHPM_COUNTER_8   = 12'hB08,
+    CSR_MHPM_COUNTER_9   = 12'hB09,  // reserved
+    CSR_MHPM_COUNTER_10  = 12'hB0A,  // reserved
+    CSR_MHPM_COUNTER_11  = 12'hB0B,  // reserved
+    CSR_MHPM_COUNTER_12  = 12'hB0C,  // reserved
+    CSR_MHPM_COUNTER_13  = 12'hB0D,  // reserved
+    CSR_MHPM_COUNTER_14  = 12'hB0E,  // reserved
+    CSR_MHPM_COUNTER_15  = 12'hB0F,  // reserved
+    CSR_MHPM_COUNTER_16  = 12'hB10,  // reserved
+    CSR_MHPM_COUNTER_17  = 12'hB11,  // reserved
+    CSR_MHPM_COUNTER_18  = 12'hB12,  // reserved
+    CSR_MHPM_COUNTER_19  = 12'hB13,  // reserved
+    CSR_MHPM_COUNTER_20  = 12'hB14,  // reserved
+    CSR_MHPM_COUNTER_21  = 12'hB15,  // reserved
+    CSR_MHPM_COUNTER_22  = 12'hB16,  // reserved
+    CSR_MHPM_COUNTER_23  = 12'hB17,  // reserved
+    CSR_MHPM_COUNTER_24  = 12'hB18,  // reserved
+    CSR_MHPM_COUNTER_25  = 12'hB19,  // reserved
+    CSR_MHPM_COUNTER_26  = 12'hB1A,  // reserved
+    CSR_MHPM_COUNTER_27  = 12'hB1B,  // reserved
+    CSR_MHPM_COUNTER_28  = 12'hB1C,  // reserved
+    CSR_MHPM_COUNTER_29  = 12'hB1D,  // reserved
+    CSR_MHPM_COUNTER_30  = 12'hB1E,  // reserved
+    CSR_MHPM_COUNTER_31  = 12'hB1F,  // reserved
+    CSR_MHPM_COUNTER_3H  = 12'hB83,
+    CSR_MHPM_COUNTER_4H  = 12'hB84,
+    CSR_MHPM_COUNTER_5H  = 12'hB85,
+    CSR_MHPM_COUNTER_6H  = 12'hB86,
+    CSR_MHPM_COUNTER_7H  = 12'hB87,
+    CSR_MHPM_COUNTER_8H  = 12'hB88,
+    CSR_MHPM_COUNTER_9H  = 12'hB89,  // reserved
+    CSR_MHPM_COUNTER_10H = 12'hB8A,  // reserved
+    CSR_MHPM_COUNTER_11H = 12'hB8B,  // reserved
+    CSR_MHPM_COUNTER_12H = 12'hB8C,  // reserved
+    CSR_MHPM_COUNTER_13H = 12'hB8D,  // reserved
+    CSR_MHPM_COUNTER_14H = 12'hB8E,  // reserved
+    CSR_MHPM_COUNTER_15H = 12'hB8F,  // reserved
+    CSR_MHPM_COUNTER_16H = 12'hB90,  // reserved
+    CSR_MHPM_COUNTER_17H = 12'hB91,  // reserved
+    CSR_MHPM_COUNTER_18H = 12'hB92,  // reserved
+    CSR_MHPM_COUNTER_19H = 12'hB93,  // reserved
+    CSR_MHPM_COUNTER_20H = 12'hB94,  // reserved
+    CSR_MHPM_COUNTER_21H = 12'hB95,  // reserved
+    CSR_MHPM_COUNTER_22H = 12'hB96,  // reserved
+    CSR_MHPM_COUNTER_23H = 12'hB97,  // reserved
+    CSR_MHPM_COUNTER_24H = 12'hB98,  // reserved
+    CSR_MHPM_COUNTER_25H = 12'hB99,  // reserved
+    CSR_MHPM_COUNTER_26H = 12'hB9A,  // reserved
+    CSR_MHPM_COUNTER_27H = 12'hB9B,  // reserved
+    CSR_MHPM_COUNTER_28H = 12'hB9C,  // reserved
+    CSR_MHPM_COUNTER_29H = 12'hB9D,  // reserved
+    CSR_MHPM_COUNTER_30H = 12'hB9E,  // reserved
+    CSR_MHPM_COUNTER_31H = 12'hB9F,  // reserved
+    // Cache Control (platform specifc)
+    CSR_DCACHE           = 12'h7C1,
+    CSR_ICACHE           = 12'h7C0,
+    // Accelerator memory consistency (platform specific)
+    CSR_ACC_CONS         = 12'h7C2,
+    // Triggers
+    CSR_TSELECT          = 12'h7A0,
+    CSR_TDATA1           = 12'h7A1,
+    CSR_TDATA2           = 12'h7A2,
+    CSR_TDATA3           = 12'h7A3,
+    CSR_TINFO            = 12'h7A4,
+    // Debug CSR
+    CSR_DCSR             = 12'h7b0,
+    CSR_DPC              = 12'h7b1,
+    CSR_DSCRATCH0        = 12'h7b2,  // optional
+    CSR_DSCRATCH1        = 12'h7b3,  // optional
+    // Counters and Timers (User Mode - R/O Shadows)
+    CSR_CYCLE            = 12'hC00,
+    CSR_CYCLEH           = 12'hC80,
+    CSR_TIME             = 12'hC01,
+    CSR_TIMEH            = 12'hC81,
+    CSR_INSTRET          = 12'hC02,
+    CSR_INSTRETH         = 12'hC82,
+    // Performance counters (User Mode - R/O Shadows)
+    CSR_HPM_COUNTER_3    = 12'hC03,
+    CSR_HPM_COUNTER_4    = 12'hC04,
+    CSR_HPM_COUNTER_5    = 12'hC05,
+    CSR_HPM_COUNTER_6    = 12'hC06,
+    CSR_HPM_COUNTER_7    = 12'hC07,
+    CSR_HPM_COUNTER_8    = 12'hC08,
+    CSR_HPM_COUNTER_9    = 12'hC09,  // reserved
+    CSR_HPM_COUNTER_10   = 12'hC0A,  // reserved
+    CSR_HPM_COUNTER_11   = 12'hC0B,  // reserved
+    CSR_HPM_COUNTER_12   = 12'hC0C,  // reserved
+    CSR_HPM_COUNTER_13   = 12'hC0D,  // reserved
+    CSR_HPM_COUNTER_14   = 12'hC0E,  // reserved
+    CSR_HPM_COUNTER_15   = 12'hC0F,  // reserved
+    CSR_HPM_COUNTER_16   = 12'hC10,  // reserved
+    CSR_HPM_COUNTER_17   = 12'hC11,  // reserved
+    CSR_HPM_COUNTER_18   = 12'hC12,  // reserved
+    CSR_HPM_COUNTER_19   = 12'hC13,  // reserved
+    CSR_HPM_COUNTER_20   = 12'hC14,  // reserved
+    CSR_HPM_COUNTER_21   = 12'hC15,  // reserved
+    CSR_HPM_COUNTER_22   = 12'hC16,  // reserved
+    CSR_HPM_COUNTER_23   = 12'hC17,  // reserved
+    CSR_HPM_COUNTER_24   = 12'hC18,  // reserved
+    CSR_HPM_COUNTER_25   = 12'hC19,  // reserved
+    CSR_HPM_COUNTER_26   = 12'hC1A,  // reserved
+    CSR_HPM_COUNTER_27   = 12'hC1B,  // reserved
+    CSR_HPM_COUNTER_28   = 12'hC1C,  // reserved
+    CSR_HPM_COUNTER_29   = 12'hC1D,  // reserved
+    CSR_HPM_COUNTER_30   = 12'hC1E,  // reserved
+    CSR_HPM_COUNTER_31   = 12'hC1F,  // reserved
+    CSR_HPM_COUNTER_3H   = 12'hC83,
+    CSR_HPM_COUNTER_4H   = 12'hC84,
+    CSR_HPM_COUNTER_5H   = 12'hC85,
+    CSR_HPM_COUNTER_6H   = 12'hC86,
+    CSR_HPM_COUNTER_7H   = 12'hC87,
+    CSR_HPM_COUNTER_8H   = 12'hC88,
+    CSR_HPM_COUNTER_9H   = 12'hC89,  // reserved
+    CSR_HPM_COUNTER_10H  = 12'hC8A,  // reserved
+    CSR_HPM_COUNTER_11H  = 12'hC8B,  // reserved
+    CSR_HPM_COUNTER_12H  = 12'hC8C,  // reserved
+    CSR_HPM_COUNTER_13H  = 12'hC8D,  // reserved
+    CSR_HPM_COUNTER_14H  = 12'hC8E,  // reserved
+    CSR_HPM_COUNTER_15H  = 12'hC8F,  // reserved
+    CSR_HPM_COUNTER_16H  = 12'hC90,  // reserved
+    CSR_HPM_COUNTER_17H  = 12'hC91,  // reserved
+    CSR_HPM_COUNTER_18H  = 12'hC92,  // reserved
+    CSR_HPM_COUNTER_19H  = 12'hC93,  // reserved
+    CSR_HPM_COUNTER_20H  = 12'hC94,  // reserved
+    CSR_HPM_COUNTER_21H  = 12'hC95,  // reserved
+    CSR_HPM_COUNTER_22H  = 12'hC96,  // reserved
+    CSR_HPM_COUNTER_23H  = 12'hC97,  // reserved
+    CSR_HPM_COUNTER_24H  = 12'hC98,  // reserved
+    CSR_HPM_COUNTER_25H  = 12'hC99,  // reserved
+    CSR_HPM_COUNTER_26H  = 12'hC9A,  // reserved
+    CSR_HPM_COUNTER_27H  = 12'hC9B,  // reserved
+    CSR_HPM_COUNTER_28H  = 12'hC9C,  // reserved
+    CSR_HPM_COUNTER_29H  = 12'hC9D,  // reserved
+    CSR_HPM_COUNTER_30H  = 12'hC9E,  // reserved
+    CSR_HPM_COUNTER_31H  = 12'hC9F,  // reserved
+    // Memory control (Custom Machine Level - R/W)
+    CSR_MEMCTRL          = 12'h7C3
+  } csr_reg_t;
+
+  localparam logic [63:0] SSTATUS_UIE = 'h00000001;
+  localparam logic [63:0] SSTATUS_SIE = 'h00000002;
+  localparam logic [63:0] SSTATUS_SPIE = 'h00000020;
+  localparam logic [63:0] SSTATUS_SPP = 'h00000100;
+  localparam logic [63:0] SSTATUS_FS = 'h00006000;
+  localparam logic [63:0] SSTATUS_XS = 'h00018000;
+  localparam logic [63:0] SSTATUS_SUM = 'h00040000;
+  localparam logic [63:0] SSTATUS_MXR = 'h00080000;
+  localparam logic [63:0] SSTATUS_UPIE = 'h00000010;
+  localparam logic [63:0] SSTATUS_UXL = 64'h0000000300000000;
+  function automatic logic [63:0] sstatus_sd(logic IS_XLEN64);
+    return {IS_XLEN64, 31'h00000000, ~IS_XLEN64, 31'h00000000};
+  endfunction
+
+  localparam logic [63:0] HSTATUS_VSBE = 'h00000020;
+  localparam logic [63:0] HSTATUS_GVA = 'h00000040;
+  localparam logic [63:0] HSTATUS_SPV = 'h00000080;
+  localparam logic [63:0] HSTATUS_SPVP = 'h00000100;
+  localparam logic [63:0] HSTATUS_HU = 'h00000200;
+  localparam logic [63:0] HSTATUS_VGEIN = 'h0003F000;
+  localparam logic [63:0] HSTATUS_VTVM = 'h00100000;
+  localparam logic [63:0] HSTATUS_VTW = 'h00200000;
+  localparam logic [63:0] HSTATUS_VTSR = 'h00400000;
+  localparam logic [63:0] HSTATUS_VSXL = 64'h0000000300000000;
+
+  localparam logic [63:0] MSTATUS_UIE = 'h00000001;
+  localparam logic [63:0] MSTATUS_SIE = 'h00000002;
+  localparam logic [63:0] MSTATUS_HIE = 'h00000004;
+  localparam logic [63:0] MSTATUS_MIE = 'h00000008;
+  localparam logic [63:0] MSTATUS_UPIE = 'h00000010;
+  localparam logic [63:0] MSTATUS_SPIE = 'h00000020;
+  localparam logic [63:0] MSTATUS_HPIE = 'h00000040;
+  localparam logic [63:0] MSTATUS_MPIE = 'h00000080;
+  localparam logic [63:0] MSTATUS_SPP = 'h00000100;
+  localparam logic [63:0] MSTATUS_HPP = 'h00000600;
+  localparam logic [63:0] MSTATUS_MPP = 'h00001800;
+  localparam logic [63:0] MSTATUS_FS = 'h00006000;
+  localparam logic [63:0] MSTATUS_XS = 'h00018000;
+  localparam logic [63:0] MSTATUS_MPRV = 'h00020000;
+  localparam logic [63:0] MSTATUS_SUM = 'h00040000;
+  localparam logic [63:0] MSTATUS_MXR = 'h00080000;
+  localparam logic [63:0] MSTATUS_TVM = 'h00100000;
+  localparam logic [63:0] MSTATUS_TW = 'h00200000;
+  localparam logic [63:0] MSTATUS_TSR = 'h00400000;
+  function automatic logic [63:0] mstatus_uxl(logic IS_XLEN64);
+    return {30'h0000000, IS_XLEN64, IS_XLEN64, 32'h00000000};
+  endfunction
+  function automatic logic [63:0] mstatus_sxl(logic IS_XLEN64);
+    return {28'h0000000, IS_XLEN64, IS_XLEN64, 34'h00000000};
+  endfunction
+  function automatic logic [63:0] mstatus_sd(logic IS_XLEN64);
+    return {IS_XLEN64, 31'h00000000, ~IS_XLEN64, 31'h00000000};
+  endfunction
+
+  localparam logic [63:0] MENVCFG_FIOM = 'h00000001;
+  localparam logic [63:0] MENVCFG_CBIE = 'h00000030;
+  localparam logic [63:0] MENVCFG_CBFE = 'h00000040;
+  localparam logic [63:0] MENVCFG_CBZE = 'h00000080;
+  localparam logic [63:0] MENVCFG_PBMTE = 64'h4000000000000000;
+  localparam logic [63:0] MENVCFG_STCE = 64'h8000000000000000;
+
+
+
+  typedef enum logic [2:0] {
+    CSRRW  = 3'h1,
+    CSRRS  = 3'h2,
+    CSRRC  = 3'h3,
+    CSRRWI = 3'h5,
+    CSRRSI = 3'h6,
+    CSRRCI = 3'h7
+  } csr_op_t;
+
+  // decoded CSR address
+  typedef struct packed {
+    logic [1:0] rw;
+    priv_lvl_t  priv_lvl;
+    logic [7:0] address;
+  } csr_addr_t;
+
+  typedef union packed {
+    csr_reg_t  address;
+    csr_addr_t csr_decode;
+  } csr_t;
+
+  // Floating-Point control and status register (32-bit!)
+  typedef struct packed {
+    logic [31:15] reserved;  // reserved for L extension, return 0 otherwise
+    logic [6:0]   fprec;     // div/sqrt precision control
+    logic [2:0]   frm;       // float rounding mode
+    logic [4:0]   fflags;    // float exception flags
+  } fcsr_t;
+
+  // PMP
+  typedef enum logic [1:0] {
+    OFF   = 2'b00,
+    TOR   = 2'b01,
+    NA4   = 2'b10,
+    NAPOT = 2'b11
+  } pmp_addr_mode_t;
+
+  // PMP Access Type
+  typedef enum logic [2:0] {
+    ACCESS_NONE  = 3'b000,
+    ACCESS_READ  = 3'b001,
+    ACCESS_WRITE = 3'b010,
+    ACCESS_EXEC  = 3'b100
+  } pmp_access_t;
+
+  typedef struct packed {
+    logic x;
+    logic w;
+    logic r;
+  } pmpcfg_access_t;
+
+  // packed struct of a PMP configuration register (8bit)
+  typedef struct packed {
+    logic           locked;       // lock this configuration
+    logic [1:0]     reserved;
+    pmp_addr_mode_t addr_mode;    // Off, TOR, NA4, NAPOT
+    pmpcfg_access_t access_type;
+  } pmpcfg_t;
+
+  typedef enum logic [1:0] {
+      CSR_MEMCTRL_ISCR_EN       = 2'b00,
+      CSR_MEMCTRL_DSCR_EN       = 2'b01,
+      CSR_MEMCTRL_AHB_PERIPH_EN = 2'b10,
+      CSR_MEMCTRL_ISCR_MODE     = 2'b11
+  } csr_memctrl_t;
+
+  // -----
+  // Debug
+  // -----
+  typedef struct packed {
+    logic [31:28] xdebugver;
+    logic [27:18] zero2;
+    logic         ebreakvs;
+    logic         ebreakvu;
+    logic         ebreakm;
+    logic         zero1;
+    logic         ebreaks;
+    logic         ebreaku;
+    logic         stepie;
+    logic         stopcount;
+    logic         stoptime;
+    logic [8:6]   cause;
+    logic         v;
+    logic         mprven;
+    logic         nmip;
+    logic         step;
+    priv_lvl_t    prv;
+  } dcsr_t;
+
+  // Instruction Generation *incomplete*
+  function automatic logic [31:0] jal(logic [4:0] rd, logic [20:0] imm);
+    // OpCode Jal
+    return {imm[20], imm[10:1], imm[11], imm[19:12], rd, 7'h6f};
+  endfunction
+
+  function automatic logic [31:0] jalr(logic [4:0] rd, logic [4:0] rs1, logic [11:0] offset);
+    // OpCode Jal
+    return {offset[11:0], rs1, 3'b0, rd, 7'h67};
+  endfunction
+
+  function automatic logic [31:0] andi(logic [4:0] rd, logic [4:0] rs1, logic [11:0] imm);
+    // OpCode andi
+    return {imm[11:0], rs1, 3'h7, rd, 7'h13};
+  endfunction
+
+  function automatic logic [31:0] slli(logic [4:0] rd, logic [4:0] rs1, logic [5:0] shamt);
+    // OpCode slli
+    return {6'b0, shamt[5:0], rs1, 3'h1, rd, 7'h13};
+  endfunction
+
+  function automatic logic [31:0] srli(logic [4:0] rd, logic [4:0] rs1, logic [5:0] shamt);
+    // OpCode srli
+    return {6'b0, shamt[5:0], rs1, 3'h5, rd, 7'h13};
+  endfunction
+
+  function automatic logic [31:0] load(logic [2:0] size, logic [4:0] dest, logic [4:0] base,
+                                       logic [11:0] offset);
+    // OpCode Load
+    return {offset[11:0], base, size, dest, 7'h03};
+  endfunction
+
+  function automatic logic [31:0] auipc(logic [4:0] rd, logic [20:0] imm);
+    // OpCode Auipc
+    return {imm[20], imm[10:1], imm[11], imm[19:12], rd, 7'h17};
+  endfunction
+
+  function automatic logic [31:0] store(logic [2:0] size, logic [4:0] src, logic [4:0] base,
+                                        logic [11:0] offset);
+    // OpCode Store
+    return {offset[11:5], src, base, size, offset[4:0], 7'h23};
+  endfunction
+
+  function automatic logic [31:0] float_load(logic [2:0] size, logic [4:0] dest, logic [4:0] base,
+                                             logic [11:0] offset);
+    // OpCode Load
+    return {offset[11:0], base, size, dest, 7'b00_001_11};
+  endfunction
+
+  function automatic logic [31:0] float_store(logic [2:0] size, logic [4:0] src, logic [4:0] base,
+                                              logic [11:0] offset);
+    // OpCode Store
+    return {offset[11:5], src, base, size, offset[4:0], 7'b01_001_11};
+  endfunction
+
+  function automatic logic [31:0] csrw(csr_reg_t csr, logic [4:0] rs1);
+    // CSRRW, rd, OpCode System
+    return {csr, rs1, 3'h1, 5'h0, 7'h73};
+  endfunction
+
+  function automatic logic [31:0] csrr(csr_reg_t csr, logic [4:0] dest);
+    // rs1, CSRRS, rd, OpCode System
+    return {csr, 5'h0, 3'h2, dest, 7'h73};
+  endfunction
+
+  function automatic logic [31:0] branch(logic [4:0] src2, logic [4:0] src1, logic [2:0] funct3,
+                                         logic [11:0] offset);
+    // OpCode Branch
+    return {offset[11], offset[9:4], src2, src1, funct3, offset[3:0], offset[10], 7'b11_000_11};
+  endfunction
+
+  function automatic logic [31:0] ebreak();
+    return 32'h00100073;
+  endfunction
+
+  function automatic logic [31:0] wfi();
+    return 32'h10500073;
+  endfunction
+
+  function automatic logic [31:0] nop();
+    return 32'h00000013;
+  endfunction
+
+  function automatic logic [31:0] illegal();
+    return 32'h00000000;
+  endfunction
+
+  // This functions converts S-mode CSR addresses into VS-mode CSR addresses
+  // when V=1 (i.e., running in VS-mode).
+  function automatic csr_t convert_vs_access_csr(csr_t csr_addr, logic v);
+    csr_t ret;
+    ret = csr_addr;
+    unique case (csr_addr.address) inside
+      [CSR_SSTATUS : CSR_STVEC], [CSR_SSCRATCH : CSR_SATP]: begin
+        if (v) begin
+          ret.csr_decode.priv_lvl = PRIV_LVL_HS;
+        end
+        return ret;
+      end
+      default: return ret;
+    endcase
+  endfunction
+
+
+  // trace log compatible to spikes commit log feature
+  // pragma translate_off
+  function string spikeCommitLog(logic [63:0] pc, priv_lvl_t priv_lvl, logic [31:0] instr,
+                                 logic [4:0] rd, logic [63:0] result, logic rd_fpr);
+    static string rf_s = rd_fpr ? "f" : "x";
+    static string rd_s = (rd < 10) ? $sformatf("%s %0d", rf_s, rd) : $sformatf("%s%0d", rf_s, rd);
+    static string instr_word = (instr[1:0] != 2'b11) ? $sformatf("(0x%h)", instr[15:0]) : $sformatf("(0x%h)", instr);
+
+    if (rd_fpr || rd != 0) begin
+      // 0 0x0000000080000118 (0xeecf8f93) x31 0x0000000080004000
+      return $sformatf("%d 0x%h %s %s 0x%h\n", priv_lvl, pc, instr_word, rd_s, result);
+    end else begin
+      // 0 0x000000008000019c (0x0040006f)
+      return $sformatf("%d 0x%h %s\n", priv_lvl, pc, instr_word);
+    end
+  endfunction
+
+  typedef struct {
+    byte priv;
+    longint unsigned pc;
+    byte is_fp;
+    byte rd;
+    longint unsigned data;
+    int unsigned instr;
+    byte was_exception;
+  } commit_log_t;
+  // pragma translate_on
+
+endpackage

--- a/core/rb_cva6_copro_wrapper/README.md
+++ b/core/rb_cva6_copro_wrapper/README.md
@@ -1,0 +1,72 @@
+# TRISTAN/rb_cva6_cropro_wrapper
+This repository is holding the source RTL for the CVX-if coprocessor wrapper  CRC designed by Bosch, in the context of the TRISTAN project.
+Additionnaly, some testbenches are available.
+
+## Table of Contents <!-- omit in toc -->
+- [How to use this repo](#howto)
+- [Directory Structure](#directory-structure)
+- [Links and resources](#links-resources)
+- [About](#about)
+  - [Maintainers](#maintainers)
+
+An example implementation of a CRC and EXP coprocessor wrapper on the CVX-ID interface is given below :
+
+```
+ 
+  // ---------------
+  // CRC Coprocessor wrapper : CRC +EXP 
+  // ---------------
+
+  cvxif_pkg::cvxif_req_t  [cvxif_wrapper_pkg::COPRO_NBR-1:0] cvxif_req_copro;
+  cvxif_pkg::cvxif_resp_t [cvxif_wrapper_pkg::COPRO_NBR-1:0] cvxif_resp_copro;  
+ 
+  cvxif_coprocessor_wrapper #(
+        .COPRO_NBR        ( cvxif_wrapper_pkg::COPRO_NBR ),
+        .SAME_COPRO_NBR   ( cvxif_wrapper_pkg::SAME_COPRO_NBR ),
+        .SAME_COPRO_TABLE ( cvxif_wrapper_pkg::SAME_COPRO_TABLE ),
+        .DECODING_TYPE    ( cvxif_wrapper_pkg::DECODING_TYPE ),
+        .decoding_LUT     ( cvxif_wrapper_pkg::decoding_LUT ),
+        .i_resp_LUT       ( cvxif_wrapper_pkg::i_resp_LUT )
+    ) i_cvxif_coprocessor_wrapper (
+      .clk_i                ( clk                            ),
+      .rst_ni               ( sys_rst_n                      ),
+      .cvxif_req_i          ( cvxif_req                      ),
+      .cvxif_req_copro      ( cvxif_req_copro                ),
+      .cvxif_resp_copro     ( cvxif_resp_copro               ),
+      .cvxif_resp_o         ( cvxif_resp                     )
+    );
+ 
+    cvxif_crc_coprocessor i_cvxif_crc_coprocessor0 (
+      .clk_i                ( clk                            ),
+      .rst_ni               ( sys_rst_n                      ),
+      .cvxif_req_i          ( cvxif_req_copro[0]             ),
+      .cvxif_resp_o         ( cvxif_resp_copro[0]            )
+    );
+ 
+    cvxif_exp_coprocessor i_cvxif_exp_coprocessor1 (
+      .clk_i                ( clk                            ),
+      .rst_ni               ( sys_rst_n                      ),     
+      .cvxif_req_i          ( cvxif_req_copro[1]             ),
+      .cvxif_resp_o         ( cvxif_resp_copro[1]            )
+    );
+ 
+ 
+```
+
+
+## Directory Structure <a name="directory-structure"></a>
+
+This repository is structured according to the standard EIY folder structure :
+* rtl_v : contains RTL files
+
+
+## Links and resources <a name="links-resources"></a>
+* [EU TRISTAN project description](https://cordis.europa.eu/project/id/101095947)
+
+## About <a name="about"></a>
+Together for RISc-V Technology and ApplicatioNs (TRISTAN) is a project financed partly by the Europan Union and involving multiple companies.
+Some of the activities done by BOSCH will by open-sourced while other aspects will stay closed source.
+
+### Maintainers <a name="maintainers"></a>
+
+* [Nicolas TRIBIE](nicolas.tribie___at__@fr.bosch.com)

--- a/core/rb_cva6_copro_wrapper/rtl_v/cvxif_coprocessor_wrapper.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/cvxif_coprocessor_wrapper.sv
@@ -1,0 +1,172 @@
+// Original Author: Maxime TRAVAILLARD (fixed-term.maxime.travaillard@fr.bosch.com)
+
+// Top level of the coprocessor wrapper
+
+// To use this wrapper, you need to know which instruction your coprocessor is supporting (which opcode custom and if it use the full opcode)
+// You also need to know a bit about the signals used in the CV-X-IF interface, to at least connect the right signals togethers.
+// I recommend you to first implement you coprocessor with the CVA6 before setting your parameters in the package.
+// for more information to make the parameter, look inside the cvxif_wrapper_pkg
+
+module cvxif_coprocessor_wrapper
+  import cvxif_pkg::*;
+#(
+    parameter COPRO_NBR = cvxif_wrapper_pkg::COPRO_NBR,
+    parameter COPRO_BITS_NBR = $clog2(COPRO_NBR),
+    parameter SAME_COPRO_NBR = cvxif_wrapper_pkg::SAME_COPRO_NBR,
+    parameter SCT_SIZE = (SAME_COPRO_NBR == 0) ? 0 : SAME_COPRO_NBR-1,
+    parameter logic [COPRO_BITS_NBR:0] SAME_COPRO_TABLE[0:SCT_SIZE] = cvxif_wrapper_pkg::SAME_COPRO_TABLE,
+    parameter int unsigned DECODING_TYPE = cvxif_wrapper_pkg::DECODING_TYPE,
+    parameter int unsigned deco_LUT_size =   (DECODING_TYPE == 0) ? 2**2 : ((DECODING_TYPE == 1) ? 2**4 : ((DECODING_TYPE == 2) ? 2**5 : ((DECODING_TYPE == 3) ? 2**7 : 0))),
+    parameter logic [COPRO_BITS_NBR:0] decoding_LUT [0:deco_LUT_size-1] = cvxif_wrapper_pkg::decoding_LUT,
+    parameter logic [5:0] i_resp_LUT[COPRO_NBR-1:0] = cvxif_wrapper_pkg::i_resp_LUT
+) (
+    input  logic                        clk_i,             // Clock
+    input  logic                        rst_ni,            // Asynchronous reset active low
+    input  cvxif_req_t                  cvxif_req_i,
+    output cvxif_req_t  [COPRO_NBR-1:0] cvxif_req_copro,
+    input  cvxif_resp_t [COPRO_NBR-1:0] cvxif_resp_copro,
+    output cvxif_resp_t                 cvxif_resp_o
+);
+
+  typedef struct packed {
+    cvxif_pkg::x_issue_req_t   x_issue_req;
+    logic [COPRO_BITS_NBR-1:0] coprocessor_index;
+  } x_issue_indexed_t;
+
+  // type source_signal;
+
+  // decoder outputs
+  x_issue_req_t decoder_issue_req;
+  logic [COPRO_BITS_NBR-1:0] decoder_coprocessor_index;
+  logic decoder_push;
+
+  // sfifo outputs
+  x_issue_req_t sfifo_issue_req;
+  logic [COPRO_BITS_NBR-1:0] sfifo_coprocessor_index;
+  logic sfifo_full;
+  logic sfifo_empty;
+
+  // commit filter outputs
+  logic commit_filter_pop;  // used to pop from sfifo and to push into corresponding coprocessor
+
+  // coprocessors inputs/outputs
+  x_issue_req_t [COPRO_NBR-1:0] copros_issue_req;
+  logic [COPRO_NBR-1:0] copros_issue_rdy;
+  logic [COPRO_NBR-1:0] copros_issue_vld;
+  x_result_t [COPRO_NBR-1:0] copros_result;
+  logic [COPRO_NBR-1:0] copros_result_vld;
+  logic [COPRO_NBR-1:0] copros_result_rdy;
+  logic [COPRO_NBR-1:0] issue_rdy_cmp;
+
+  // Decoder :
+  wrapper_decoder #(
+      .COPRO_NBR       (COPRO_NBR),
+      .SAME_COPRO_NBR  (SAME_COPRO_NBR),
+      .SCT_SIZE (SCT_SIZE),
+      .SAME_COPRO_TABLE(SAME_COPRO_TABLE),
+      .DECODING_TYPE   (DECODING_TYPE),
+      .decoding_LUT    (decoding_LUT),
+      .i_resp_LUT      (i_resp_LUT)
+  ) decoder (
+      .clk_i              (clk_i),
+      .rst_ni             (rst_ni),
+      .issue_req_i        (cvxif_req_i.x_issue_req),
+      .issue_valid_i      (cvxif_req_i.x_issue_valid),
+      .fifo_full_i        (sfifo_full),
+      .issue_req_o        (decoder_issue_req),
+      .issue_resp_o       (cvxif_resp_o.x_issue_resp),
+      .coprocessor_index_o(decoder_coprocessor_index),
+      .push_sfifo_o       (decoder_push)
+  );
+
+  // Speculative FIFO :
+  fifo_v3 #(
+      .FALL_THROUGH(1),  //data_o ready and pop in the same cycle
+      .DATA_WIDTH(64),
+      .DEPTH(cva6_config_pkg::CVA6ConfigNrScoreboardEntries),  // CVA6 scoreboard size
+      .dtype(x_issue_indexed_t)  // correspond to concatenation of x_issue and copro_index
+  ) sfifo (  // need to check parameter ( bit width )
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .flush_i(1'b0),
+      .testmode_i(1'b0),
+      .full_o(sfifo_full),  // used by decoder to not push when full
+      .empty_o(sfifo_empty),  // used by commit filter to not pop when empty
+      .usage_o(),
+      .data_i({decoder_issue_req, decoder_coprocessor_index}),
+      .push_i(decoder_push),
+      .data_o({sfifo_issue_req, sfifo_coprocessor_index}),
+      .pop_i(commit_filter_pop)
+  );
+
+  // Commit Filter :
+  wrapper_commit_filter #(
+      .COPRO_NBR(COPRO_NBR)
+  ) commit_filter (
+      .clk_i              (clk_i),
+      .rst_ni             (rst_ni),
+      .issue_req_i        (sfifo_issue_req),
+      .coprocessor_index_i(sfifo_coprocessor_index),
+      .commit_valid_i     (cvxif_req_i.x_commit_valid),
+      .commit_i           (cvxif_req_i.x_commit),
+      .fifo_empty_i       (sfifo_empty),
+      .pop_o              (commit_filter_pop),
+      .issue_req_o        (copros_issue_req),
+      .issue_valid_o      (copros_issue_vld)
+  );
+
+  // Coprocessor : cvxif signals for coprocessors
+  always_comb begin : gen_cvxif_req
+    for (int i = 0; i < COPRO_NBR; i++) begin
+      cvxif_req_copro[i].x_compressed_valid = '0;
+      cvxif_req_copro[i].x_compressed_req = '0;
+      cvxif_req_copro[i].x_mem_ready = '0;
+      cvxif_req_copro[i].x_mem_resp = '0;
+      cvxif_req_copro[i].x_mem_result_valid = '0;
+      cvxif_req_copro[i].x_mem_result = '0;
+      cvxif_req_copro[i].x_result_ready = copros_result_rdy[i];
+      cvxif_req_copro[i].x_issue_req = copros_issue_req[i];
+      cvxif_req_copro[i].x_issue_valid = copros_issue_vld[i];
+      cvxif_req_copro[i].x_commit_valid = copros_issue_vld[i];
+      cvxif_req_copro[i].x_commit.id = (copros_issue_vld[i]) ? copros_issue_req[i].id : 0;
+      cvxif_req_copro[i].x_commit.x_commit_kill = '0;
+
+      copros_issue_rdy[i] = cvxif_resp_copro[i].x_issue_ready;
+
+      copros_result[i] = cvxif_resp_copro[i].x_result;
+      copros_result_vld[i] = cvxif_resp_copro[i].x_result_valid;
+    end
+  end
+
+
+  // round robin arbiter, comming from PULP platform
+  rr_arb_tree #(
+      .NumIn    (COPRO_NBR),
+      .DataType (x_result_t),
+      .AxiVldRdy(1'b1)
+  ) arbiter (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .flush_i(1'b0),
+      .rr_i(2'b00),
+      .req_i(copros_result_vld),  // result valid from coprocessors
+      .gnt_o(copros_result_rdy),  // result ready for coprocressors
+      .data_i(copros_result),  // result from coprocessors
+      .req_o(cvxif_resp_o.x_result_valid),  // result valid for CV-X-IF
+      .gnt_i(cvxif_req_i.x_result_ready),  // result ready from CV-X-IF
+      .data_o(cvxif_resp_o.x_result),  // x_result for CV-X-IF
+      .idx_o() // could be useful if commit handling is changed by using a scoreboard instead of sfifo + filter after decoder, it give the index of the input that is sending it result
+  );
+
+  assign issue_rdy_cmp = '1;
+
+  // not supported in CVA6 :
+  assign cvxif_resp_o.x_mem_valid = '0;
+  assign cvxif_resp_o.x_mem_req = '0;
+  assign cvxif_resp_o.x_compressed_ready = '0;
+  assign cvxif_resp_o.x_compressed_resp = '0;
+  assign cvxif_resp_o.x_issue_ready = ~sfifo_full & (copros_issue_rdy == issue_rdy_cmp);
+  // cvxif_resp result handled by the arbiter
+  // cvxif_resp issue handled by the decoder
+
+endmodule : cvxif_coprocessor_wrapper

--- a/core/rb_cva6_copro_wrapper/rtl_v/fifo_v3.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/fifo_v3.sv
@@ -1,0 +1,192 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+module fifo_v3 #(
+    parameter bit          FALL_THROUGH = 1'b0, // fifo is in fall-through mode
+    parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
+    parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
+    parameter type dtype                = logic [DATA_WIDTH-1:0],
+    parameter bit          FPGA_EN      = 1'b0,
+    // DO NOT OVERWRITE THIS PARAMETER
+    parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
+)(
+    input  logic  clk_i,            // Clock
+    input  logic  rst_ni,           // Asynchronous reset active low
+    input  logic  flush_i,          // flush the queue
+    input  logic  testmode_i,       // test_mode to bypass clock gating
+    // status flags
+    output logic  full_o,           // queue is full
+    output logic  empty_o,          // queue is empty
+    output logic  [ADDR_DEPTH-1:0] usage_o,     // fill pointer
+    // as long as the queue is not full we can push new data
+    input  dtype  data_i,           // data to push into the queue
+    input  logic  push_i,           // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    output dtype  data_o,           // output data
+    input  logic  pop_i             // pop head from queue
+);
+    // local parameter
+    // FIFO depth - handle the case of pass-through, synthesizer will do constant propagation
+    localparam int unsigned FifoDepth = (DEPTH > 0) ? DEPTH : 1;
+    // clock gating control
+    logic gate_clock;
+    // pointer to the read and write section of the queue
+    logic [ADDR_DEPTH - 1:0] read_pointer_n, read_pointer_q, write_pointer_n, write_pointer_q;
+    // keep a counter to keep track of the current queue status
+    // this integer will be truncated by the synthesis tool
+    logic [ADDR_DEPTH:0] status_cnt_n, status_cnt_q;
+    // actual memory
+    dtype [FifoDepth - 1:0] mem_n, mem_q;
+
+    // fifo ram signals for fpga target
+    logic   fifo_ram_we;
+    logic   [ADDR_DEPTH-1:0] fifo_ram_read_address;
+    logic   [ADDR_DEPTH-1:0] fifo_ram_write_address;
+    logic   [$bits(dtype)-1:0] fifo_ram_wdata;
+    logic   [$bits(dtype)-1:0] fifo_ram_rdata;
+
+    assign usage_o = status_cnt_q[ADDR_DEPTH-1:0];
+
+    if (DEPTH == 0) begin : gen_pass_through
+        assign empty_o     = ~push_i;
+        assign full_o      = ~pop_i;
+    end else begin : gen_fifo
+        assign full_o       = (status_cnt_q == FifoDepth[ADDR_DEPTH:0]);
+        assign empty_o      = (status_cnt_q == 0) & ~(FALL_THROUGH & push_i);
+    end
+    // status flags
+
+    // read and write queue logic
+    always_comb begin : read_write_comb
+        // default assignment
+        read_pointer_n  = read_pointer_q;
+        write_pointer_n = write_pointer_q;
+        status_cnt_n    = status_cnt_q;
+        if (FPGA_EN) begin
+             fifo_ram_we             = '0;
+             fifo_ram_read_address   = read_pointer_q;
+             fifo_ram_write_address  = '0;
+             fifo_ram_wdata          = '0;
+             data_o = (DEPTH == 0) ? data_i : fifo_ram_rdata;
+        end else begin
+            data_o          = (DEPTH == 0) ? data_i : mem_q[read_pointer_q];
+            mem_n           = mem_q;
+            gate_clock      = 1'b1;
+        end
+
+        // push a new element to the queue
+        if (push_i && ~full_o) begin
+            if (FPGA_EN) begin
+                fifo_ram_we = 1'b1;
+                fifo_ram_write_address = write_pointer_q;
+                fifo_ram_wdata = data_i;
+            end else begin
+                // push the data onto the queue
+                mem_n[write_pointer_q] = data_i;
+                // un-gate the clock, we want to write something
+                gate_clock = 1'b0;
+            end
+            
+            // increment the write counter
+            if (write_pointer_q == FifoDepth[ADDR_DEPTH-1:0] - 1)
+                write_pointer_n = '0;
+            else
+                write_pointer_n = write_pointer_q + 1;
+            // increment the overall counter
+            status_cnt_n    = status_cnt_q + 1;
+        end
+
+        if (pop_i && ~empty_o) begin
+            // read from the queue is a default assignment
+            // but increment the read pointer...
+            if (read_pointer_n == FifoDepth[ADDR_DEPTH-1:0] - 1)
+                read_pointer_n = '0;
+            else
+                read_pointer_n = read_pointer_q + 1;
+            // ... and decrement the overall count
+            status_cnt_n   = status_cnt_q - 1;
+        end
+
+        // keep the count pointer stable if we push and pop at the same time
+        if (push_i && pop_i &&  ~full_o && ~empty_o)
+            status_cnt_n   = status_cnt_q;
+
+        // FIFO is in pass through mode -> do not change the pointers
+        if (FALL_THROUGH && (status_cnt_q == 0) && push_i) begin
+            data_o = data_i;
+            if (pop_i) begin
+                status_cnt_n = status_cnt_q;
+                read_pointer_n = read_pointer_q;
+                write_pointer_n = write_pointer_q;
+            end
+        end
+    end
+
+    // sequential process
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(~rst_ni) begin
+            read_pointer_q  <= '0;
+            write_pointer_q <= '0;
+            status_cnt_q    <= '0;
+        end else begin
+            if (flush_i) begin
+                read_pointer_q  <= '0;
+                write_pointer_q <= '0;
+                status_cnt_q    <= '0;
+             end else begin
+                read_pointer_q  <= read_pointer_n;
+                write_pointer_q <= write_pointer_n;
+                status_cnt_q    <= status_cnt_n;
+            end
+        end
+    end
+
+    if (FPGA_EN) begin : gen_fpga_queue
+        AsyncDpRam #(
+            .ADDR_WIDTH (ADDR_DEPTH),
+            .DATA_DEPTH (DEPTH),
+            .DATA_WIDTH ($bits(dtype))
+        ) fifo_ram (
+            .Clk_CI      ( clk_i                   ),  
+            .WrEn_SI     ( fifo_ram_we             ),
+            .RdAddr_DI   ( fifo_ram_read_address   ),
+            .WrAddr_DI   ( fifo_ram_write_address  ),
+            .WrData_DI   ( fifo_ram_wdata          ),
+            .RdData_DO   ( fifo_ram_rdata          )
+        );
+    end else begin : gen_asic_queue
+        always_ff @(posedge clk_i or negedge rst_ni) begin
+            if(~rst_ni) begin
+                mem_q <= '0;
+            end else if (!gate_clock) begin
+                mem_q <= mem_n;
+            end
+        end
+    end
+
+// pragma translate_off
+`ifndef VERILATOR
+    initial begin
+        assert (DEPTH > 0)             else $error("DEPTH must be greater than 0.");
+    end
+
+    full_write : assert property(
+        @(posedge clk_i) disable iff (~rst_ni) (full_o |-> ~push_i))
+        else $fatal (1, "Trying to push new data although the FIFO is full.");
+
+    empty_read : assert property(
+        @(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
+        else $fatal (1, "Trying to pop data although the FIFO is empty.");
+`endif
+// pragma translate_on
+
+endmodule // fifo_v3

--- a/core/rb_cva6_copro_wrapper/rtl_v/include/cvxif_wrapper_pkg.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/include/cvxif_wrapper_pkg.sv
@@ -1,0 +1,43 @@
+
+package cvxif_wrapper_pkg;
+
+  localparam int unsigned COPRO_NBR = 2;  //number of coprocessor
+  localparam int unsigned COPRO_BITS_NBR = $clog2(
+      COPRO_NBR
+  );  //minimal number of bits for the number of coprocessor
+  localparam int unsigned SAME_COPRO_NBR  = 0; // number of identical or same coprocessor, 0 or [2:COPRO_NBR]
+  localparam int unsigned SCT_SIZE  = (SAME_COPRO_NBR == 0) ? 0 : SAME_COPRO_NBR-1; //
+
+  localparam logic [COPRO_BITS_NBR:0] SAME_COPRO_TABLE[0:SCT_SIZE] = {'0};  // table containing index of the same coprocessor, not needed to parametrize if not using coprocessor
+
+  localparam int unsigned DECODING_TYPE = 1;
+  // 0 : using only opcode, by default if wrong value for DECODING_TYPE
+  // 1 : using opcode and func2
+  // 2 : using opcode and func3
+  // 3 : using opcode, func3 and func2
+
+  localparam int unsigned deco_LUT_size =   (DECODING_TYPE == 0) ? 2**2
+                                          :  ((DECODING_TYPE == 1) ? 2**4
+                                          :  ((DECODING_TYPE == 2) ? 2**5
+                                          :  ((DECODING_TYPE == 3) ? 2**7 : 2**2)));
+
+  // INDEX : It is the position where you have implemented your coprocessor.
+
+  // Decoding look-up table : 
+  // This LUT will be used by the decoder to give a index for an instruction, to fill this table do the following :
+  // they are 8 position by opcode, because it also use func3, so first position (decoding_lookup_table[0][00000]) is for custom0 and func3 = 000, second for custom0 and func3 = 001
+  // and it goes on until custom3 and func3 = 111
+  // So if a coprocessor can process an instruction put it index in the corresponding position
+  // if an instruction is not supoported by any coprocessor, put COPRO_NBR (or numerical value) in it.
+  // if an instruction is supported by same coprocessors, put SAME_COPRO_TABLE[0] (or the numerical value) in it
+  // custom0  |  custom1  |  custom2  |  custom3  
+  localparam logic [COPRO_BITS_NBR:0] decoding_LUT[0:deco_LUT_size-1] = {
+    1, 2, 2, 2, 2, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2
+  };
+
+  // Lookup table to handle issue_resp
+  //This LUT use coprocessor index to know which value will be used
+  //                                                 { copro2  ,  copro1  }
+  localparam logic [5:0] i_resp_LUT[COPRO_NBR-1:0] = {6'b110000, 6'b110000};
+
+endpackage

--- a/core/rb_cva6_copro_wrapper/rtl_v/lzc.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/lzc.sv
@@ -1,0 +1,114 @@
+// Copyright (c) 2018 - 2019 ETH Zurich, University of Bologna
+// All rights reserved.
+//
+// This code is under development and not yet released to the public.
+// Until it is released, the code is under the copyright of ETH Zurich and
+// the University of Bologna, and may contain confidential and/or unpublished
+// work. Any reuse/redistribution is strictly forbidden without written
+// permission from ETH Zurich.
+//
+// Bug fixes and contributions will eventually be released under the
+// SolderPad open hardware license in the context of the PULP platform
+// (http://www.pulp-platform.org), under the copyright of ETH Zurich and the
+// University of Bologna.
+
+/// A trailing zero counter / leading zero counter.
+/// Set MODE to 0 for trailing zero counter => cnt_o is the number of trailing zeros (from the LSB)
+/// Set MODE to 1 for leading zero counter  => cnt_o is the number of leading zeros  (from the MSB)
+/// If the input does not contain a zero, `empty_o` is asserted. Additionally `cnt_o` contains
+/// the maximum number of zeros - 1. For example:
+///   in_i = 000_0000, empty_o = 1, cnt_o = 6 (mode = 0)
+///   in_i = 000_0001, empty_o = 0, cnt_o = 0 (mode = 0)
+///   in_i = 000_1000, empty_o = 0, cnt_o = 3 (mode = 0)
+/// Furthermore, this unit contains a more efficient implementation for Verilator (simulation only).
+/// This speeds up simulation significantly.
+module lzc 
+  import cf_math_pkg::*;
+#(
+  /// The width of the input vector.
+  parameter int unsigned WIDTH = 2,
+  /// Mode selection: 0 -> trailing zero, 1 -> leading zero
+  parameter bit          MODE  = 1'b0,
+  /// Dependent parameter. Do **not** change!
+  ///
+  /// Width of the output signal with the zero count.
+  parameter int unsigned CNT_WIDTH = cf_math_pkg::idx_width(WIDTH)
+) (
+  /// Input vector to be counted.
+  input  logic [WIDTH-1:0]     in_i,
+  /// Count of the leading / trailing zeros.
+  output logic [CNT_WIDTH-1:0] cnt_o,
+  /// Counter is empty: Asserted if all bits in in_i are zero.
+  output logic                 empty_o
+);
+
+  if (WIDTH == 1) begin : gen_degenerate_lzc
+
+    assign cnt_o[0] = !in_i[0];
+    assign empty_o = !in_i[0];
+
+  end else begin : gen_lzc
+
+    localparam int unsigned NumLevels = $clog2(WIDTH);
+
+    // pragma translate_off
+    initial begin
+      assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
+    end
+    // pragma translate_on
+
+    logic [WIDTH-1:0][NumLevels-1:0] index_lut;
+    logic [2**NumLevels-1:0] sel_nodes;
+    logic [2**NumLevels-1:0][NumLevels-1:0] index_nodes;
+
+    logic [WIDTH-1:0] in_tmp;
+
+    // reverse vector if required
+    always_comb begin : flip_vector
+      for (int unsigned i = 0; i < WIDTH; i++) begin
+        in_tmp[i] = (MODE) ? in_i[WIDTH-1-i] : in_i[i];
+      end
+    end
+
+    for (genvar j = 0; unsigned'(j) < WIDTH; j++) begin : g_index_lut
+      assign index_lut[j] = (NumLevels)'(unsigned'(j));
+    end
+
+    for (genvar level = 0; unsigned'(level) < NumLevels; level++) begin : g_levels
+      if (unsigned'(level) == NumLevels - 1) begin : g_last_level
+        for (genvar k = 0; k < 2 ** level; k++) begin : g_level
+          // if two successive indices are still in the vector...
+          if (unsigned'(k) * 2 < WIDTH - 1) begin : g_reduce
+            assign sel_nodes[2 ** level - 1 + k] = in_tmp[k * 2] | in_tmp[k * 2 + 1];
+            assign index_nodes[2 ** level - 1 + k] = (in_tmp[k * 2] == 1'b1)
+              ? index_lut[k * 2] :
+                index_lut[k * 2 + 1];
+          end
+          // if only the first index is still in the vector...
+          if (unsigned'(k) * 2 == WIDTH - 1) begin : g_base
+            assign sel_nodes[2 ** level - 1 + k] = in_tmp[k * 2];
+            assign index_nodes[2 ** level - 1 + k] = index_lut[k * 2];
+          end
+          // if index is out of range
+          if (unsigned'(k) * 2 > WIDTH - 1) begin : g_out_of_range
+            assign sel_nodes[2 ** level - 1 + k] = 1'b0;
+            assign index_nodes[2 ** level - 1 + k] = '0;
+          end
+        end
+      end else begin : g_not_last_level
+        for (genvar l = 0; l < 2 ** level; l++) begin : g_level
+          assign sel_nodes[2 ** level - 1 + l] =
+              sel_nodes[2 ** (level + 1) - 1 + l * 2] | sel_nodes[2 ** (level + 1) - 1 + l * 2 + 1];
+          assign index_nodes[2 ** level - 1 + l] = (sel_nodes[2 ** (level + 1) - 1 + l * 2] == 1'b1)
+            ? index_nodes[2 ** (level + 1) - 1 + l * 2] :
+              index_nodes[2 ** (level + 1) - 1 + l * 2 + 1];
+        end
+      end
+    end
+
+    assign cnt_o = NumLevels > unsigned'(0) ? index_nodes[0] : {($clog2(WIDTH)) {1'b0}};
+    assign empty_o = NumLevels > unsigned'(0) ? ~sel_nodes[0] : ~(|in_i);
+
+  end : gen_lzc
+
+endmodule : lzc

--- a/core/rb_cva6_copro_wrapper/rtl_v/rb_cvxif_coprocessor_wrapper.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/rb_cvxif_coprocessor_wrapper.sv
@@ -1,0 +1,170 @@
+// Original Author: Maxime TRAVAILLARD (fixed-term.maxime.travaillard@fr.bosch.com)
+
+// Top level of the coprocessor wrapper
+
+module rb_cvxif_coprocessor_wrapper
+  import cvxif_pkg::*;
+(
+    input logic clk_i,  // Clock
+    input logic rst_ni, // Asynchronous reset active low
+
+    // CVXIF_REQ signals
+    // compressed
+    input logic                                    x_compressed_valid_i,
+    input logic [           15:0]                  x_compressed_instr_i,
+    input logic [            1:0]                  x_compressed_mode_i,
+    input logic [ X_ID_WIDTH-1:0]                  x_compressed_id_i,
+    // issue
+    input logic                                    x_issue_valid_i,
+    input logic [           31:0]                  x_issue_instr_i,
+    input logic [            1:0]                  x_issue_mode_i,
+    input logic [ X_ID_WIDTH-1:0]                  x_issue_id_i,
+    input logic [   X_NUM_RS-1:0][X_RFR_WIDTH-1:0] x_issue_rs_i,
+    input logic [   X_NUM_RS-1:0]                  x_issue_rs_valid_i,
+    // commit
+    input logic                                    x_commit_valid_i,
+    input logic [ X_ID_WIDTH-1:0]                  x_commit_id_i,
+    input logic                                    x_commit_kill_i,
+    // memory
+    input logic                                    x_mem_ready_i,
+    input logic                                    x_mem_exc_i,
+    input logic [            5:0]                  x_mem_exccode_i,
+    input logic                                    x_mem_result_valid_i,
+    input logic [ X_ID_WIDTH-1:0]                  x_mem_id_i,
+    input logic [X_MEM_WIDTH-1:0]                  x_mem_rdata_i,
+    input logic                                    x_mem_err_i,
+    //result
+    input logic                                    x_result_ready,
+
+
+    // CVXIF_RESP signals
+    // compressed
+    output logic                   x_compressed_ready_o,
+    output logic [           31:0] x_compressed_instr_o,
+    output logic                   x_compressed_accept_o,
+    // issue
+    output logic                   x_issue_ready_o,
+    output logic                   x_issue_accept_o,
+    output logic                   x_issue_writeback_o,
+    output logic                   x_issue_dualwrite_o,
+    output logic                   x_issue_dualread_o,
+    output logic                   x_issue_loadstore_o,
+    output logic                   x_issue_exc_o,
+    // memory
+    output logic                   x_mem_valid_o,
+    output logic [ X_ID_WIDTH-1:0] x_mem_id_o,
+    output logic [           31:0] x_mem_addr_o,
+    output logic [            1:0] x_mem_mode_o,
+    output logic                   x_mem_we_o,
+    output logic [            1:0] x_mem_size_o,
+    output logic [X_MEM_WIDTH-1:0] x_mem_wdata_o,
+    output logic                   x_mem_last_o,
+    output logic                   x_mem_spec_o,
+    // result 
+    output logic                   x_result_valid_o,
+    output logic [ X_ID_WIDTH-1:0] x_result_id_o,
+    output logic [X_RFW_WIDTH-1:0] x_result_data_o,
+    output logic [            4:0] x_result_rd_o,
+    output logic                   x_result_we_o,
+    output logic                   x_result_exc_o,
+    output logic [            5:0] x_result_exccode_o
+);
+
+  cvxif_pkg::cvxif_req_t cvxif_req_i;
+  cvxif_pkg::cvxif_resp_t cvxif_resp_o;
+  cvxif_pkg::cvxif_req_t [cvxif_wrapper_pkg::COPRO_NBR-1:0] cvxif_req_copro;
+
+  // ---------------------
+  // CVXIF_REQ assignment
+  // ---------------------
+  // compressed
+  assign cvxif_req_i.x_compressed_valid = x_compressed_valid_i;
+  assign cvxif_req_i.x_compressed_req.instr = x_compressed_instr_i;
+  assign cvxif_req_i.x_compressed_req.mode = x_compressed_mode_i;
+  assign cvxif_req_i.x_compressed_req.id = x_compressed_id_i;
+  // issue
+  assign cvxif_req_i.x_issue_valid = x_issue_valid_i;
+  assign cvxif_req_i.x_issue_req.instr = x_issue_instr_i;
+  assign cvxif_req_i.x_issue_req.mode = x_issue_mode_i;
+  assign cvxif_req_i.x_issue_req.id = x_issue_id_i;
+  assign cvxif_req_i.x_issue_req.rs = x_issue_rs_i;
+  assign cvxif_req_i.x_issue_req.rs_valid = x_issue_rs_valid_i;
+  // commit
+  assign cvxif_req_i.x_commit_valid = x_commit_valid_i;
+  assign cvxif_req_i.x_commit.id = x_commit_id_i;
+  assign cvxif_req_i.x_commit.x_commit_kill = x_commit_kill_i;
+  // memory
+  assign cvxif_req_i.x_mem_ready = x_mem_ready_i;
+  assign cvxif_req_i.x_mem_resp.exc = x_mem_exc_i;
+  assign cvxif_req_i.x_mem_resp.exccode = x_mem_exccode_i;
+  assign cvxif_req_i.x_mem_result_valid = x_mem_result_valid_i;
+  assign cvxif_req_i.x_mem_result.id = x_mem_id_i;
+  assign cvxif_req_i.x_mem_result.rdata = x_mem_rdata_i;
+  assign cvxif_req_i.x_mem_result.err = x_mem_err_i;
+  // result
+  assign cvxif_req_i.x_result_ready = x_result_ready;
+
+  // ---------------------
+  // CVXIF_RESP assignment
+  // ---------------------
+  // compressed
+  assign x_compressed_ready_o = cvxif_resp_o.x_compressed_ready;
+  assign x_compressed_instr_o = cvxif_resp_o.x_compressed_resp.instr;  // useful for filter ?
+  assign x_compressed_accept_o = cvxif_resp_o.x_compressed_resp.accept;
+  // issue
+  assign x_issue_ready_o = cvxif_resp_o.x_issue_ready;
+  assign x_issue_accept_o = cvxif_resp_o.x_issue_resp.accept;
+  assign x_issue_writeback_o = cvxif_resp_o.x_issue_resp.writeback;
+  assign x_issue_dualwrite_o = cvxif_resp_o.x_issue_resp.dualwrite;
+  assign x_issue_dualread_o = cvxif_resp_o.x_issue_resp.dualread;
+  assign x_issue_loadstore_o = cvxif_resp_o.x_issue_resp.loadstore;
+  assign x_issue_exc_o = cvxif_resp_o.x_issue_resp.exc;
+  // memory
+  assign x_mem_valid_o = cvxif_resp_o.x_mem_valid;
+  assign x_mem_id_o = cvxif_resp_o.x_mem_req.id;
+  assign x_mem_addr_o = cvxif_resp_o.x_mem_req.addr;
+  assign x_mem_mode_o = cvxif_resp_o.x_mem_req.mode;
+  assign x_mem_we_o = cvxif_resp_o.x_mem_req.we;
+  assign x_mem_size_o = cvxif_resp_o.x_mem_req.size;
+  assign x_mem_wdata_o = cvxif_resp_o.x_mem_req.wdata;
+  assign x_mem_last_o = cvxif_resp_o.x_mem_req.last;
+  assign x_mem_spec_o = cvxif_resp_o.x_mem_req.spec;
+  // result
+  assign x_result_valid_o = cvxif_resp_o.x_result_valid;
+  assign x_result_id_o = cvxif_resp_o.x_result.id;
+  assign x_result_data_o = cvxif_resp_o.x_result.data;
+  assign x_result_rd_o = cvxif_resp_o.x_result.rd;
+  assign x_result_we_o = cvxif_resp_o.x_result.we;
+  assign x_result_exc_o = cvxif_resp_o.x_result.exc;
+  assign x_result_exccode_o = cvxif_resp_o.x_result.exccode;
+
+  /*
+    // Signals not supported by this implementation
+    assign cvxif_resp_o.x_compressed_ready = '0;
+    assign cvxif_resp_o.x_compressed_resp.instr = '0;
+    assign cvxif_resp_o.x_compressed_resp.accept = '0;
+    assign cvxif_resp_o.x_mem_valid = '0;
+    assign cvxif_resp_o.x_mem_req.id = '0;
+    assign cvxif_resp_o.x_mem_req.addr = '0;
+    assign cvxif_resp_o.x_mem_req.mode = '0;
+    assign cvxif_resp_o.x_mem_req.we = '0;
+    assign cvxif_resp_o.x_mem_req.size = '0;
+    assign cvxif_resp_o.x_mem_req.wdata = '0;
+    assign cvxif_resp_o.x_mem_req.last = '0;
+    assign cvxif_resp_o.x_mem_req.spec = '0;*/
+
+  cvxif_coprocessor_wrapper #(
+      .COPRO_NBR     (cvxif_wrapper_pkg::COPRO_NBR),
+      .SAME_COPRO_NBR(cvxif_wrapper_pkg::SAME_COPRO_NBR),
+      .decoding_LUT  (cvxif_wrapper_pkg::decoding_LUT),
+      .i_resp_LUT    (cvxif_wrapper_pkg::i_resp_LUT)
+  ) copro_wrapper (
+      .clk_i           (clk_i),
+      .rst_ni          (rst_ni),
+      .cvxif_req_i     (cvxif_req_i),
+      .cvxif_req_copro (cvxif_req_copro),
+      .cvxif_resp_copro('0),
+      .cvxif_resp_o    (cvxif_resp_o)
+  );
+
+endmodule : rb_cvxif_coprocessor_wrapper

--- a/core/rb_cva6_copro_wrapper/rtl_v/rr_arb_tree.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/rr_arb_tree.sv
@@ -1,0 +1,355 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+//         Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>, ETH Zurich
+// Date: 02.04.2019
+// Description: logarithmic arbitration tree with round robin arbitration scheme.
+
+/// The rr_arb_tree employs non-starving round robin-arbitration - i.e., the priorities
+/// rotate each cycle.
+///
+/// ## Fair vs. unfair Arbitration
+///
+/// This refers to fair throughput distribution when not all inputs have active requests.
+/// This module has an internal state `rr_q` which defines the highest priority input. (When
+/// `ExtPrio` is `1'b1` this state is provided from the outside.) The arbitration tree will
+/// choose the input with the same index as currently defined by the state if it has an active
+/// request. Otherwise a *random* other active input is selected. The parameter `FairArb` is used
+/// to distinguish between two methods of calculating the next state.
+/// * `1'b0`: The next state is calculated by advancing the current state by one. This leads to the
+///           state being calculated without the context of the active request. Leading to an
+///           unfair throughput distribution if not all inputs have active requests.
+/// * `1'b1`: The next state jumps to the next unserved request with higher index.
+///           This is achieved by using two trailing-zero-counters (`lzc`). The upper has the masked
+///           `req_i` signal with all indices which will have a higher priority in the next state.
+///           The trailing zero count defines the input index with the next highest priority after
+///           the current one is served. When the upper is empty the lower `lzc` provides the
+///           wrapped index if there are outstanding requests with lower or same priority.
+/// The implication of throughput fairness on the module timing are:
+/// * The trailing zero counter (`lzc`) has a loglog relation of input to output timing. This means
+///   that in this module the input to register path scales with Log(Log(`NumIn`)).
+/// * The `rr_arb_tree` data multiplexing scales with Log(`NumIn`). This means that the input to output
+///   timing path of this module also scales scales with Log(`NumIn`).
+/// This implies that in this module the input to output path is always longer than the input to
+/// register path. As the output data usually also terminates in a register the parameter `FairArb`
+/// only has implications on the area. When it is `1'b0` a static plus one adder is instantiated.
+/// If it is `1'b1` two `lzc`, a masking logic stage and a two input multiplexer are instantiated.
+/// However these are small in respect of the data multiplexers needed, as the width of the `req_i`
+/// signal is usually less as than `DataWidth`.
+module rr_arb_tree #(
+  /// Number of inputs to be arbitrated.
+  parameter int unsigned NumIn      = 64,
+  /// Data width of the payload in bits. Not needed if `DataType` is overwritten.
+  parameter int unsigned DataWidth  = 32,
+  /// Data type of the payload, can be overwritten with custom type. Only use of `DataWidth`.
+  parameter type         DataType   = logic [DataWidth-1:0],
+  /// The `ExtPrio` option allows to override the internal round robin counter via the
+  /// `rr_i` signal. This can be useful in case multiple arbiters need to have
+  /// rotating priorities that are operating in lock-step. If static priority arbitration
+  /// is needed, just connect `rr_i` to '0.
+  ///
+  /// Set to 1'b1 to enable.
+  parameter bit          ExtPrio    = 1'b0,
+  /// If `AxiVldRdy` is set, the req/gnt signals are compliant with the AXI style vld/rdy
+  /// handshake. Namely, upstream vld (req) must not depend on rdy (gnt), as it can be deasserted
+  /// again even though vld is asserted. Enabling `AxiVldRdy` leads to a reduction of arbiter
+  /// delay and area.
+  ///
+  /// Set to `1'b1` to treat req/gnt as vld/rdy.
+  parameter bit          AxiVldRdy  = 1'b0,
+  /// The `LockIn` option prevents the arbiter from changing the arbitration
+  /// decision when the arbiter is disabled. I.e., the index of the first request
+  /// that wins the arbitration will be locked in case the destination is not
+  /// able to grant the request in the same cycle.
+  ///
+  /// Set to `1'b1` to enable.
+  parameter bit          LockIn     = 1'b0,
+  /// When set, ensures that throughput gets distributed evenly between all inputs.
+  ///
+  /// Set to `1'b0` to disable.
+  parameter bit          FairArb    = 1'b1,
+  /// Dependent parameter, do **not** overwrite.
+  /// Width of the arbitration priority signal and the arbitrated index.
+  parameter int unsigned IdxWidth   = (NumIn > 32'd1) ? unsigned'($clog2(NumIn)) : 32'd1,
+  /// Dependent parameter, do **not** overwrite.
+  /// Type for defining the arbitration priority and arbitrated index signal.
+  parameter type         idx_t      = logic [IdxWidth-1:0]
+) (
+  /// Clock, positive edge triggered.
+  input  logic                clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                rst_ni,
+  /// Clears the arbiter state. Only used if `ExtPrio` is `1'b0` or `LockIn` is `1'b1`.
+  input  logic                flush_i,
+  /// External round-robin priority. Only used if `ExtPrio` is `1'b1.`
+  input  idx_t                rr_i,
+  /// Input requests arbitration.
+  input  logic    [NumIn-1:0] req_i,
+  /* verilator lint_off UNOPTFLAT */
+  /// Input request is granted.
+  output logic    [NumIn-1:0] gnt_o,
+  /* verilator lint_on UNOPTFLAT */
+  /// Input data for arbitration.
+  input  DataType [NumIn-1:0] data_i,
+  /// Output request is valid.
+  output logic                req_o,
+  /// Output request is granted.
+  input  logic                gnt_i,
+  /// Output data.
+  output DataType             data_o,
+  /// Index from which input the data came from.
+  output idx_t                idx_o
+);
+  
+  // pragma translate_off
+  `ifndef VERILATOR
+  `ifndef XSIM
+  // Default SVA reset
+  default disable iff (!rst_ni || flush_i);
+  `endif
+  `endif
+  // pragma translate_on
+  
+  // just pass through in this corner case
+  if (NumIn == unsigned'(1)) begin : gen_pass_through
+    assign req_o    = req_i[0];
+    assign gnt_o[0] = gnt_i;
+    assign data_o   = data_i[0];
+    assign idx_o    = '0;
+  // non-degenerate cases
+  end else begin : gen_arbiter
+    localparam int unsigned NumLevels = unsigned'($clog2(NumIn));
+
+    /* verilator lint_off UNOPTFLAT */
+    idx_t    [2**NumLevels-2:0] index_nodes; // used to propagate the indices
+    DataType [2**NumLevels-2:0] data_nodes;  // used to propagate the data
+    logic    [2**NumLevels-2:0] gnt_nodes;   // used to propagate the grant to masters
+    logic    [2**NumLevels-2:0] req_nodes;   // used to propagate the requests to slave
+    /* lint_off */
+    idx_t                       rr_q;
+    logic [NumIn-1:0]           req_d;
+
+    // the final arbitration decision can be taken from the root of the tree
+    assign req_o        = req_nodes[0];
+    assign data_o       = data_nodes[0];
+    assign idx_o        = index_nodes[0];
+    
+    if (ExtPrio) begin : gen_ext_rr
+      assign rr_q       = rr_i;
+      assign req_d      = req_i;
+    end else begin : gen_int_rr
+      idx_t rr_d;
+
+      // lock arbiter decision in case we got at least one req and no acknowledge
+      if (LockIn) begin : gen_lock
+        logic  lock_d, lock_q;
+        logic [NumIn-1:0] req_q;
+        
+        assign lock_d     = req_o & ~gnt_i;
+        assign req_d      = (lock_q) ? req_q : req_i;
+        
+        always_ff @(posedge clk_i or negedge rst_ni) begin : p_lock_reg
+          if (!rst_ni) begin
+            lock_q <= '0;
+          end else begin
+            if (flush_i) begin
+              lock_q <= '0;
+            end else begin
+              lock_q <= lock_d;
+            end
+          end
+        end
+
+        /*
+        // pragma translate_off
+        `ifndef VERILATOR
+          lock: assert property(
+            @(posedge clk_i) LockIn |-> req_o &&
+                             (!gnt_i && !flush_i) |=> idx_o == $past(idx_o)) else
+                $fatal (1, "Lock implies same arbiter decision in next cycle if output is not \
+                            ready.");
+
+          logic [NumIn-1:0] req_tmp;
+          assign req_tmp = req_q & req_i;
+          lock_req: assert property(
+            @(posedge clk_i) LockIn |-> lock_d |=> req_tmp == req_q) else
+                $fatal (1, "It is disallowed to deassert unserved request signals when LockIn is \
+                            enabled."); 
+        `endif
+        // pragma translate_on
+        */
+
+
+        always_ff @(posedge clk_i or negedge rst_ni) begin : p_req_regs
+          if (!rst_ni) begin
+            req_q  <= '0;
+          end else begin
+            if (flush_i) begin
+              req_q  <= '0;
+            end else begin
+              req_q  <= req_d;
+            end
+          end
+        end 
+      end else begin : gen_no_lock
+        assign req_d = req_i;
+      end
+
+      if (FairArb) begin : gen_fair_arb
+        logic [NumIn-1:0] upper_mask,  lower_mask;
+        idx_t             upper_idx,   lower_idx,   next_idx;
+        logic             upper_empty, lower_empty;
+
+        for (genvar i = 0; i < NumIn; i++) begin : gen_mask
+          assign upper_mask[i] = (i >  rr_q) ? req_d[i] : 1'b0;
+          assign lower_mask[i] = (i <= rr_q) ? req_d[i] : 1'b0;
+        end
+
+        lzc #(
+          .WIDTH ( NumIn ),
+          .MODE  ( 1'b0  )
+        ) i_lzc_upper (
+          .in_i    ( upper_mask  ),
+          .cnt_o   ( upper_idx   ),
+          .empty_o ( upper_empty )
+        );
+
+        lzc #(
+          .WIDTH ( NumIn ),
+          .MODE  ( 1'b0  )
+        ) i_lzc_lower (
+          .in_i    ( lower_mask  ),
+          .cnt_o   ( lower_idx   ),
+          .empty_o ( /*unused*/  )
+        );
+
+        assign next_idx = upper_empty      ? lower_idx : upper_idx;
+        assign rr_d     = (gnt_i && req_o) ? next_idx  : rr_q;
+
+      end else begin : gen_unfair_arb
+        assign rr_d = (gnt_i && req_o) ? ((rr_q == idx_t'(NumIn-1)) ? '0 : rr_q + 1'b1) : rr_q;
+      end
+
+      // this holds the highest priority
+      always_ff @(posedge clk_i or negedge rst_ni) begin : p_rr_regs
+        if (!rst_ni) begin
+          rr_q   <= '0;
+        end else begin
+          if (flush_i) begin
+            rr_q   <= '0;
+          end else begin
+            rr_q   <= rr_d;
+          end
+        end
+      end
+    end
+    
+    assign gnt_nodes[0] = gnt_i;
+
+    // arbiter tree
+    for (genvar level = 0; unsigned'(level) < NumLevels; level++) begin : gen_levels
+      for (genvar l = 0; l < 2**level; l++) begin : gen_level
+        // local select signal
+        logic sel;
+        // index calcs
+        localparam int unsigned Idx0 = 2**level-1+l;// current node
+        localparam int unsigned Idx1 = 2**(level+1)-1+l*2;
+        //////////////////////////////////////////////////////////////
+        // uppermost level where data is fed in from the inputs
+        if (unsigned'(level) == NumLevels-1) begin : gen_first_level
+          // if two successive indices are still in the vector...
+          if (unsigned'(l) * 2 < NumIn-1) begin : gen_reduce
+            assign req_nodes[Idx0]   = req_d[l*2] | req_d[l*2+1];
+
+            // arbitration: round robin
+            assign sel =  ~req_d[l*2] | req_d[l*2+1] & rr_q[NumLevels-1-level];
+
+            assign index_nodes[Idx0] = idx_t'(sel);
+            assign data_nodes[Idx0]  = (sel) ? data_i[l*2+1] : data_i[l*2];
+            assign gnt_o[l*2]        = gnt_nodes[Idx0] & (AxiVldRdy | req_d[l*2])   & ~sel;
+            assign gnt_o[l*2+1]      = gnt_nodes[Idx0] & (AxiVldRdy | req_d[l*2+1]) & sel;
+          end
+          // if only the first index is still in the vector...
+          if (unsigned'(l) * 2 == NumIn-1) begin : gen_first
+            assign req_nodes[Idx0]   = req_d[l*2];
+            assign index_nodes[Idx0] = '0;// always zero in this case
+            assign data_nodes[Idx0]  = data_i[l*2];
+            assign gnt_o[l*2]        = gnt_nodes[Idx0] & (AxiVldRdy | req_d[l*2]);
+          end
+          // if index is out of range, fill up with zeros (will get pruned)
+          if (unsigned'(l) * 2 > NumIn-1) begin : gen_out_of_range
+            assign req_nodes[Idx0]   = 1'b0;
+            assign index_nodes[Idx0] = idx_t'('0);
+            assign data_nodes[Idx0]  = DataType'('0);
+          end
+        //////////////////////////////////////////////////////////////
+        // general case for other levels within the tree
+        end else begin : gen_other_levels
+          assign req_nodes[Idx0]   = req_nodes[Idx1] | req_nodes[Idx1+1];
+
+          // arbitration: round robin
+          assign sel =  ~req_nodes[Idx1] | req_nodes[Idx1+1] & rr_q[NumLevels-1-level];
+
+          assign index_nodes[Idx0] = (sel) ?
+            idx_t'({1'b1, index_nodes[Idx1+1][NumLevels-unsigned'(level)-2:0]}) :
+            idx_t'({1'b0, index_nodes[Idx1][NumLevels-unsigned'(level)-2:0]});
+
+          assign data_nodes[Idx0]  = (sel) ? data_nodes[Idx1+1] : data_nodes[Idx1];
+          assign gnt_nodes[Idx1]   = gnt_nodes[Idx0] & ~sel;
+          assign gnt_nodes[Idx1+1] = gnt_nodes[Idx0] & sel;
+        end
+        //////////////////////////////////////////////////////////////
+      end
+    end
+
+   
+    // pragma translate_off
+    /*
+
+    `ifndef VERILATOR
+    `ifndef XSIM
+    initial begin : p_assert
+      assert(NumIn)
+        else $fatal(1, "Input must be at least one element wide.");
+      assert(!(LockIn && ExtPrio))
+        else $fatal(1,"Cannot use LockIn feature together with external ExtPrio.");
+    end
+
+    hot_one : assert property(
+      @(posedge clk_i) $onehot0(gnt_o))
+        else $fatal (1, "Grant signal must be hot1 or zero.");
+
+    gnt0 : assert property(
+      @(posedge clk_i) |gnt_o |-> gnt_i)
+        else $fatal (1, "Grant out implies grant in.");
+
+    gnt1 : assert property(
+      @(posedge clk_i) req_o |-> gnt_i |-> |gnt_o)
+        else $fatal (1, "Req out and grant in implies grant out.");
+
+    gnt_idx : assert property(
+      @(posedge clk_i) req_o |->  gnt_i |-> gnt_o[idx_o])
+        else $fatal (1, "Idx_o / gnt_o do not match.");
+
+    req0 : assert property(
+      @(posedge clk_i) |req_i |-> req_o)
+        else $fatal (1, "Req in implies req out.");
+
+    //req1 : assert property(
+    //  @(posedge clk_i) req_o |-> |req_i)
+    //    else $fatal (1, "Req out implies req in.");
+    `endif
+    `endif
+    // pragma translate_on
+    */
+  end
+
+endmodule : rr_arb_tree

--- a/core/rb_cva6_copro_wrapper/rtl_v/wrapper_commit_filter.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/wrapper_commit_filter.sv
@@ -1,0 +1,113 @@
+// Original Author: Maxime TRAVAILLARD (fixed-term.maxime.travaillard@fr.bosch.com)
+
+// Module to handle commit_kill and dispatch non-speculative instruction to their corresponding coprocessor
+
+module wrapper_commit_filter
+  import cvxif_pkg::*;
+#(
+    parameter COPRO_NBR = cvxif_wrapper_pkg::COPRO_NBR,
+    parameter COPRO_BITS_NBR = $clog2(COPRO_NBR)
+) (
+    input logic clk_i,  // Clock
+    input logic rst_ni,  // Asynchronous reset active low
+    input x_issue_req_t issue_req_i,
+    input logic [COPRO_BITS_NBR-1:0] coprocessor_index_i,
+    input logic commit_valid_i,
+    input x_commit_t commit_i,
+    input logic fifo_empty_i,
+    output logic                         pop_o,       // To unqueue an instruction that is sent to a coprocessor or need to be killed
+    output x_issue_req_t [COPRO_NBR-1:0] issue_req_o, // array, each column of the array correspond to a issue_req, indexed by his copro_index to go to the corresponding coprocessor
+    output logic [COPRO_NBR-1:0]         issue_valid_o // array, each column of the array correspond to a issue_valid, indexed by his copro_index to go to the corresponding coprocessor
+);
+
+  // youngest id that need to be executed
+  logic [cvxif_pkg::X_ID_WIDTH-1:0] id_searched_q, id_searched_d;
+
+  // state definition
+  typedef enum {
+    Init,
+    InstrToDo,
+    InstrToBeKilled,
+    InstrToKill
+  } commit_filter_state_e;
+
+  commit_filter_state_e commit_filter_state_d, commit_filter_state_q;
+
+  // Combinational of the state
+  always_comb begin
+    commit_filter_state_d = commit_filter_state_q;
+    id_searched_d = id_searched_q;
+    pop_o = '0;
+    issue_req_o = '0;
+    issue_valid_o = 'b0;
+    case (commit_filter_state_q)
+      Init: begin
+        id_searched_d = 0;
+        if (commit_valid_i) begin
+          id_searched_d = commit_i.id;
+          if (!commit_i.x_commit_kill) begin
+            if (issue_req_i.id == id_searched_d) begin
+              issue_req_o[coprocessor_index_i] = (~fifo_empty_i) ? issue_req_i : '0;
+              issue_valid_o[coprocessor_index_i] = ~fifo_empty_i;
+              pop_o = ~fifo_empty_i;
+              commit_filter_state_d = Init;
+            end else begin
+              issue_req_o[coprocessor_index_i] = (~fifo_empty_i) ? issue_req_i : '0;
+              issue_valid_o[coprocessor_index_i] = ~fifo_empty_i;
+              pop_o = ~fifo_empty_i;
+              commit_filter_state_d = InstrToDo;
+            end
+          end else begin
+            commit_filter_state_d = InstrToBeKilled;
+          end
+        end
+      end
+
+      InstrToDo: begin
+        issue_req_o[coprocessor_index_i] = (~fifo_empty_i) ? issue_req_i : '0;
+        issue_valid_o[coprocessor_index_i] = ~fifo_empty_i;
+        pop_o = ~fifo_empty_i;
+        if (issue_req_i.id == id_searched_d) begin
+          commit_filter_state_d = Init;
+        end
+        if (commit_valid_i) begin
+          id_searched_d = commit_i.id;
+          commit_filter_state_d = (commit_i.x_commit_kill) ? InstrToBeKilled : InstrToDo;
+        end
+      end
+
+      InstrToBeKilled: begin
+        if (commit_valid_i) begin
+          id_searched_d = commit_i.id;
+          commit_filter_state_d = InstrToKill;
+        end
+      end
+
+      InstrToKill: begin
+        pop_o = ~fifo_empty_i;
+        if (issue_req_i.id == id_searched_d) begin
+          issue_req_o[coprocessor_index_i] = (~fifo_empty_i) ? issue_req_i : '0;
+          issue_valid_o[coprocessor_index_i] = ~fifo_empty_i;
+          commit_filter_state_d = Init;
+        end
+      end
+
+      default: begin
+        commit_filter_state_d = Init;
+      end
+    endcase
+
+  end
+
+  // state register
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (!rst_ni | fifo_empty_i) begin
+      commit_filter_state_q <= Init;
+      id_searched_q <= 0;
+    end else begin
+      commit_filter_state_q <= commit_filter_state_d;
+      id_searched_q <= id_searched_d;
+    end
+  end
+
+endmodule

--- a/core/rb_cva6_copro_wrapper/rtl_v/wrapper_decoder.sv
+++ b/core/rb_cva6_copro_wrapper/rtl_v/wrapper_decoder.sv
@@ -1,0 +1,92 @@
+// Original Author: Maxime TRAVAILLARD (fixed-term.maxime.travaillard@fr.bosch.com)
+
+// Decoder to handle issue response and give coprocessor index for each instruction
+// If the instruction is not for 
+
+module wrapper_decoder
+  import cvxif_pkg::*;
+#(
+    parameter COPRO_NBR = cvxif_wrapper_pkg::COPRO_NBR,
+    parameter COPRO_BITS_NBR = $clog2(COPRO_NBR),
+    parameter SAME_COPRO_NBR = cvxif_wrapper_pkg::SAME_COPRO_NBR,
+    parameter SCT_SIZE = (SAME_COPRO_NBR == 0) ? 0 : SAME_COPRO_NBR-1,
+    parameter logic [COPRO_BITS_NBR:0] SAME_COPRO_TABLE[0:SCT_SIZE] = cvxif_wrapper_pkg::SAME_COPRO_TABLE,
+    parameter int unsigned DECODING_TYPE = cvxif_wrapper_pkg::DECODING_TYPE,
+    parameter int unsigned deco_LUT_size =   (DECODING_TYPE == 0) ? 2**2 : ((DECODING_TYPE == 1) ? 2**4 : ((DECODING_TYPE == 2) ? 2**5 : ((DECODING_TYPE == 3) ? 2**7 : 2**2))),
+    parameter logic [COPRO_BITS_NBR:0] decoding_LUT [0:deco_LUT_size-1] = cvxif_wrapper_pkg::decoding_LUT,
+    parameter logic [5:0] i_resp_LUT[COPRO_NBR-1:0] = cvxif_wrapper_pkg::i_resp_LUT
+) (
+    input logic clk_i,  // Clock
+    input logic rst_ni,  // Asynchronous reset active low
+    input x_issue_req_t issue_req_i,
+    input logic issue_valid_i,
+    input logic fifo_full_i,
+    output x_issue_req_t issue_req_o,
+    output x_issue_resp_t issue_resp_o,
+    output logic [COPRO_BITS_NBR-1:0] coprocessor_index_o,
+    output logic push_sfifo_o
+);
+
+  logic [COPRO_BITS_NBR:0] decoding_LUT_q[0:deco_LUT_size-1];
+  int same_copro_current_index;
+  logic to_do_instr;  // this signal handle when a given instr is not supported by any coprocessor
+
+  always_comb begin
+    // getting the index of the corresponding coprocessor
+    if (issue_valid_i & ~fifo_full_i) begin
+      //checking if it is a supported instruction (veryfing if it is a custom opcode and in the LUT as the LUT do not cover cover the full opcode size to make it easier to fill)
+      case (DECODING_TYPE)
+        1: begin
+          to_do_instr = ((COPRO_NBR-1 >= decoding_LUT_q[{issue_req_i.instr[6:5],issue_req_i.instr[26:25]}]) && ((issue_req_i.instr[6:0] == riscv::OpcodeCustom0) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom1) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom2) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom3)));
+          coprocessor_index_o = to_do_instr ? decoding_LUT_q[{issue_req_i.instr[6:5],issue_req_i.instr[26:25]}] : 0; // sending the copro index
+        end
+
+        2: begin
+          to_do_instr = ((COPRO_NBR-1 >= decoding_LUT_q[{issue_req_i.instr[6:5],issue_req_i.instr[14:12]}]) && ((issue_req_i.instr[6:0] == riscv::OpcodeCustom0) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom1) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom2) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom3)));
+          coprocessor_index_o = to_do_instr ? decoding_LUT_q[{issue_req_i.instr[6:5],issue_req_i.instr[14:12]}] : 0; // sending the copro index
+        end
+
+        3: begin
+          to_do_instr = ((COPRO_NBR-1 >= decoding_LUT_q[{issue_req_i.instr[6:5],issue_req_i.instr[26:25]}]) && ((issue_req_i.instr[6:0] == riscv::OpcodeCustom0) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom1) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom2) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom3)));
+          coprocessor_index_o = to_do_instr ? decoding_LUT_q[{issue_req_i.instr[6:5],issue_req_i.instr[14:12],issue_req_i.instr[26:25]}] : 0; // sending the copro index
+        end
+
+        default: begin
+          to_do_instr = ((COPRO_NBR-1 >= decoding_LUT_q[issue_req_i.instr[6:5]]) && ((issue_req_i.instr[6:0] == riscv::OpcodeCustom0) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom1) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom2) || (issue_req_i.instr[6:0] == riscv::OpcodeCustom3)));
+          coprocessor_index_o = to_do_instr ? decoding_LUT_q[issue_req_i.instr[6:5]] : 0; // sending the copro index
+        end
+      endcase
+
+    end else begin
+      to_do_instr = 0;
+      coprocessor_index_o = '0;
+    end
+  end
+
+
+  assign  issue_req_o  = to_do_instr ? issue_req_i : '0;  //sending the incomming issue to the sfifo
+  assign  issue_resp_o = to_do_instr ? i_resp_LUT[coprocessor_index_o] : '0; // sending the issue response to the core, for now, we consider that a coprocessor have the same response for each instruction, if not, you can make the same than the other LUT.
+  assign  push_sfifo_o = to_do_instr;  // used to push the req + copro_index in the sfifo
+
+  // initializing the LUT
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      decoding_LUT_q = decoding_LUT;
+      same_copro_current_index = 0;
+    end
+    // checking if the coprocessor index is corresponding to a same coprocessor
+    if ((SAME_COPRO_NBR >= 2) && (coprocessor_index_o == SAME_COPRO_TABLE[same_copro_current_index]) && to_do_instr) begin
+      // incrementing the counter and going back to zero when at the end
+      if (same_copro_current_index == (SAME_COPRO_NBR - 1)) begin
+        same_copro_current_index = 0;
+      end else begin
+        same_copro_current_index++;
+      end
+      // updating the LUT with the corresponding index
+      for (int i = 0; i < deco_LUT_size; i++) begin
+        decoding_LUT_q[i]  = (decoding_LUT[i] == SAME_COPRO_TABLE[0]) ? SAME_COPRO_TABLE[same_copro_current_index] : decoding_LUT[i];
+      end
+    end
+  end
+
+endmodule


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
This PR contains 2 coprocessors examples, and a wrapper  , developped as part of the TRISTAN project :  
    
    - a configurable CRC coprocessor , which performs the inner CRC bitwise computation loop using any polynomial
   
    - a EXPonential coprocessor, which computes exp(-x) in fixed point Q0.31 , where is in Q5.26 (i.e x is in [0,32[ and exp(-x) in ]0,1[)

    - a wrapper, which allows to connect several coprocessors to a single cvx-if

By default, the coprocessors are not instantiated. An example instantiation is given at cva6 level for each of them

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

