### PR TITLE
csr_regfile: zero mtval/stval/vstval on interrupt traps 

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -2051,12 +2051,12 @@ module csr_regfile
           // set epc
           vsepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
           // set vstval
-          vstval_d        = (ariane_pkg::ZERO_TVAL
+          vstval_d        = ((ariane_pkg::ZERO_TVAL
                              && (ex_i.cause inside {
                              riscv::ILLEGAL_INSTR,
                              riscv::BREAKPOINT,
                              riscv::ENV_CALL_UMODE
-                             } || ex_i.cause[CVA6Cfg.XLEN-1])) ? '0 : ex_i.tval;
+                             })) || ex_i.cause[CVA6Cfg.XLEN-1]) ? '0 : ex_i.tval;
         end else begin
           // update sstatus
           mstatus_d.sie = 1'b0;
@@ -2068,14 +2068,14 @@ module csr_regfile
           // set epc
           sepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
           // set mtval or stval
-          stval_d        = (ariane_pkg::ZERO_TVAL
+          stval_d        = ((ariane_pkg::ZERO_TVAL
                                   && (ex_i.cause inside {
                                     riscv::ILLEGAL_INSTR,
                                     riscv::BREAKPOINT,
                                     riscv::ENV_CALL_UMODE,
                                     riscv::ENV_CALL_SMODE,
                                     riscv::ENV_CALL_MMODE
-                                  } || ex_i.cause[CVA6Cfg.XLEN-1])) ? '0 : ex_i.tval;
+                                  })) || ex_i.cause[CVA6Cfg.XLEN-1]) ? '0 : ex_i.tval;
           if (CVA6Cfg.RVH) begin
             htinst_d       = (ariane_pkg::ZERO_TVAL
                               && (ex_i.cause inside {
@@ -2107,14 +2107,14 @@ module csr_regfile
         mepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
         // set mtval or stval
         if (CVA6Cfg.TvalEn) begin
-          mtval_d        = (ariane_pkg::ZERO_TVAL
+          mtval_d        = ((ariane_pkg::ZERO_TVAL
                                     && (ex_i.cause inside {
                                       riscv::ILLEGAL_INSTR,
                                       riscv::BREAKPOINT,
                                       riscv::ENV_CALL_UMODE,
                                       riscv::ENV_CALL_SMODE,
                                       riscv::ENV_CALL_MMODE
-                                    } || ex_i.cause[CVA6Cfg.GPLEN-1])) ? '0 : ex_i.tval;
+                                    })) || ex_i.cause[CVA6Cfg.XLEN-1]) ? '0 : ex_i.tval;
         end else begin
           mtval_d = '0;
         end

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -2127,12 +2127,12 @@ module csr_regfile
           // set epc
           vsepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
           // set vstval
-          vstval_d        = (ariane_pkg::ZERO_TVAL
+          vstval_d        = ((ariane_pkg::ZERO_TVAL
                              && (ex_i.cause inside {
                              riscv::ILLEGAL_INSTR,
                              riscv::BREAKPOINT,
                              riscv::ENV_CALL_UMODE
-                             } || ex_i.cause[CVA6Cfg.XLEN-1])) ? '0 : ex_i.tval;
+                             })) || ex_i.cause[CVA6Cfg.XLEN-1]) ? '0 : ex_i.tval;
         end else begin
           // update sstatus
           mstatus_d.sie = 1'b0;
@@ -2144,14 +2144,14 @@ module csr_regfile
           // set epc
           sepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
           // set mtval or stval
-          stval_d        = (ariane_pkg::ZERO_TVAL
+          stval_d        = ((ariane_pkg::ZERO_TVAL
                                   && (ex_i.cause inside {
                                     riscv::ILLEGAL_INSTR,
                                     riscv::BREAKPOINT,
                                     riscv::ENV_CALL_UMODE,
                                     riscv::ENV_CALL_SMODE,
                                     riscv::ENV_CALL_MMODE
-                                  } || ex_i.cause[CVA6Cfg.XLEN-1])) ? '0 : ex_i.tval;
+                                  })) || ex_i.cause[CVA6Cfg.XLEN-1]) ? '0 : ex_i.tval;
           if (CVA6Cfg.RVH) begin
             htinst_d       = (ariane_pkg::ZERO_TVAL
                               && (ex_i.cause inside {
@@ -2186,14 +2186,14 @@ module csr_regfile
           if (CVA6Cfg.SdtrigEtrigger && sdtrig_etrigger_context_saved_valid && mret) begin
             mtval_d = sdtrig_etrigger_context_mtval;
           end else begin
-            mtval_d        = (ariane_pkg::ZERO_TVAL
+            mtval_d        = ((ariane_pkg::ZERO_TVAL
                                       && (ex_i.cause inside {
                                         riscv::ILLEGAL_INSTR,
                                         riscv::BREAKPOINT,
                                         riscv::ENV_CALL_UMODE,
                                         riscv::ENV_CALL_SMODE,
                                         riscv::ENV_CALL_MMODE
-                                      } || ex_i.cause[CVA6Cfg.XLEN-1])) ? '0 : ex_i.tval; //TODO changed ex_i.cause[CVA6Cfg.GPLEN-1] to XLEN because spyglass triggered and i fail to understand why
+                                      })) || ex_i.cause[CVA6Cfg.XLEN-1]) ? '0 : ex_i.tval;
           end
         end
 


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


# Why this change is needed

issue #3379, filed on 6 July against master `b30e7db`, reported two separate reasons an interrupt could leave `ex_i.tval` in the trap-value CSR:

1. The M-mode `mtval` expression tested `ex_i.cause[GPLEN-1]` instead of the interrupt bit at `XLEN-1`.
2. The interrupt test was inside the `ZERO_TVAL` guard, which is disabled in default builds.

An unrelated change in #3418 later changed `GPLEN-1` to `XLEN-1`. That part of #3379 is therefore already corrected on master and is not part of this diff.

This PR addresses the remaining grouping problem at the `mtval`, `stval`, and `vstval` sites. It changes:

```systemverilog
ZERO_TVAL && (listed_exception || interrupt)
```

to:

```systemverilog
(ZERO_TVAL && listed_exception) || interrupt
```

The `ZERO_TVAL`-gated behavior for listed exceptions is unchanged. Interrupt traps now select zero independently of `ZERO_TVAL`. the `mtval` and `stval` behavior was found and checked through formal property checking of `csr_regfile`.

Fixes #3379.

# Verification scope

The archived formal proof covers `mtval` and `stval` with `RVH=0` on pre-rebase PR head `3250ed48`. The identical `vstval` grouping correction is not covered by that proof. The RVH-only `htinst` and `mtinst` paths are unchanged and outside this PR’s scope.

Formal checker, logs, and traces: https://github.com/codeadpool/cva6-priv-sva/tree/main/evidence/mstatus


