### PR TITLE
csr_regfile: legalize mstatus.MPP against reserved 2'b10 when RVH=1

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1549,7 +1549,7 @@ module csr_regfile
             mstatus_d.tw   = riscv::Off;
             mstatus_d.mprv = riscv::Off;
           end
-          if ((!CVA6Cfg.RVH & mstatus_d.mpp == riscv::PRIV_LVL_HS) |
+          if ((mstatus_d.mpp == riscv::PRIV_LVL_HS) |
               (!CVA6Cfg.RVS & mstatus_d.mpp == riscv::PRIV_LVL_S) |
               (!CVA6Cfg.RVU & mstatus_d.mpp == riscv::PRIV_LVL_U)) begin
             mstatus_d.mpp = mstatus_q.mpp;

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1619,7 +1619,7 @@ module csr_regfile
             mstatus_d.mpv = 1'b0;
             mstatus_d.gva = 1'b0;
           end
-          if ((!CVA6Cfg.RVH & mstatus_d.mpp == riscv::PRIV_LVL_HS) |
+          if ((mstatus_d.mpp == riscv::PRIV_LVL_HS) |
               (!CVA6Cfg.RVS & mstatus_d.mpp == riscv::PRIV_LVL_S) |
               (!CVA6Cfg.RVU & mstatus_d.mpp == riscv::PRIV_LVL_U)) begin
             mstatus_d.mpp = mstatus_q.mpp;


### PR DESCRIPTION
## Why this PR is needed

`mstatus.MPP` is WARL over the implemented privilege modes, the current write path rejects the reserved encoding `2'b10` (`PRIV_LVL_HS`) only when `CVA6Cfg.RVH=0`:

```systemverilog
if ((!CVA6Cfg.RVH & mstatus_d.mpp == riscv::PRIV_LVL_HS) |
    (!CVA6Cfg.RVS & mstatus_d.mpp == riscv::PRIV_LVL_S) |
    (!CVA6Cfg.RVU & mstatus_d.mpp == riscv::PRIV_LVL_U)) begin
  mstatus_d.mpp = mstatus_q.mpp;
end
```

`2'b10` is not a legal privilege encoding for `MPP`, even when the hypervisor extension is implemented. HS-mode uses S-mode privilege (`2'b01`) with `V=0`; the H extension does not add a fourth privilege encoding.

With `RVH=1`, the first check is disabled, so an M-mode write of `MPP=2'b10` retains that reserved value.

## What changed

This PR makes the `MPP=2'b10` check unconditional by removing the `!CVA6Cfg.RVH` condition. the existing checks for unsupported S-mode and U-mode are unchanged.

An attempted write of `2'b10` now retains the previous `MPP` value under both `RVH=0` and `RVH=1`.

## Verification

Formal checking was run with yosys, yosys-slang, and SymbiYosys on `cv64a6_imafdch_sv39` (`RVH=1`). The checked property requires `mstatus.MPP` to remain in `{M, S, U}`.

PR #3387 was applied to both runs to remove the independent `dcsr.prv`/`dret` path:

* Before this change: counterexample at step 3.
* After this change: unbounded proof with PDR.

Checker and logs:  https://github.com/codeadpool/cva6-priv-sva/tree/main/evidence/probe/probe_mpp_legal_rvh_fixed_prove/

## Related issues

Fixes #3411.

This completes the `RVH=1` case missed by #1988/PR #2035 and #2274/PR #2285.

The trap-to-M path can separately copy an already-invalid `priv_lvl_q` into `MPP`. That independent `dcsr.prv`/`dret` path is covered by #3383 and PR #3387. This PR fixes the direct `mstatus` CSR-write path.
