### PR TITLE
Master candidate dcls

### DIFF
--- a/config/target/cv32a60x/Flist.cva6
+++ b/config/target/cv32a60x/Flist.cva6
@@ -1,11 +1,11 @@
-# Copyright 2026 Thales France
-#
-# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
-# You may obtain a copy of the License at https://solderpad.org/licenses/
-#
-# Original Author: Yannick Casamatta (yannick.casamatta@thalesgroup.com)
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Yannick Casamatta (yannick.casamatta@thalesgroup.com)
 
 
 -F ${CVA6_REPO_DIR}/core/Flist.cva6

--- a/config/target/cv32a60x/Flist.cva6_gate
+++ b/config/target/cv32a60x/Flist.cva6_gate
@@ -1,11 +1,11 @@
-# Copyright 2026 Thales France
-#
-# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
-# You may obtain a copy of the License at https://solderpad.org/licenses/
-#
-# Original Author: Yannick Casamatta (yannick.casamatta@thalesgroup.com)
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Yannick Casamatta (yannick.casamatta@thalesgroup.com)
 
 
 -F ${CVA6_REPO_DIR}/core/Flist.cva6_gate

--- a/config/target/cv32a60x/expected_spyglass.rpt
+++ b/config/target/cv32a60x/expected_spyglass.rpt
@@ -31,13 +31,16 @@ INFO       ElabSummary          1     Generates Elaborated design units
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Severity   Rule Name            Count Short Help                               
 ===============================================================================
-WARNING    FlopEConst           2     Flip-flop enable pin is permanently 
+WARNING    FlopEConst           4     Flip-flop enable pin is permanently 
                                       disabled or enabled 
-WARNING    STARC05-2.2.3.3      1     Do not assign over the same signal in 
-                                      an always construct for sequential 
-                                      circuits 
-WARNING    W287b                16    Output port of an instance is not 
+WARNING    STARC05-1.3.1.3      1     Asynchronous reset/preset signals must 
+                                      not be used as non-reset/preset or 
+                                      synchronous reset/preset signals 
+WARNING    W287a                1     Some inputs to instance are not driven 
+                                      or unconnected 
+WARNING    W287b                17    Output port of an instance is not 
                                       connected 
 WARNING    W415a                5     Signal may be multiply assigned (beside 
                                       initialization) in the same scope. 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+

--- a/config/target/cv32a60x/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(1),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(1),
+      DclsCommonBHT: bit'(1)
   };
 
 endpackage

--- a/config/target/cv32a60x/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(1),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(1),
+      DclsCommonBHT: bit'(1)
   };
 
 endpackage

--- a/config/target/cv32a60x_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_no_zcmt/expected_spyglass.rpt
+++ b/config/target/cv32a60x_no_zcmt/expected_spyglass.rpt
@@ -33,11 +33,9 @@ Severity   Rule Name            Count Short Help
 ===============================================================================
 WARNING    FlopEConst           2     Flip-flop enable pin is permanently 
                                       disabled or enabled 
-WARNING    STARC05-2.2.3.3      1     Do not assign over the same signal in 
-                                      an always construct for sequential 
-                                      circuits 
-WARNING    W287b                16    Output port of an instance is not 
+WARNING    W287b                17    Output port of an instance is not 
                                       connected 
 WARNING    W415a                5     Signal may be multiply assigned (beside 
                                       initialization) in the same scope. 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+

--- a/config/target/cv32a60x_no_zcmt/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_no_zcmt/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_no_zcmt/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_no_zcmt/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_no_zcmt_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_no_zcmt_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_no_zcmt_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_no_zcmt_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_zcmt_pmp/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_zcmt_pmp/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_zcmt_pmp/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_zcmt_pmp/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_zcmt_pmp_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_zcmt_pmp_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a60x_zcmt_pmp_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a60x_zcmt_pmp_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_noPMP/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_noPMP/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_noPMP/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_noPMP/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_noPMP_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_noPMP_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_noPMP_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_noPMP_axi/rtl_cfg_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_sv32/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_sv32/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_sv32/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_sv32/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_sv32_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_sv32_axi/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a65x_sv32_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a65x_sv32_axi/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a6_imac_sv32/rtl_cfg_pkg.sv
+++ b/config/target/cv32a6_imac_sv32/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a6_imac_sv32/rtl_cfg_pkg.sv
+++ b/config/target/cv32a6_imac_sv32/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a6_imac_sv32_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a6_imac_sv32_obi/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv32a6_imac_sv32_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv32a6_imac_sv32_obi/rtl_cfg_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_axi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_axi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_obi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_nopmp_nommu_obi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_axi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_axi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_obi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_mmu_obi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_axi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_axi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_axi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_obi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_obi/rtl_cfg_pkg.sv
+++ b/config/target/cv64a6_imafdc_sv39_hpdcache_pmp_nommu_obi/rtl_cfg_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -147,6 +147,7 @@ ${CVA6_REPO_DIR}/vendor/pulp-platform/obi/src/obi_xbar.sv
 // Top-level source files (not necessarily instantiated at the top of the cva6).
 ${CVA6_REPO_DIR}/core/cva6_example_obi.sv
 ${CVA6_REPO_DIR}/core/cva6_example_axi.sv
+${CVA6_REPO_DIR}/core/cva6_top.sv
 ${CVA6_REPO_DIR}/core/cva6.sv
 ${CVA6_REPO_DIR}/core/cva6_pipeline.sv
 ${CVA6_REPO_DIR}/core/cva6_rvfi_probes.sv
@@ -232,5 +233,12 @@ ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_mmu.sv
 ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_ptw.sv
 ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_tlb.sv
 ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_shared_tlb.sv
+
+// DCLS
+${CVA6_REPO_DIR}/core/dcls_comparator.sv
+${CVA6_REPO_DIR}/core/dcls_logic.sv
+${CVA6_REPO_DIR}/core/dcls_common.sv
+${CVA6_REPO_DIR}/core/dcls_common_regfile.sv
+${CVA6_REPO_DIR}/core/dcls_common_bht.sv
 
 // end of manifest

--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -147,6 +147,7 @@ ${CVA6_REPO_DIR}/vendor/pulp-platform/obi/src/obi_xbar.sv
 // Top-level source files (not necessarily instantiated at the top of the cva6).
 ${CVA6_REPO_DIR}/core/cva6_example_obi.sv
 ${CVA6_REPO_DIR}/core/cva6_example_axi.sv
+${CVA6_REPO_DIR}/core/cva6_top.sv
 ${CVA6_REPO_DIR}/core/cva6.sv
 ${CVA6_REPO_DIR}/core/cva6_pipeline.sv
 ${CVA6_REPO_DIR}/core/cva6_rvfi_probes.sv
@@ -232,5 +233,13 @@ ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_mmu.sv
 ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_ptw.sv
 ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_tlb.sv
 ${CVA6_REPO_DIR}/core/cva6_mmu/cva6_shared_tlb.sv
+
+// Embedded lock-step
+${CVA6_REPO_DIR}/core/dcls_comparator.sv
+${CVA6_REPO_DIR}/core/dcls_delay_ff.sv
+${CVA6_REPO_DIR}/core/dcls_logic.sv
+${CVA6_REPO_DIR}/core/dcls_common.sv
+${CVA6_REPO_DIR}/core/dcls_common_regfile.sv
+${CVA6_REPO_DIR}/core/dcls_common_bht.sv
 
 // end of manifest

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -29,6 +29,12 @@ module cva6
     parameter type noc_req_t  = logic,
     parameter type noc_resp_t = logic,
 
+    // DCLS
+    parameter type regfile_inputs_t = logic,
+    parameter type bht_inputs_t = logic,
+    parameter type dcls_common_modules_ctrl_t = logic,
+    parameter type dcls_common_modules_data_t = logic,
+
     // CVXIF Types
     localparam type readregflags_t = `READREGFLAGS_T(CVA6Cfg),
     localparam type writeregflags_t = `WRITEREGFLAGS_T(CVA6Cfg),
@@ -71,7 +77,10 @@ module cva6
     // noc request, can be AXI or OpenPiton - SUBSYSTEM
     output noc_req_t noc_req_o,
     // noc response, can be AXI or OpenPiton - SUBSYSTEM
-    input noc_resp_t noc_resp_i
+    input noc_resp_t noc_resp_i,
+    // DCLS
+    input dcls_common_modules_data_t dcls_from_common_i,
+    output dcls_common_modules_ctrl_t dcls_to_common_o
 );
 
 
@@ -155,7 +164,11 @@ module cva6
       .x_commit_t         (x_commit_t),
       .x_result_t         (x_result_t),
       .cvxif_req_t        (cvxif_req_t),
-      .cvxif_resp_t       (cvxif_resp_t)
+      .cvxif_resp_t       (cvxif_resp_t),
+      .regfile_inputs_t    (regfile_inputs_t),
+      .bht_inputs_t(bht_inputs_t),
+      .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+      .dcls_common_modules_data_t(dcls_common_modules_data_t)
       //
   ) i_cva6_pipeline (
       .clk_i(clk_i),
@@ -198,7 +211,9 @@ module cva6
       .ypb_zcmt_rsp_i   (ypb_zcmt_rsp),
 
       .dcache_wbuffer_empty_i (wbuffer_empty),
-      .dcache_wbuffer_not_ni_i(wbuffer_not_ni)
+      .dcache_wbuffer_not_ni_i(wbuffer_not_ni),
+      .dcls_from_common_i,
+      .dcls_to_common_o
   );
 
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -29,6 +29,12 @@ module cva6
     parameter type noc_req_t  = logic,
     parameter type noc_resp_t = logic,
 
+    // DCLS
+    parameter type regfile_inputs_t = logic,
+    parameter type bht_inputs_t = logic,
+    parameter type dcls_common_modules_ctrl_t = logic,
+    parameter type dcls_common_modules_data_t = logic,
+
     // CVXIF Types
     localparam type readregflags_t = `READREGFLAGS_T(CVA6Cfg),
     localparam type writeregflags_t = `WRITEREGFLAGS_T(CVA6Cfg),
@@ -71,7 +77,10 @@ module cva6
     // noc request, can be AXI or OpenPiton - SUBSYSTEM
     output noc_req_t noc_req_o,
     // noc response, can be AXI or OpenPiton - SUBSYSTEM
-    input noc_resp_t noc_resp_i
+    input noc_resp_t noc_resp_i,
+    // DCLS
+    input dcls_common_modules_data_t dcls_from_common_i,
+    output dcls_common_modules_ctrl_t dcls_to_common_o
 );
 
 
@@ -126,36 +135,40 @@ module cva6
 
   cva6_pipeline #(
       // CVA6 config
-      .CVA6Cfg            (CVA6Cfg),
+      .CVA6Cfg                   (CVA6Cfg),
       // RVFI PROBES
-      .rvfi_probes_t      (rvfi_probes_t),
+      .rvfi_probes_t             (rvfi_probes_t),
       // YPB 
-      .ypb_fetch_req_t    (ypb_fetch_req_t),
-      .ypb_fetch_rsp_t    (ypb_fetch_rsp_t),
-      .ypb_store_req_t    (ypb_store_req_t),
-      .ypb_store_rsp_t    (ypb_store_rsp_t),
-      .ypb_amo_req_t      (ypb_amo_req_t),
-      .ypb_amo_rsp_t      (ypb_amo_rsp_t),
-      .ypb_load_req_t     (ypb_load_req_t),
-      .ypb_load_rsp_t     (ypb_load_rsp_t),
-      .ypb_mmu_ptw_req_t  (ypb_mmu_ptw_req_t),
-      .ypb_mmu_ptw_rsp_t  (ypb_mmu_ptw_rsp_t),
-      .ypb_zcmt_req_t     (ypb_zcmt_req_t),
-      .ypb_zcmt_rsp_t     (ypb_zcmt_rsp_t),
+      .ypb_fetch_req_t           (ypb_fetch_req_t),
+      .ypb_fetch_rsp_t           (ypb_fetch_rsp_t),
+      .ypb_store_req_t           (ypb_store_req_t),
+      .ypb_store_rsp_t           (ypb_store_rsp_t),
+      .ypb_amo_req_t             (ypb_amo_req_t),
+      .ypb_amo_rsp_t             (ypb_amo_rsp_t),
+      .ypb_load_req_t            (ypb_load_req_t),
+      .ypb_load_rsp_t            (ypb_load_rsp_t),
+      .ypb_mmu_ptw_req_t         (ypb_mmu_ptw_req_t),
+      .ypb_mmu_ptw_rsp_t         (ypb_mmu_ptw_rsp_t),
+      .ypb_zcmt_req_t            (ypb_zcmt_req_t),
+      .ypb_zcmt_rsp_t            (ypb_zcmt_rsp_t),
       // CVXIF
-      .readregflags_t     (readregflags_t),
-      .writeregflags_t    (writeregflags_t),
-      .id_t               (id_t),
-      .hartid_t           (hartid_t),
-      .x_compressed_req_t (x_compressed_req_t),
-      .x_compressed_resp_t(x_compressed_resp_t),
-      .x_issue_req_t      (x_issue_req_t),
-      .x_issue_resp_t     (x_issue_resp_t),
-      .x_register_t       (x_register_t),
-      .x_commit_t         (x_commit_t),
-      .x_result_t         (x_result_t),
-      .cvxif_req_t        (cvxif_req_t),
-      .cvxif_resp_t       (cvxif_resp_t)
+      .readregflags_t            (readregflags_t),
+      .writeregflags_t           (writeregflags_t),
+      .id_t                      (id_t),
+      .hartid_t                  (hartid_t),
+      .x_compressed_req_t        (x_compressed_req_t),
+      .x_compressed_resp_t       (x_compressed_resp_t),
+      .x_issue_req_t             (x_issue_req_t),
+      .x_issue_resp_t            (x_issue_resp_t),
+      .x_register_t              (x_register_t),
+      .x_commit_t                (x_commit_t),
+      .x_result_t                (x_result_t),
+      .cvxif_req_t               (cvxif_req_t),
+      .cvxif_resp_t              (cvxif_resp_t),
+      .regfile_inputs_t          (regfile_inputs_t),
+      .bht_inputs_t              (bht_inputs_t),
+      .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+      .dcls_common_modules_data_t(dcls_common_modules_data_t)
       //
   ) i_cva6_pipeline (
       .clk_i(clk_i),
@@ -198,7 +211,9 @@ module cva6
       .ypb_zcmt_rsp_i   (ypb_zcmt_rsp),
 
       .dcache_wbuffer_empty_i (wbuffer_empty),
-      .dcache_wbuffer_not_ni_i(wbuffer_not_ni)
+      .dcache_wbuffer_not_ni_i(wbuffer_not_ni),
+      .dcls_from_common_i,
+      .dcls_to_common_o
   );
 
 

--- a/core/cva6_example_axi.sv
+++ b/core/cva6_example_axi.sv
@@ -82,10 +82,12 @@ module cva6_example_axi
     // noc request, can be AXI or OpenPiton - SUBSYSTEM
     output noc_req_t noc_req_o,
     // noc response, can be AXI or OpenPiton - SUBSYSTEM
-    input noc_resp_t noc_resp_i
+    input noc_resp_t noc_resp_i,
+    // DCLS Alarms on core outputs & common modules inputs - DCLS
+    output logic [3:0] dcls_alarm_o
 );
 
-  cva6 #(
+  cva6_top #(
       .CVA6Cfg      (CVA6Cfg),
       .rvfi_probes_t(rvfi_probes_t),
       .noc_req_t    (noc_req_t),
@@ -103,7 +105,8 @@ module cva6_example_axi
       .cvxif_req_o(cvxif_req_o),
       .cvxif_resp_i(cvxif_resp_i),
       .noc_req_o(noc_req_o),
-      .noc_resp_i(noc_resp_i)
+      .noc_resp_i(noc_resp_i),
+      .dcls_alarm_o
   );
 
 endmodule  // ariane

--- a/core/cva6_example_axi.sv
+++ b/core/cva6_example_axi.sv
@@ -82,15 +82,17 @@ module cva6_example_axi
     // noc request, can be AXI or OpenPiton - SUBSYSTEM
     output noc_req_t noc_req_o,
     // noc response, can be AXI or OpenPiton - SUBSYSTEM
-    input noc_resp_t noc_resp_i
+    input noc_resp_t noc_resp_i,
+    // DCLS Alarms on core outputs & common modules inputs - DCLS
+    output logic [3:0] dcls_alarm_o
 );
 
-  cva6 #(
+  cva6_top #(
       .CVA6Cfg      (CVA6Cfg),
       .rvfi_probes_t(rvfi_probes_t),
       .noc_req_t    (noc_req_t),
       .noc_resp_t   (noc_resp_t)
-  ) i_cva6 (
+  ) i_cva6_top (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
       .boot_addr_i(boot_addr_i),
@@ -103,7 +105,8 @@ module cva6_example_axi
       .cvxif_req_o(cvxif_req_o),
       .cvxif_resp_i(cvxif_resp_i),
       .noc_req_o(noc_req_o),
-      .noc_resp_i(noc_resp_i)
+      .noc_resp_i(noc_resp_i),
+      .dcls_alarm_o
   );
 
 endmodule  // ariane

--- a/core/cva6_example_obi.sv
+++ b/core/cva6_example_obi.sv
@@ -155,10 +155,12 @@ module cva6_example_obi
     // noc request, can be AXI or OpenPiton - SUBSYSTEM
     output noc_req_t noc_req_o,
     // noc response, can be AXI or OpenPiton - SUBSYSTEM
-    input noc_resp_t noc_resp_i
+    input noc_resp_t noc_resp_i,
+    // DCLS Alarms on core outputs & common modules inputs - DCLS
+    output logic [3:0] dcls_alarm_o
 );
 
-  cva6 #(
+  cva6_top #(
       .CVA6Cfg      (CVA6Cfg),
       .rvfi_probes_t(rvfi_probes_t),
       .noc_req_t    (noc_req_t),
@@ -176,7 +178,8 @@ module cva6_example_obi
       .cvxif_req_o(cvxif_req_o),
       .cvxif_resp_i(cvxif_resp_i),
       .noc_req_o(noc_req_o),
-      .noc_resp_i(noc_resp_i)
+      .noc_resp_i(noc_resp_i),
+      .dcls_alarm_o
   );
 
 endmodule  // ariane

--- a/core/cva6_example_obi.sv
+++ b/core/cva6_example_obi.sv
@@ -155,15 +155,17 @@ module cva6_example_obi
     // noc request, can be AXI or OpenPiton - SUBSYSTEM
     output noc_req_t noc_req_o,
     // noc response, can be AXI or OpenPiton - SUBSYSTEM
-    input noc_resp_t noc_resp_i
+    input noc_resp_t noc_resp_i,
+    // DCLS Alarms on core outputs & common modules inputs - DCLS
+    output logic [3:0] dcls_alarm_o
 );
 
-  cva6 #(
+  cva6_top #(
       .CVA6Cfg      (CVA6Cfg),
       .rvfi_probes_t(rvfi_probes_t),
       .noc_req_t    (noc_req_t),
       .noc_resp_t   (noc_resp_t)
-  ) i_cva6 (
+  ) i_cva6_top (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
       .boot_addr_i(boot_addr_i),
@@ -176,7 +178,8 @@ module cva6_example_obi
       .cvxif_req_o(cvxif_req_o),
       .cvxif_resp_i(cvxif_resp_i),
       .noc_req_o(noc_req_o),
-      .noc_resp_i(noc_resp_i)
+      .noc_resp_i(noc_resp_i),
+      .dcls_alarm_o
   );
 
 endmodule  // ariane

--- a/core/cva6_pipeline.sv
+++ b/core/cva6_pipeline.sv
@@ -52,7 +52,13 @@ module cva6_pipeline
     parameter type x_commit_t = logic,
     parameter type x_result_t = logic,
     parameter type cvxif_req_t = logic,
-    parameter type cvxif_resp_t = logic
+    parameter type cvxif_resp_t = logic,
+
+    // DCLS
+    parameter type regfile_inputs_t = logic,
+    parameter type bht_inputs_t = logic,
+    parameter type dcls_common_modules_ctrl_t = logic,
+    parameter type dcls_common_modules_data_t = logic
 
 ) (
     // Subsystem Clock - SUBSYSTEM
@@ -130,7 +136,10 @@ module cva6_pipeline
     // Write buffer status to know if empty - EX_STAGE
     input logic dcache_wbuffer_empty_i,
     // Write buffer status to know if not non idempotent - EX_STAGE
-    input logic dcache_wbuffer_not_ni_i
+    input logic dcache_wbuffer_not_ni_i,
+    // DCLS
+    input dcls_common_modules_data_t dcls_from_common_i,
+    output dcls_common_modules_ctrl_t dcls_to_common_o
 );
 
   localparam type rvfi_probes_instr_t = `RVFI_PROBES_INSTR_T(CVA6Cfg);
@@ -544,6 +553,9 @@ module cva6_pipeline
   // --------------
   // Frontend
   // --------------
+  bht_inputs_t bht_to_common;
+  bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] bht_from_common;
+
   frontend #(
       .CVA6Cfg(CVA6Cfg),
       .bp_resolve_t(bp_resolve_t),
@@ -551,7 +563,8 @@ module cva6_pipeline
       .fetch_areq_t(fetch_areq_t),
       .fetch_arsp_t(fetch_arsp_t),
       .ypb_fetch_req_t(ypb_fetch_req_t),
-      .ypb_fetch_rsp_t(ypb_fetch_rsp_t)
+      .ypb_fetch_rsp_t(ypb_fetch_rsp_t),
+      .bht_inputs_t(bht_inputs_t)
   ) i_frontend (
       .clk_i,
       .rst_ni,
@@ -574,8 +587,17 @@ module cva6_pipeline
       .ypb_fetch_rsp_i    (ypb_fetch_rsp_i),
       .fetch_entry_o      (fetch_entry_if_id),
       .fetch_entry_valid_o(fetch_valid_if_id),
-      .fetch_entry_ready_i(fetch_ready_id_if)
+      .fetch_entry_ready_i(fetch_ready_id_if),
+      .dcls_common_bht_data_i(bht_from_common),
+      .dcls_common_bht_ctrl_o(bht_to_common)
   );
+
+  if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonBHT) begin
+    assign bht_from_common = dcls_from_common_i.bht_prediction;
+    assign dcls_to_common_o.bht_inputs = bht_to_common;
+  end else begin
+    assign bht_from_common = '0;
+  end
 
   // ---------
   // ID
@@ -696,6 +718,10 @@ module cva6_pipeline
   // ---------
   // Issue
   // ---------
+
+  regfile_inputs_t common_regfile_ctrl;
+  logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] common_regfile_rdata;
+
   issue_stage #(
       .CVA6Cfg(CVA6Cfg),
       .bp_resolve_t(bp_resolve_t),
@@ -707,7 +733,8 @@ module cva6_pipeline
       .x_issue_req_t(x_issue_req_t),
       .x_issue_resp_t(x_issue_resp_t),
       .x_register_t(x_register_t),
-      .x_commit_t(x_commit_t)
+      .x_commit_t(x_commit_t),
+      .regfile_inputs_t    (regfile_inputs_t)
   ) issue_stage_i (
       .clk_i,
       .rst_ni,
@@ -795,8 +822,17 @@ module cva6_pipeline
       .rvfi_commit_pointer_o(rvfi_commit_pointer),
       .rvfi_rs1_o           (rvfi_rs1),
       .rvfi_rs2_o           (rvfi_rs2),
-      .orig_instr_aes_bits  (orig_instr_aes)
+      .orig_instr_aes_bits  (orig_instr_aes),
+      .dcls_common_regfile_data_i(common_regfile_rdata),
+      .dcls_common_regfile_ctrl_o(common_regfile_ctrl)
   );
+
+  if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonRegfile) begin
+    assign dcls_to_common_o.regfile_inputs = common_regfile_ctrl;
+    assign common_regfile_rdata = dcls_from_common_i.regfile_rdata;
+  end else begin
+    assign common_regfile_rdata = '0;
+  end
 
   // ---------
   // EX

--- a/core/cva6_pipeline.sv
+++ b/core/cva6_pipeline.sv
@@ -568,31 +568,31 @@ module cva6_pipeline
   ) i_frontend (
       .clk_i,
       .rst_ni,
-      .boot_addr_i        (boot_addr_i[CVA6Cfg.VLEN-1:0]),
-      .flush_bp_i         (1'b0),
-      .flush_i            (flush_ctrl_if),                  // not entirely correct
-      .halt_i             (halt_ctrl),
-      .set_pc_commit_i    (set_pc_ctrl_pcgen),
-      .pc_commit_i        (pc_commit),
-      .ex_valid_i         (ex_commit.valid),
-      .resolved_branch_i  (resolved_branch),
-      .eret_i             (eret),
-      .epc_i              (epc_commit_pcgen),
-      .trap_vector_base_i (trap_vector_base_commit_pcgen),
-      .set_debug_pc_i     (set_debug_pc),
-      .debug_mode_i       (debug_mode),
-      .areq_o             (fetch_areq_frontend_ex),
-      .arsp_i             (fetch_arsp_ex_frontend),
-      .ypb_fetch_req_o    (ypb_fetch_req_o),
-      .ypb_fetch_rsp_i    (ypb_fetch_rsp_i),
-      .fetch_entry_o      (fetch_entry_if_id),
-      .fetch_entry_valid_o(fetch_valid_if_id),
-      .fetch_entry_ready_i(fetch_ready_id_if),
+      .boot_addr_i           (boot_addr_i[CVA6Cfg.VLEN-1:0]),
+      .flush_bp_i            (1'b0),
+      .flush_i               (flush_ctrl_if),                  // not entirely correct
+      .halt_i                (halt_ctrl),
+      .set_pc_commit_i       (set_pc_ctrl_pcgen),
+      .pc_commit_i           (pc_commit),
+      .ex_valid_i            (ex_commit.valid),
+      .resolved_branch_i     (resolved_branch),
+      .eret_i                (eret),
+      .epc_i                 (epc_commit_pcgen),
+      .trap_vector_base_i    (trap_vector_base_commit_pcgen),
+      .set_debug_pc_i        (set_debug_pc),
+      .debug_mode_i          (debug_mode),
+      .areq_o                (fetch_areq_frontend_ex),
+      .arsp_i                (fetch_arsp_ex_frontend),
+      .ypb_fetch_req_o       (ypb_fetch_req_o),
+      .ypb_fetch_rsp_i       (ypb_fetch_rsp_i),
+      .fetch_entry_o         (fetch_entry_if_id),
+      .fetch_entry_valid_o   (fetch_valid_if_id),
+      .fetch_entry_ready_i   (fetch_ready_id_if),
       .dcls_common_bht_data_i(bht_from_common),
       .dcls_common_bht_ctrl_o(bht_to_common)
   );
 
-  if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonBHT) begin
+  if (CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonBHT) begin
     assign bht_from_common = dcls_from_common_i.bht_prediction;
     assign dcls_to_common_o.bht_inputs = bht_to_common;
   end else begin
@@ -723,18 +723,18 @@ module cva6_pipeline
   logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] common_regfile_rdata;
 
   issue_stage #(
-      .CVA6Cfg(CVA6Cfg),
-      .bp_resolve_t(bp_resolve_t),
+      .CVA6Cfg            (CVA6Cfg),
+      .bp_resolve_t       (bp_resolve_t),
       .branchpredict_sbe_t(branchpredict_sbe_t),
-      .exception_t(exception_t),
-      .fu_data_t(fu_data_t),
-      .scoreboard_entry_t(scoreboard_entry_t),
-      .writeback_t(writeback_t),
-      .x_issue_req_t(x_issue_req_t),
-      .x_issue_resp_t(x_issue_resp_t),
-      .x_register_t(x_register_t),
-      .x_commit_t(x_commit_t),
-      .regfile_inputs_t    (regfile_inputs_t)
+      .exception_t        (exception_t),
+      .fu_data_t          (fu_data_t),
+      .scoreboard_entry_t (scoreboard_entry_t),
+      .writeback_t        (writeback_t),
+      .x_issue_req_t      (x_issue_req_t),
+      .x_issue_resp_t     (x_issue_resp_t),
+      .x_register_t       (x_register_t),
+      .x_commit_t         (x_commit_t),
+      .regfile_inputs_t   (regfile_inputs_t)
   ) issue_stage_i (
       .clk_i,
       .rst_ni,
@@ -808,26 +808,26 @@ module cva6_pipeline
       .x_we_i                  (x_we_ex_id),
       .x_rd_i                  (x_rd_ex_id),
 
-      .waddr_i              (waddr_commit_id),
-      .wdata_i              (wdata_commit_id),
-      .we_gpr_i             (we_gpr_commit_id),
-      .we_fpr_i             (we_fpr_commit_id),
-      .commit_instr_o       (commit_instr_id_commit),
-      .commit_drop_o        (commit_drop_id_commit),
-      .commit_ack_i         (commit_ack_commit_id),
+      .waddr_i                   (waddr_commit_id),
+      .wdata_i                   (wdata_commit_id),
+      .we_gpr_i                  (we_gpr_commit_id),
+      .we_fpr_i                  (we_fpr_commit_id),
+      .commit_instr_o            (commit_instr_id_commit),
+      .commit_drop_o             (commit_drop_id_commit),
+      .commit_ack_i              (commit_ack_commit_id),
       // Performance Counters
-      .stall_issue_o        (stall_issue),
+      .stall_issue_o             (stall_issue),
       //RVFI
-      .rvfi_issue_pointer_o (rvfi_issue_pointer),
-      .rvfi_commit_pointer_o(rvfi_commit_pointer),
-      .rvfi_rs1_o           (rvfi_rs1),
-      .rvfi_rs2_o           (rvfi_rs2),
-      .orig_instr_aes_bits  (orig_instr_aes),
+      .rvfi_issue_pointer_o      (rvfi_issue_pointer),
+      .rvfi_commit_pointer_o     (rvfi_commit_pointer),
+      .rvfi_rs1_o                (rvfi_rs1),
+      .rvfi_rs2_o                (rvfi_rs2),
+      .orig_instr_aes_bits       (orig_instr_aes),
       .dcls_common_regfile_data_i(common_regfile_rdata),
       .dcls_common_regfile_ctrl_o(common_regfile_ctrl)
   );
 
-  if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonRegfile) begin
+  if (CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonRegfile) begin
     assign dcls_to_common_o.regfile_inputs = common_regfile_ctrl;
     assign common_regfile_rdata = dcls_from_common_i.regfile_rdata;
   end else begin

--- a/core/cva6_top.sv
+++ b/core/cva6_top.sv
@@ -1,0 +1,250 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+`include "rvfi_types.svh"
+`include "cvxif_types.svh"
+`include "ypb_types.svh"
+
+module cva6_top
+  import ariane_pkg::*;
+#(
+    // CVA6 config
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+
+    // RVFI PROBES
+    parameter type rvfi_probes_t = logic,
+
+    // NOC Types AXI bus or several OBI bus
+    parameter type noc_req_t  = logic,
+    parameter type noc_resp_t = logic,
+
+    // CVXIF Types
+    localparam type readregflags_t = `READREGFLAGS_T(CVA6Cfg),
+    localparam type writeregflags_t = `WRITEREGFLAGS_T(CVA6Cfg),
+    localparam type id_t = `ID_T(CVA6Cfg),
+    localparam type hartid_t = `HARTID_T(CVA6Cfg),
+    localparam type x_compressed_req_t = `X_COMPRESSED_REQ_T(CVA6Cfg, hartid_t),
+    localparam type x_compressed_resp_t = `X_COMPRESSED_RESP_T(CVA6Cfg),
+    localparam type x_issue_req_t = `X_ISSUE_REQ_T(CVA6Cfg, hartit_t, id_t),
+    localparam type x_issue_resp_t = `X_ISSUE_RESP_T(CVA6Cfg, writeregflags_t, readregflags_t),
+    localparam type x_register_t = `X_REGISTER_T(CVA6Cfg, hartid_t, id_t, readregflags_t),
+    localparam type x_commit_t = `X_COMMIT_T(CVA6Cfg, hartid_t, id_t),
+    localparam type x_result_t = `X_RESULT_T(CVA6Cfg, hartid_t, id_t, writeregflags_t),
+    localparam type cvxif_req_t =
+    `CVXIF_REQ_T(CVA6Cfg, x_compressed_req_t, x_issue_req_t, x_register_t, x_commit_t),
+    localparam type cvxif_resp_t =
+    `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t),
+    // --- DCLS ---
+    //  Types
+    localparam type core_inputs_t = struct packed {
+        logic [1:0] irq;
+        logic ipi;
+        logic time_irq;
+        logic debug_req;
+        cvxif_resp_t cvxif_resp;
+        noc_resp_t noc_resp;
+    },
+    localparam type core_outputs_t = struct packed {
+        cvxif_req_t cvxif_req;
+        noc_req_t noc_req;
+    },
+    localparam type regfile_inputs_t = struct packed {
+        logic [CVA6Cfg.NrRgprPorts-1:0][4:0] raddr;
+        logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.XLEN-1:0] wdata;
+        logic [CVA6Cfg.NrCommitPorts-1:0][4:0] waddr;
+        logic [CVA6Cfg.NrCommitPorts-1:0] we;
+    },
+    localparam type bht_update_t = struct packed {
+      logic                    valid;
+      logic [CVA6Cfg.VLEN-1:0] pc;     // update at PC
+      logic                    taken;
+    },
+    localparam type bht_inputs_t = struct packed {
+        logic flush_bp;
+        logic debug_mode;
+        logic [CVA6Cfg.VLEN-1:0] vpc;
+        bht_update_t bht_update;
+    },
+    localparam type dcls_common_modules_ctrl_t = struct packed {
+        regfile_inputs_t regfile_inputs;
+        bht_inputs_t bht_inputs;
+    },
+    localparam type dcls_common_modules_data_t = struct packed {
+        logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] regfile_rdata;
+        bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] bht_prediction;
+    }
+    // -----
+) (
+    // Subsystem Clock - SUBSYSTEM
+    input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
+    input logic rst_ni,
+    // Reset boot address - SUBSYSTEM
+    input logic [CVA6Cfg.VLEN-1:0] boot_addr_i,
+    // Hard ID reflected as CSR - SUBSYSTEM
+    input logic [CVA6Cfg.XLEN-1:0] hart_id_i,
+    // Level sensitive (async) interrupts - SUBSYSTEM
+    input logic [1:0] irq_i,
+    // Inter-processor (async) interrupt - SUBSYSTEM
+    input logic ipi_i,
+    // Timer (async) interrupt - SUBSYSTEM
+    input logic time_irq_i,
+    // External events input
+    input logic [8:0] ev_i,
+    // Debug (async) request - SUBSYSTEM
+    input logic debug_req_i,
+    // Probes to build RVFI, can be left open when not used - RVFI
+    output rvfi_probes_t rvfi_probes_o,
+    // CVXIF request - SUBSYSTEM
+    output cvxif_req_t cvxif_req_o,
+    // CVXIF response - SUBSYSTEM
+    input cvxif_resp_t cvxif_resp_i,
+    // noc request, can be AXI or OpenPiton - SUBSYSTEM
+    output noc_req_t noc_req_o,
+    // noc response, can be AXI or OpenPiton - SUBSYSTEM
+    input noc_resp_t noc_resp_i,
+    // DCLS alarm
+    output logic [3:0] dcls_alarm_o
+);
+    if(CVA6Cfg.DclsEn) begin: gen_cva6_dcls
+        // ********* CORES IO *********
+        core_inputs_t main_inputs, main_inputs_delayed;
+        core_outputs_t main_outputs, shadow_outputs;
+
+        assign main_inputs = '{
+            irq_i,
+            ipi_i,
+            time_irq_i,
+            debug_req_i,
+            cvxif_resp_i,
+            noc_resp_i
+        };
+        assign main_outputs = '{
+            cvxif_req_o,
+            noc_req_o
+        };
+        // ********* DCLS CTRL *********
+        logic rst_shadow;
+
+        dcls_logic #(
+            .noc_resp_t(noc_resp_t),
+            .core_inputs_t(core_inputs_t),
+            .core_outputs_t(core_outputs_t),
+            .DCLS_DELAY(CVA6Cfg.DclsDelay)
+        ) i_dcls_logic (
+            .clk_i,
+            .rst_ni,
+            .rst_shadow_no(rst_shadow),
+            .main_inputs_i(main_inputs),
+            .main_inputs_delayed_o(main_inputs_delayed),
+            .main_outputs_i(main_outputs),
+            .shadow_outputs_i(shadow_outputs),
+            .alarm_o(dcls_alarm_o[1:0])
+        );
+        // ********* CORES COMM *********
+        dcls_common_modules_ctrl_t common_from_main, common_from_shadow;
+        dcls_common_modules_data_t common_to_main, common_to_shadow;
+
+        if(CVA6Cfg.DclsCommonModules) begin: gen_dcls_common_modules
+            dcls_common #(
+                .CVA6Cfg      (CVA6Cfg),
+                .regfile_inputs_t    (regfile_inputs_t),
+                .bht_update_t    (bht_update_t),
+                .bht_inputs_t(bht_inputs_t),
+                .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+                .dcls_common_modules_data_t(dcls_common_modules_data_t),
+                .DCLS_DELAY(CVA6Cfg.DclsDelay)
+            ) i_dcls_common_modules (
+                .clk_i,
+                .rst_ni,
+                .from_main_i(common_from_main),
+                .to_main_o(common_to_main),
+                .from_shadow_i(common_from_shadow),
+                .to_shadow_o(common_to_shadow),
+                .alarms_o(dcls_alarm_o[3:2])
+            );
+        end
+        // ********* CORES *********
+        cva6 #(
+            .CVA6Cfg      (CVA6Cfg),
+            .rvfi_probes_t(rvfi_probes_t),
+            .noc_req_t    (noc_req_t),
+            .noc_resp_t   (noc_resp_t),
+            .regfile_inputs_t    (regfile_inputs_t),
+            .bht_inputs_t(bht_inputs_t),
+            .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+            .dcls_common_modules_data_t(dcls_common_modules_data_t)
+        ) i_cva6_main (
+            .clk_i(clk_i),
+            .rst_ni(rst_ni),
+            .boot_addr_i(boot_addr_i),
+            .hart_id_i(hart_id_i),
+            .irq_i(irq_i),
+            .ipi_i(ipi_i),
+            .time_irq_i(time_irq_i),
+            .debug_req_i(debug_req_i),
+            .rvfi_probes_o(rvfi_probes_o),
+            .cvxif_req_o(cvxif_req_o),
+            .cvxif_resp_i(cvxif_resp_i),
+            .noc_req_o(noc_req_o),
+            .noc_resp_i(noc_resp_i),
+            .dcls_from_common_i(common_to_main),
+            .dcls_to_common_o(common_from_main)
+        );
+        cva6 #(
+            .CVA6Cfg      (CVA6Cfg),
+            .rvfi_probes_t(rvfi_probes_t),
+            .noc_req_t    (noc_req_t),
+            .noc_resp_t   (noc_resp_t),
+            .regfile_inputs_t    (regfile_inputs_t),
+            .bht_inputs_t(bht_inputs_t),
+            .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+            .dcls_common_modules_data_t(dcls_common_modules_data_t)
+        ) i_cva6_shadow (
+            .clk_i(clk_i),
+            .rst_ni(rst_shadow),
+            .boot_addr_i(boot_addr_i),
+            .hart_id_i(hart_id_i),
+            .irq_i(main_inputs_delayed.irq),
+            .ipi_i(main_inputs_delayed.ipi),
+            .time_irq_i(main_inputs_delayed.time_irq),
+            .debug_req_i(main_inputs_delayed.debug_req),
+            .rvfi_probes_o(),
+            .cvxif_req_o(shadow_outputs.cvxif_req),
+            .cvxif_resp_i(main_inputs_delayed.cvxif_resp),
+            .noc_req_o(shadow_outputs.noc_req),
+            .noc_resp_i(main_inputs_delayed.noc_resp),
+            .dcls_from_common_i(common_to_shadow),
+            .dcls_to_common_o(common_from_shadow)
+        );
+    end else begin: gen_cva6
+        cva6 #(
+            .CVA6Cfg      (CVA6Cfg),
+            .rvfi_probes_t(rvfi_probes_t),
+            .noc_req_t    (noc_req_t),
+            .noc_resp_t   (noc_resp_t)
+        ) i_cva6 (
+            .clk_i(clk_i),
+            .rst_ni(rst_ni),
+            .boot_addr_i(boot_addr_i),
+            .hart_id_i(hart_id_i),
+            .irq_i(irq_i),
+            .ipi_i(ipi_i),
+            .time_irq_i(time_irq_i),
+            .debug_req_i(debug_req_i),
+            .rvfi_probes_o(rvfi_probes_o),
+            .cvxif_req_o(cvxif_req_o),
+            .cvxif_resp_i(cvxif_resp_i),
+            .noc_req_o(noc_req_o),
+            .noc_resp_i(noc_resp_i),
+            .dcls_from_common_i('0),
+            .dcls_to_common_o()
+        );
+    end
+    endmodule

--- a/core/cva6_top.sv
+++ b/core/cva6_top.sv
@@ -1,0 +1,243 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+`include "rvfi_types.svh"
+`include "cvxif_types.svh"
+`include "ypb_types.svh"
+
+module cva6_top
+  import ariane_pkg::*;
+#(
+    // CVA6 config
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+
+    // RVFI PROBES
+    parameter type rvfi_probes_t = logic,
+
+    // NOC Types AXI bus or several OBI bus
+    parameter type noc_req_t  = logic,
+    parameter type noc_resp_t = logic,
+
+    // CVXIF Types
+    localparam type readregflags_t = `READREGFLAGS_T(CVA6Cfg),
+    localparam type writeregflags_t = `WRITEREGFLAGS_T(CVA6Cfg),
+    localparam type id_t = `ID_T(CVA6Cfg),
+    localparam type hartid_t = `HARTID_T(CVA6Cfg),
+    localparam type x_compressed_req_t = `X_COMPRESSED_REQ_T(CVA6Cfg, hartid_t),
+    localparam type x_compressed_resp_t = `X_COMPRESSED_RESP_T(CVA6Cfg),
+    localparam type x_issue_req_t = `X_ISSUE_REQ_T(CVA6Cfg, hartit_t, id_t),
+    localparam type x_issue_resp_t = `X_ISSUE_RESP_T(CVA6Cfg, writeregflags_t, readregflags_t),
+    localparam type x_register_t = `X_REGISTER_T(CVA6Cfg, hartid_t, id_t, readregflags_t),
+    localparam type x_commit_t = `X_COMMIT_T(CVA6Cfg, hartid_t, id_t),
+    localparam type x_result_t = `X_RESULT_T(CVA6Cfg, hartid_t, id_t, writeregflags_t),
+    localparam type cvxif_req_t =
+    `CVXIF_REQ_T(CVA6Cfg, x_compressed_req_t, x_issue_req_t, x_register_t, x_commit_t),
+    localparam type cvxif_resp_t =
+    `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t),
+    // --- DCLS ---
+    //  Types
+    localparam type core_inputs_t = struct packed {
+      logic [1:0] irq;
+      logic ipi;
+      logic time_irq;
+      logic debug_req;
+      cvxif_resp_t cvxif_resp;
+      noc_resp_t noc_resp;
+    },
+    localparam type core_outputs_t = struct packed {
+      cvxif_req_t cvxif_req;
+      noc_req_t   noc_req;
+    },
+    localparam type regfile_inputs_t = struct packed {
+      logic [CVA6Cfg.NrRgprPorts-1:0][4:0] raddr;
+      logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.XLEN-1:0] wdata;
+      logic [CVA6Cfg.NrCommitPorts-1:0][4:0] waddr;
+      logic [CVA6Cfg.NrCommitPorts-1:0] we;
+    },
+    localparam type bht_update_t = struct packed {
+      logic                    valid;
+      logic [CVA6Cfg.VLEN-1:0] pc;     // update at PC
+      logic                    taken;
+    },
+    localparam type bht_inputs_t = struct packed {
+      logic flush_bp;
+      logic debug_mode;
+      logic [CVA6Cfg.VLEN-1:0] vpc;
+      bht_update_t bht_update;
+    },
+    localparam type dcls_common_modules_ctrl_t = struct packed {
+      regfile_inputs_t regfile_inputs;
+      bht_inputs_t bht_inputs;
+    },
+    localparam type dcls_common_modules_data_t = struct packed {
+      logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] regfile_rdata;
+      bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] bht_prediction;
+    }
+    // -----
+) (
+    // Subsystem Clock - SUBSYSTEM
+    input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
+    input logic rst_ni,
+    // Reset boot address - SUBSYSTEM
+    input logic [CVA6Cfg.VLEN-1:0] boot_addr_i,
+    // Hard ID reflected as CSR - SUBSYSTEM
+    input logic [CVA6Cfg.XLEN-1:0] hart_id_i,
+    // Level sensitive (async) interrupts - SUBSYSTEM
+    input logic [1:0] irq_i,
+    // Inter-processor (async) interrupt - SUBSYSTEM
+    input logic ipi_i,
+    // Timer (async) interrupt - SUBSYSTEM
+    input logic time_irq_i,
+    // Debug (async) request - SUBSYSTEM
+    input logic debug_req_i,
+    // Probes to build RVFI, can be left open when not used - RVFI
+    output rvfi_probes_t rvfi_probes_o,
+    // CVXIF request - SUBSYSTEM
+    output cvxif_req_t cvxif_req_o,
+    // CVXIF response - SUBSYSTEM
+    input cvxif_resp_t cvxif_resp_i,
+    // noc request, can be AXI or OpenPiton - SUBSYSTEM
+    output noc_req_t noc_req_o,
+    // noc response, can be AXI or OpenPiton - SUBSYSTEM
+    input noc_resp_t noc_resp_i,
+    // DCLS alarm
+    output logic [3:0] dcls_alarm_o
+);
+  if (CVA6Cfg.DclsEn) begin : gen_cva6_dcls
+    // ********* CORES IO *********
+    core_inputs_t main_inputs, main_inputs_delayed;
+    core_outputs_t main_outputs, shadow_outputs;
+
+    assign main_inputs  = '{irq_i, ipi_i, time_irq_i, debug_req_i, cvxif_resp_i, noc_resp_i};
+    assign main_outputs = '{cvxif_req_o, noc_req_o};
+    // ********* DCLS CTRL *********
+    logic rst_shadow;
+
+    dcls_logic #(
+        .noc_resp_t(noc_resp_t),
+        .core_inputs_t(core_inputs_t),
+        .core_outputs_t(core_outputs_t),
+        .DCLS_DELAY(CVA6Cfg.DclsDelay)
+    ) i_dcls_logic (
+        .clk_i,
+        .rst_ni,
+        .rst_shadow_no(rst_shadow),
+        .main_inputs_i(main_inputs),
+        .main_inputs_delayed_o(main_inputs_delayed),
+        .main_outputs_i(main_outputs),
+        .shadow_outputs_i(shadow_outputs),
+        .alarm_o(dcls_alarm_o[1:0])
+    );
+    // ********* CORES COMM *********
+    dcls_common_modules_ctrl_t common_from_main, common_from_shadow;
+    dcls_common_modules_data_t common_to_main, common_to_shadow;
+
+    if (CVA6Cfg.DclsCommonModules) begin : gen_dcls_common_modules
+      dcls_common #(
+          .CVA6Cfg                   (CVA6Cfg),
+          .regfile_inputs_t          (regfile_inputs_t),
+          .bht_update_t              (bht_update_t),
+          .bht_inputs_t              (bht_inputs_t),
+          .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+          .dcls_common_modules_data_t(dcls_common_modules_data_t),
+          .DCLS_DELAY                (CVA6Cfg.DclsDelay)
+      ) i_dcls_common_modules (
+          .clk_i,
+          .rst_ni,
+          .from_main_i(common_from_main),
+          .to_main_o(common_to_main),
+          .from_shadow_i(common_from_shadow),
+          .to_shadow_o(common_to_shadow),
+          .alarms_o(dcls_alarm_o[3:2])
+      );
+    end else begin : gen_dcls_no_common_modules
+      assign dcls_alarm_o[3:2] = '0;
+      assign common_to_main = '0;
+      assign common_to_shadow = '0;
+    end
+    // ********* CORES *********
+    cva6 #(
+        .CVA6Cfg                   (CVA6Cfg),
+        .rvfi_probes_t             (rvfi_probes_t),
+        .noc_req_t                 (noc_req_t),
+        .noc_resp_t                (noc_resp_t),
+        .regfile_inputs_t          (regfile_inputs_t),
+        .bht_inputs_t              (bht_inputs_t),
+        .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+        .dcls_common_modules_data_t(dcls_common_modules_data_t)
+    ) i_cva6_main (
+        .clk_i(clk_i),
+        .rst_ni(rst_ni),
+        .boot_addr_i(boot_addr_i),
+        .hart_id_i(hart_id_i),
+        .irq_i(irq_i),
+        .ipi_i(ipi_i),
+        .time_irq_i(time_irq_i),
+        .debug_req_i(debug_req_i),
+        .rvfi_probes_o(rvfi_probes_o),
+        .cvxif_req_o(cvxif_req_o),
+        .cvxif_resp_i(cvxif_resp_i),
+        .noc_req_o(noc_req_o),
+        .noc_resp_i(noc_resp_i),
+        .dcls_from_common_i(common_to_main),
+        .dcls_to_common_o(common_from_main)
+    );
+    cva6 #(
+        .CVA6Cfg                   (CVA6Cfg),
+        .rvfi_probes_t             (rvfi_probes_t),
+        .noc_req_t                 (noc_req_t),
+        .noc_resp_t                (noc_resp_t),
+        .regfile_inputs_t          (regfile_inputs_t),
+        .bht_inputs_t              (bht_inputs_t),
+        .dcls_common_modules_ctrl_t(dcls_common_modules_ctrl_t),
+        .dcls_common_modules_data_t(dcls_common_modules_data_t)
+    ) i_cva6_shadow (
+        .clk_i(clk_i),
+        .rst_ni(rst_shadow),
+        .boot_addr_i(boot_addr_i),
+        .hart_id_i(hart_id_i),
+        .irq_i(main_inputs_delayed.irq),
+        .ipi_i(main_inputs_delayed.ipi),
+        .time_irq_i(main_inputs_delayed.time_irq),
+        .debug_req_i(main_inputs_delayed.debug_req),
+        .rvfi_probes_o(),
+        .cvxif_req_o(shadow_outputs.cvxif_req),
+        .cvxif_resp_i(main_inputs_delayed.cvxif_resp),
+        .noc_req_o(shadow_outputs.noc_req),
+        .noc_resp_i(main_inputs_delayed.noc_resp),
+        .dcls_from_common_i(common_to_shadow),
+        .dcls_to_common_o(common_from_shadow)
+    );
+  end else begin : gen_cva6
+    cva6 #(
+        .CVA6Cfg      (CVA6Cfg),
+        .rvfi_probes_t(rvfi_probes_t),
+        .noc_req_t    (noc_req_t),
+        .noc_resp_t   (noc_resp_t)
+    ) i_cva6 (
+        .clk_i(clk_i),
+        .rst_ni(rst_ni),
+        .boot_addr_i(boot_addr_i),
+        .hart_id_i(hart_id_i),
+        .irq_i(irq_i),
+        .ipi_i(ipi_i),
+        .time_irq_i(time_irq_i),
+        .debug_req_i(debug_req_i),
+        .rvfi_probes_o(rvfi_probes_o),
+        .cvxif_req_o(cvxif_req_o),
+        .cvxif_resp_i(cvxif_resp_i),
+        .noc_req_o(noc_req_o),
+        .noc_resp_i(noc_resp_i),
+        .dcls_from_common_i('0),
+        .dcls_to_common_o()
+    );
+    assign dcls_alarm_o = '0;
+  end
+endmodule

--- a/core/dcls_common.sv
+++ b/core/dcls_common.sv
@@ -1,0 +1,59 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_common #(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type dcls_common_modules_data_t = logic,
+    parameter type dcls_common_modules_ctrl_t = logic,
+    parameter type bht_inputs_t = logic,
+    parameter type regfile_inputs_t = logic,
+    parameter type bht_update_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // MAIN
+    input dcls_common_modules_ctrl_t from_main_i,
+    output dcls_common_modules_data_t to_main_o,
+    // SHADOW
+    input dcls_common_modules_ctrl_t from_shadow_i,
+    output dcls_common_modules_data_t to_shadow_o,
+    // ALARM
+    output logic[1:0] alarms_o
+);
+    if(CVA6Cfg.DclsCommonRegfile) begin: gen_dcls_common_regfile
+        dcls_common_regfile #(
+            .CVA6Cfg      (CVA6Cfg),
+            .regfile_inputs_t(regfile_inputs_t),
+            .DCLS_DELAY(DCLS_DELAY)
+        ) i_dcls_common_regfile (
+            .clk_i,
+            .rst_ni,
+            .main_i(from_main_i.regfile_inputs),
+            .main_o(to_main_o.regfile_rdata),
+            .shadow_i(from_shadow_i.regfile_inputs),
+            .shadow_o(to_shadow_o.regfile_rdata),
+            .alarms_o(alarms_o)
+        );
+    end
+    if(CVA6Cfg.DclsCommonBHT) begin: gen_dcls_common_bht
+        dcls_common_bht #(
+            .CVA6Cfg      (CVA6Cfg),
+            .bht_inputs_t(bht_inputs_t),
+            .bht_update_t(bht_update_t),
+            .DCLS_DELAY(DCLS_DELAY)
+        ) i_dcls_common_bht (
+            .clk_i,
+            .rst_ni,
+            .from_main_i(from_main_i.bht_inputs),
+            .to_main_o(to_main_o.bht_prediction),
+            .to_shadow_o(to_shadow_o.bht_prediction)
+        );
+    end
+endmodule

--- a/core/dcls_common.sv
+++ b/core/dcls_common.sv
@@ -1,0 +1,66 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_common #(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type dcls_common_modules_data_t = logic,
+    parameter type dcls_common_modules_ctrl_t = logic,
+    parameter type bht_inputs_t = logic,
+    parameter type regfile_inputs_t = logic,
+    parameter type bht_update_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // MAIN
+    input dcls_common_modules_ctrl_t from_main_i,
+    output dcls_common_modules_data_t to_main_o,
+    // SHADOW
+    input dcls_common_modules_ctrl_t from_shadow_i,
+    output dcls_common_modules_data_t to_shadow_o,
+    // ALARM
+    output logic [1:0] alarms_o
+);
+  if (CVA6Cfg.DclsCommonRegfile) begin : gen_dcls_common_regfile
+    dcls_common_regfile #(
+        .CVA6Cfg         (CVA6Cfg),
+        .regfile_inputs_t(regfile_inputs_t),
+        .DCLS_DELAY      (DCLS_DELAY)
+    ) i_dcls_common_regfile (
+        .clk_i,
+        .rst_ni,
+        .main_i  (from_main_i.regfile_inputs),
+        .main_o  (to_main_o.regfile_rdata),
+        .shadow_i(from_shadow_i.regfile_inputs),
+        .shadow_o(to_shadow_o.regfile_rdata),
+        .alarms_o(alarms_o)
+    );
+  end else begin : gen_dcls_no_common_regfile
+    assign alarm_o = '0;
+    assign to_main_o.regfile_rdata = '0;
+    assign to_shadow_o.regfile_rdata = '0;
+  end
+  if (CVA6Cfg.DclsCommonBHT) begin : gen_dcls_common_bht
+    dcls_common_bht #(
+        .CVA6Cfg     (CVA6Cfg),
+        .bht_inputs_t(bht_inputs_t),
+        .bht_update_t(bht_update_t),
+        .DCLS_DELAY  (DCLS_DELAY)
+    ) i_dcls_common_bht (
+        .clk_i,
+        .rst_ni,
+        .from_main_i(from_main_i.bht_inputs),
+        .to_main_o  (to_main_o.bht_prediction),
+        .to_shadow_o(to_shadow_o.bht_prediction)
+    );
+  end else begin : gen_dcls_no_common_bht
+    assign to_main_o.bht_prediction   = '0;
+    assign to_shadow_o.bht_prediction = '0;
+  end
+endmodule

--- a/core/dcls_common_bht.sv
+++ b/core/dcls_common_bht.sv
@@ -1,0 +1,47 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_common_bht #(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type bht_inputs_t = logic,
+    parameter type bht_update_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // MAIN
+    input bht_inputs_t from_main_i,
+    output ariane_pkg::bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] to_main_o,
+    // SHADOW
+    output ariane_pkg::bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] to_shadow_o
+);
+  bht #(
+      .CVA6Cfg   (CVA6Cfg),
+      .bht_update_t(bht_update_t),
+      .NR_ENTRIES(CVA6Cfg.BHTEntries)
+  ) i_bht (
+      .clk_i,
+      .rst_ni,
+      .flush_bp_i(from_main_i.flush_bp),
+      .debug_mode_i(from_main_i.debug_mode),
+      .vpc_i(from_main_i.vpc),
+      .bht_update_i(from_main_i.bht_update),
+      .bht_prediction_o(to_main_o)
+  );
+
+  dcls_delay_ff #(
+      .data_t(ariane_pkg::bht_prediction_t[CVA6Cfg.INSTR_PER_FETCH-1:0]),
+      .DCLS_DELAY(DCLS_DELAY)
+  ) i_dcls_bht_output_delay (
+      .clk_i,
+      .rst_ni,
+      .data_i(to_main_o),
+      .data_o(to_shadow_o)
+  );
+endmodule

--- a/core/dcls_common_bht.sv
+++ b/core/dcls_common_bht.sv
@@ -1,0 +1,47 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_common_bht #(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type bht_inputs_t = logic,
+    parameter type bht_update_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // MAIN
+    input bht_inputs_t from_main_i,
+    output ariane_pkg::bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] to_main_o,
+    // SHADOW
+    output ariane_pkg::bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] to_shadow_o
+);
+  bht #(
+      .CVA6Cfg   (CVA6Cfg),
+      .bht_update_t(bht_update_t),
+      .NR_ENTRIES(CVA6Cfg.BHTEntries)
+  ) i_bht (
+      .clk_i,
+      .rst_ni,
+      .flush_bp_i(from_main_i.flush_bp),
+      .debug_mode_i(from_main_i.debug_mode),
+      .vpc_i(from_main_i.vpc),
+      .bht_update_i(from_main_i.bht_update),
+      .bht_prediction_o(to_main_o)
+  );
+
+  shift_reg #(
+      .dtype(ariane_pkg::bht_prediction_t[CVA6Cfg.INSTR_PER_FETCH-1:0]),
+      .Depth(DCLS_DELAY)
+  ) i_dcls_bht_output_delay (
+      .clk_i,
+      .rst_ni,
+      .d_i(to_main_o),
+      .d_o(to_shadow_o)
+  );
+endmodule

--- a/core/dcls_common_regfile.sv
+++ b/core/dcls_common_regfile.sv
@@ -1,0 +1,78 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_common_regfile #(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type regfile_inputs_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // MAIN
+    input regfile_inputs_t main_i,
+    output logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] main_o,
+    // SHADOW
+    input regfile_inputs_t shadow_i,
+    output logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] shadow_o,
+    // ALARMS
+    output logic [1:0] alarms_o
+);
+  // *********** REGFILE **************
+  ariane_regfile #(
+      .CVA6Cfg      (CVA6Cfg),
+      .DATA_WIDTH   (CVA6Cfg.XLEN),
+      .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
+      .ZERO_REG_ZERO(1)
+  ) i_ariane_regfile (
+      .clk_i,
+      .rst_ni,
+      .test_en_i(1'b0),
+      .raddr_i  (main_i.raddr),
+      .rdata_o  (main_o),
+      .waddr_i  (main_i.waddr),
+      .wdata_i  (main_i.wdata),
+      .we_i     (main_i.we)
+  );
+  // *********** DELAY **************
+  regfile_inputs_t main_inputs, main_inputs_delayed;
+
+  assign main_inputs = '{main_i.raddr, main_i.wdata, main_i.waddr, main_i.we};
+
+  shift_reg #(
+      .dtype(regfile_inputs_t),
+      .Depth(DCLS_DELAY)
+  ) i_dcls_regfile_inputs_delay (
+      .clk_i,
+      .rst_ni,
+      .d_i(main_inputs),
+      .d_o(main_inputs_delayed)
+  );
+
+  shift_reg #(
+      .dtype(logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0]),
+      .Depth(DCLS_DELAY)
+  ) i_dcls_regfile_output_delay (
+      .clk_i,
+      .rst_ni,
+      .d_i(main_o),
+      .d_o(shadow_o)
+  );
+  // *********** COMPARISON **************
+  for (genvar i = 0; i < 2; i++) begin : gen_dcls_regfile_comparators
+    dcls_comparator #(
+        .data_t(regfile_inputs_t)
+    ) i_dcls_regfile_comparator (
+        .clk_i,
+        .rst_ni,
+        .main_i  (main_inputs_delayed),
+        .shadow_i(shadow_i),
+        .alarm_o (alarms_o[i])
+    );
+  end
+endmodule

--- a/core/dcls_common_regfile.sv
+++ b/core/dcls_common_regfile.sv
@@ -1,0 +1,92 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_common_regfile #(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type regfile_inputs_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // MAIN
+    input regfile_inputs_t main_i,
+    output logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] main_o,
+    // SHADOW
+    input regfile_inputs_t shadow_i,
+    output logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] shadow_o,
+    // ALARMS
+    output logic [1:0] alarms_o
+);
+    if(CVA6Cfg.DclsCommonRegfile) begin: gen_dcls_common_regfile
+        // *********** REGFILE **************
+        ariane_regfile #(
+            .CVA6Cfg      (CVA6Cfg),
+            .DATA_WIDTH   (CVA6Cfg.XLEN),
+            .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
+            .ZERO_REG_ZERO(1)
+        ) i_ariane_regfile (
+            .clk_i,
+            .rst_ni,
+            .test_en_i(1'b0),
+            .raddr_i  (main_i.raddr),
+            .rdata_o  (main_o),
+            .waddr_i  (main_i.waddr),
+            .wdata_i  (main_i.wdata),
+            .we_i     (main_i.we)
+        );
+        // *********** DELAY **************
+        regfile_inputs_t main_inputs, main_inputs_delayed;
+
+        assign main_inputs = '{
+            main_i.raddr,
+            main_i.wdata,
+            main_i.waddr,
+            main_i.we
+        };
+
+        dcls_delay_ff #(
+            .data_t(regfile_inputs_t),
+            .DCLS_DELAY(DCLS_DELAY)
+        ) i_dcls_regfile_inputs_delay (
+            .clk_i,
+            .rst_ni,
+            .data_i(main_inputs),
+            .data_o(main_inputs_delayed)
+        );
+
+        dcls_delay_ff #(
+            .data_t(logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0]),
+            .DCLS_DELAY(DCLS_DELAY)
+        ) i_dcls_regfile_output_delay (
+            .clk_i,
+            .rst_ni,
+            .data_i(main_o),
+            .data_o(shadow_o)
+        );
+        // *********** COMPARISON **************
+        dcls_comparator #(
+            .data_t(regfile_inputs_t)
+        ) i_dcls_regfile_comparator (
+            .clk_i,
+            .rst_ni,
+            .main_i(main_inputs_delayed),
+            .shadow_i(shadow_i),
+            .alarm_o(alarms_o[0])
+        );
+        dcls_comparator #(
+            .data_t(regfile_inputs_t)
+        ) i_dcls_regfile_comparator_dup (
+            .clk_i,
+            .rst_ni,
+            .main_i(main_inputs_delayed),
+            .shadow_i(shadow_i),
+            .alarm_o(alarms_o[1])
+        );
+    end
+endmodule

--- a/core/dcls_comparator.sv
+++ b/core/dcls_comparator.sv
@@ -1,0 +1,23 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_comparator #(
+    parameter type data_t = logic
+) (
+    input  logic  clk_i,
+    input  logic  rst_ni,
+    input  data_t main_i,
+    input  data_t shadow_i,
+    output logic  alarm_o
+);
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) alarm_o <= '0;
+    else alarm_o <= main_i !== shadow_i;
+  end
+endmodule

--- a/core/dcls_comparator.sv
+++ b/core/dcls_comparator.sv
@@ -1,0 +1,27 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_comparator #(
+    parameter type data_t = logic
+) (
+    input  logic  clk_i,
+    input  logic  rst_ni,
+    input  data_t main_i,
+    input  data_t shadow_i,
+    output logic  alarm_o
+);
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) alarm_o <= '0;
+    else
+      case (main_i)
+        shadow_i: alarm_o <= '0;
+        default:  alarm_o <= '1;
+      endcase
+  end
+endmodule

--- a/core/dcls_delay_ff.sv
+++ b/core/dcls_delay_ff.sv
@@ -1,0 +1,33 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_delay_ff #(
+    parameter type data_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input  logic  clk_i,
+    input  logic  rst_ni,
+    input  data_t data_i,
+    output data_t data_o
+);
+  data_t [DCLS_DELAY-1 : 0] data_n;
+
+  assign data_o = data_n[DCLS_DELAY-1];
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      data_n <= '{default: 0};
+    end else begin
+      data_n[0] <= data_i;
+      for (int i = 1; i < DCLS_DELAY; i++) begin
+        data_n[i] <= data_n[i-1];
+      end
+    end
+  end
+endmodule

--- a/core/dcls_logic.sv
+++ b/core/dcls_logic.sv
@@ -1,0 +1,81 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_logic #(
+    parameter type noc_resp_t = logic,
+    parameter type core_inputs_t = logic,
+    parameter type core_outputs_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // RESETS
+    output logic rst_shadow_no,
+    // Core inputs
+    input core_inputs_t main_inputs_i,
+    output core_inputs_t main_inputs_delayed_o,
+    // Core outputs
+    input core_outputs_t main_outputs_i,
+    input core_outputs_t shadow_outputs_i,
+    // Alarms
+    output logic [1:0] alarm_o
+);
+  // SHADOW CORE RESET GEN
+  dcls_delay_ff #(
+      .data_t(logic),
+      .DCLS_DELAY(DCLS_DELAY)
+  ) i_dcls_shadow_rst_gen (
+      .clk_i,
+      .rst_ni(rst_ni),
+      .data_i(rst_ni),
+      .data_o(rst_shadow_no)
+  );
+  // INPUTS DELAY
+  dcls_delay_ff #(
+      .data_t(core_inputs_t),
+      .DCLS_DELAY(DCLS_DELAY)
+  ) i_dcls_input_delay (
+      .clk_i,
+      .rst_ni(rst_ni),
+      .data_i(main_inputs_i),
+      .data_o(main_inputs_delayed_o)
+  );
+  // OUTPUTS DELAY
+  core_outputs_t main_outputs_delayed, main_outputs_delayed_dup;
+
+  dcls_delay_ff #(
+      .data_t(core_outputs_t),
+      .DCLS_DELAY(DCLS_DELAY)
+  ) i_dcls_output_delay (
+      .clk_i,
+      .rst_ni(rst_ni),
+      .data_i(main_outputs_i),
+      .data_o(main_outputs_delayed)
+  );
+  // ALARMS
+  dcls_comparator #(
+      .data_t(core_outputs_t)
+  ) i_dcls_comparator (
+      .clk_i,
+      .rst_ni  (rst_shadow_no),
+      .main_i  (main_outputs_delayed),
+      .shadow_i(shadow_outputs_i),
+      .alarm_o (alarm_o[0])
+  );
+  dcls_comparator #(
+      .data_t(core_outputs_t)
+  ) i_dcls_comparator_dup (
+      .clk_i,
+      .rst_ni  (rst_shadow_no),
+      .main_i  (main_outputs_delayed),
+      .shadow_i(shadow_outputs_i),
+      .alarm_o (alarm_o[1])
+  );
+
+endmodule

--- a/core/dcls_logic.sv
+++ b/core/dcls_logic.sv
@@ -1,0 +1,73 @@
+// Copyright 2026 Thales France
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Valentin Thomazic (valentin.thomazic@thalesgroup.com)
+
+module dcls_logic #(
+    parameter type noc_resp_t = logic,
+    parameter type core_inputs_t = logic,
+    parameter type core_outputs_t = logic,
+    parameter int unsigned DCLS_DELAY = 1
+) (
+    input logic clk_i,
+    input logic rst_ni,
+    // RESETS
+    output logic rst_shadow_no,
+    // Core inputs
+    input core_inputs_t main_inputs_i,
+    output core_inputs_t main_inputs_delayed_o,
+    // Core outputs
+    input core_outputs_t main_outputs_i,
+    input core_outputs_t shadow_outputs_i,
+    // Alarms
+    output logic [1:0] alarm_o
+);
+  // SHADOW CORE RESET GEN
+  shift_reg #(
+      .dtype(logic),
+      .Depth(DCLS_DELAY)
+  ) i_dcls_shadow_rst_gen (
+      .clk_i,
+      .rst_ni(rst_ni),
+      .d_i(rst_ni),
+      .d_o(rst_shadow_no)
+  );
+  // INPUTS DELAY
+  shift_reg #(
+      .dtype(core_inputs_t),
+      .Depth(DCLS_DELAY)
+  ) i_dcls_input_delay (
+      .clk_i,
+      .rst_ni(rst_ni),
+      .d_i(main_inputs_i),
+      .d_o(main_inputs_delayed_o)
+  );
+  // OUTPUTS DELAY
+  core_outputs_t main_outputs_delayed, main_outputs_delayed_dup;
+
+  shift_reg #(
+      .dtype(core_outputs_t),
+      .Depth(DCLS_DELAY)
+  ) i_dcls_output_delay (
+      .clk_i,
+      .rst_ni(rst_ni),
+      .d_i(main_outputs_i),
+      .d_o(main_outputs_delayed)
+  );
+  // ALARMS
+  for (genvar i = 0; i < 2; i++) begin : gen_dcls_output_comparators
+    dcls_comparator #(
+        .data_t(core_outputs_t)
+    ) i_dcls_comparator (
+        .clk_i,
+        .rst_ni  (rst_shadow_no),
+        .main_i  (main_outputs_delayed),
+        .shadow_i(shadow_outputs_i),
+        .alarm_o (alarm_o[i])
+    );
+  end
+endmodule

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -815,16 +815,11 @@ module frontend
   if (CVA6Cfg.BHTEntries == 0) begin
     assign bht_prediction = '0;
   end else begin : bht_gen
-    if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonBHT) begin: gen_common_bht
+    if (CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonBHT) begin : gen_common_bht
       assign bht_prediction = dcls_common_bht_data_i;
 
-      assign dcls_common_bht_ctrl_o = '{
-          flush_bp_i,
-          debug_mode_i,
-          vpc_bht,
-          bht_update
-        };
-    end else begin: gen_no_common_bht
+      assign dcls_common_bht_ctrl_o = '{flush_bp_i, debug_mode_i, vpc_bht, bht_update};
+    end else begin : gen_no_common_bht
       bht #(
           .CVA6Cfg   (CVA6Cfg),
           .bht_update_t(bht_update_t),

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -27,7 +27,8 @@ module frontend
     parameter type fetch_areq_t = logic,
     parameter type fetch_arsp_t = logic,
     parameter type ypb_fetch_req_t = logic,
-    parameter type ypb_fetch_rsp_t = logic
+    parameter type ypb_fetch_rsp_t = logic,
+    parameter type bht_inputs_t = logic
 ) (
     // Subsystem Clock - SUBSYSTEM
     input logic clk_i,
@@ -72,7 +73,10 @@ module frontend
     // Handshake's valid between fetch and decode - ID_STAGE
     output logic [CVA6Cfg.NrIssuePorts-1:0] fetch_entry_valid_o,
     // Handshake's ready between fetch and decode - ID_STAGE
-    input logic [CVA6Cfg.NrIssuePorts-1:0] fetch_entry_ready_i
+    input logic [CVA6Cfg.NrIssuePorts-1:0] fetch_entry_ready_i,
+    // DCLS
+    input bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] dcls_common_bht_data_i,
+    output bht_inputs_t dcls_common_bht_ctrl_o
 );
 
   localparam type bht_update_t = struct packed {
@@ -811,19 +815,30 @@ module frontend
   if (CVA6Cfg.BHTEntries == 0) begin
     assign bht_prediction = '0;
   end else begin : bht_gen
-    bht #(
-        .CVA6Cfg   (CVA6Cfg),
-        .bht_update_t(bht_update_t),
-        .NR_ENTRIES(CVA6Cfg.BHTEntries)
-    ) i_bht (
-        .clk_i,
-        .rst_ni,
-        .flush_bp_i      (flush_bp_i),
-        .debug_mode_i,
-        .vpc_i           (vpc_bht),
-        .bht_update_i    (bht_update),
-        .bht_prediction_o(bht_prediction)
-    );
+    if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonBHT) begin: gen_common_bht
+      assign bht_prediction = dcls_common_bht_data_i;
+
+      assign dcls_common_bht_ctrl_o = '{
+          flush_bp_i,
+          debug_mode_i,
+          vpc_bht,
+          bht_update
+        };
+    end else begin: gen_no_common_bht
+      bht #(
+          .CVA6Cfg   (CVA6Cfg),
+          .bht_update_t(bht_update_t),
+          .NR_ENTRIES(CVA6Cfg.BHTEntries)
+      ) i_bht (
+          .clk_i,
+          .rst_ni,
+          .flush_bp_i      (flush_bp_i),
+          .debug_mode_i,
+          .vpc_i           (vpc_bht),
+          .bht_update_i    (bht_update),
+          .bht_prediction_o(bht_prediction)
+      );
+    end
   end
 
   // we need to inspect up to CVA6Cfg.INSTR_PER_FETCH instructions for branches

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -27,7 +27,8 @@ module frontend
     parameter type fetch_areq_t = logic,
     parameter type fetch_arsp_t = logic,
     parameter type ypb_fetch_req_t = logic,
-    parameter type ypb_fetch_rsp_t = logic
+    parameter type ypb_fetch_rsp_t = logic,
+    parameter type bht_inputs_t = logic
 ) (
     // Subsystem Clock - SUBSYSTEM
     input logic clk_i,
@@ -72,7 +73,10 @@ module frontend
     // Handshake's valid between fetch and decode - ID_STAGE
     output logic [CVA6Cfg.NrIssuePorts-1:0] fetch_entry_valid_o,
     // Handshake's ready between fetch and decode - ID_STAGE
-    input logic [CVA6Cfg.NrIssuePorts-1:0] fetch_entry_ready_i
+    input logic [CVA6Cfg.NrIssuePorts-1:0] fetch_entry_ready_i,
+    // DCLS
+    input bht_prediction_t [CVA6Cfg.INSTR_PER_FETCH-1:0] dcls_common_bht_data_i,
+    output bht_inputs_t dcls_common_bht_ctrl_o
 );
 
   localparam type bht_update_t = struct packed {
@@ -813,19 +817,30 @@ module frontend
   if (CVA6Cfg.BHTEntries == 0) begin
     assign bht_prediction = '0;
   end else begin : bht_gen
-    bht #(
-        .CVA6Cfg   (CVA6Cfg),
-        .bht_update_t(bht_update_t),
-        .NR_ENTRIES(CVA6Cfg.BHTEntries)
-    ) i_bht (
-        .clk_i,
-        .rst_ni,
-        .flush_bp_i      (flush_bp_i),
-        .debug_mode_i,
-        .vpc_i           (vpc_bht),
-        .bht_update_i    (bht_update),
-        .bht_prediction_o(bht_prediction)
-    );
+    if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonBHT) begin: gen_common_bht
+      assign bht_prediction = dcls_common_bht_data_i;
+
+      assign dcls_common_bht_ctrl_o = '{
+          flush_bp_i,
+          debug_mode_i,
+          vpc_bht,
+          bht_update
+        };
+    end else begin: gen_no_common_bht
+      bht #(
+          .CVA6Cfg   (CVA6Cfg),
+          .bht_update_t(bht_update_t),
+          .NR_ENTRIES(CVA6Cfg.BHTEntries)
+      ) i_bht (
+          .clk_i,
+          .rst_ni,
+          .flush_bp_i      (flush_bp_i),
+          .debug_mode_i,
+          .vpc_i           (vpc_bht),
+          .bht_update_i    (bht_update),
+          .bht_prediction_o(bht_prediction)
+      );
+    end
   end
 
   // we need to inspect up to CVA6Cfg.INSTR_PER_FETCH instructions for branches

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -300,6 +300,12 @@ package build_config_pkg;
 
     cfg.PipelineOnly = CVA6Cfg.PipelineOnly;
 
+    cfg.DclsEn = CVA6Cfg.DclsEn;
+    cfg.DclsDelay = CVA6Cfg.DclsDelay;
+    cfg.DclsCommonRegfile = CVA6Cfg.DclsCommonRegfile;
+    cfg.DclsCommonBHT = CVA6Cfg.DclsCommonBHT;
+    cfg.DclsCommonModules = CVA6Cfg.DclsCommonBHT | CVA6Cfg.DclsCommonRegfile;
+
     return cfg;
   endfunction
 

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -237,6 +237,12 @@ package config_pkg;
     int unsigned                 ObiVersion;
     // Configuration defines cva6_pipeline module as top instead of cva6 (no cache and OBI instead of AXI)
     bit                          PipelineOnly;
+    // DCLS parameters
+    bit                          DclsEn;
+    // Number of cycles o
+    int unsigned                 DclsDelay;
+    bit                          DclsCommonRegfile;
+    bit                          DclsCommonBHT;
   } cva6_user_cfg_t;
 
   typedef struct packed {
@@ -408,6 +414,12 @@ package config_pkg;
     obi_pkg::obi_cfg_t ObiZcmtbusCfg;
 
     bit PipelineOnly;
+
+    bit DclsEn;
+    int unsigned DclsDelay;
+    bit DclsCommonRegfile;
+    bit DclsCommonBHT;
+    bit DclsCommonModules;
   } cva6_cfg_t;
 
   /// Empty configuration to sanity check proper parameter passing. Whenever

--- a/core/include/cv32a60x_no_zcmt_axi_config_pkg.sv
+++ b/core/include/cv32a60x_no_zcmt_axi_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a60x_no_zcmt_axi_config_pkg.sv
+++ b/core/include/cv32a60x_no_zcmt_axi_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a60x_no_zcmt_config_pkg.sv
+++ b/core/include/cv32a60x_no_zcmt_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a60x_no_zcmt_config_pkg.sv
+++ b/core/include/cv32a60x_no_zcmt_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a65x_noPMP_noSuperScalar_axi_config_pkg.sv
+++ b/core/include/cv32a65x_noPMP_noSuperScalar_axi_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a65x_noPMP_noSuperScalar_axi_config_pkg.sv
+++ b/core/include/cv32a65x_noPMP_noSuperScalar_axi_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a65x_noPMP_noSuperScalar_config_pkg.sv
+++ b/core/include/cv32a65x_noPMP_noSuperScalar_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a65x_noPMP_noSuperScalar_config_pkg.sv
+++ b/core/include/cv32a65x_noPMP_noSuperScalar_config_pkg.sv
@@ -105,7 +105,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/cv32a6_embedded_config_pkg_deprecated.sv
@@ -158,7 +158,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(1),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/cv32a6_embedded_config_pkg_deprecated.sv
@@ -158,7 +158,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(1),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -106,7 +106,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -155,6 +155,10 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -155,6 +155,10 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -156,7 +156,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -156,7 +156,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -161,7 +161,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -161,7 +161,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_obi_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_obi_config_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_obi_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_obi_config_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(1)
+      PipelineOnly: bit'(1),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -164,7 +164,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -159,7 +159,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -159,6 +159,10 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -159,6 +159,10 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 endpackage

--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -112,7 +112,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(1),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -112,7 +112,11 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       ObiVersion: int'(config_pkg::OBI_V1_6),
-      PipelineOnly: bit'(0)
+      PipelineOnly: bit'(0),
+      DclsEn: bit'(0),
+      DclsDelay : unsigned'(2),
+      DclsCommonRegfile: bit'(0),
+      DclsCommonBHT: bit'(0)
   };
 
 endpackage

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -1013,30 +1013,25 @@ module issue_read_operands
         .we_i     (we_pack)
     );
   end else begin : gen_asic_regfile
-    if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonRegfile) begin: gen_dcls_common_regfile_dup
+    if (CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonRegfile) begin : gen_dcls_common_regfile_dup
       assign rdata = dcls_common_regfile_data_i;
-      assign dcls_common_regfile_ctrl_o = '{
-          raddr_pack,
-          wdata_pack,
-          waddr_pack,
-          we_pack
-      };
+      assign dcls_common_regfile_ctrl_o = '{raddr_pack, wdata_pack, waddr_pack, we_pack};
     end else begin
-        ariane_regfile #(
-            .CVA6Cfg      (CVA6Cfg),
-            .DATA_WIDTH   (CVA6Cfg.XLEN),
-            .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
-            .ZERO_REG_ZERO(1)
-        ) i_ariane_regfile (
-            .clk_i,
-            .rst_ni,
-            .test_en_i(1'b0),
-            .raddr_i  (raddr_pack),
-            .rdata_o  (rdata),
-            .waddr_i  (waddr_pack),
-            .wdata_i  (wdata_pack),
-            .we_i     (we_pack)
-        );
+      ariane_regfile #(
+          .CVA6Cfg      (CVA6Cfg),
+          .DATA_WIDTH   (CVA6Cfg.XLEN),
+          .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
+          .ZERO_REG_ZERO(1)
+      ) i_ariane_regfile (
+          .clk_i,
+          .rst_ni,
+          .test_en_i(1'b0),
+          .raddr_i  (raddr_pack),
+          .rdata_o  (rdata),
+          .waddr_i  (waddr_pack),
+          .wdata_i  (wdata_pack),
+          .we_i     (we_pack)
+      );
     end
   end
 

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -28,7 +28,8 @@ module issue_read_operands
     parameter type x_issue_req_t = logic,
     parameter type x_issue_resp_t = logic,
     parameter type x_register_t = logic,
-    parameter type x_commit_t = logic
+    parameter type x_commit_t = logic,
+    parameter type regfile_inputs_t = logic
 ) (
     // Subsystem Clock - SUBSYSTEM
     input logic clk_i,
@@ -131,7 +132,10 @@ module issue_read_operands
     // Information dedicated to RVFI - RVFI
     output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs2_o,
     // Original instruction bits for AES
-    output logic [5:0] orig_instr_aes_bits
+    output logic [5:0] orig_instr_aes_bits,
+    // DCLS
+    input logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] dcls_common_regfile_data_i,
+    output regfile_inputs_t dcls_common_regfile_ctrl_o
 );
 
   localparam OPERANDS_PER_INSTR = CVA6Cfg.NrRgprPorts / CVA6Cfg.NrIssuePorts;
@@ -1009,21 +1013,31 @@ module issue_read_operands
         .we_i     (we_pack)
     );
   end else begin : gen_asic_regfile
-    ariane_regfile #(
-        .CVA6Cfg      (CVA6Cfg),
-        .DATA_WIDTH   (CVA6Cfg.XLEN),
-        .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
-        .ZERO_REG_ZERO(1)
-    ) i_ariane_regfile (
-        .clk_i,
-        .rst_ni,
-        .test_en_i(1'b0),
-        .raddr_i  (raddr_pack),
-        .rdata_o  (rdata),
-        .waddr_i  (waddr_pack),
-        .wdata_i  (wdata_pack),
-        .we_i     (we_pack)
-    );
+    if(CVA6Cfg.DclsEn & CVA6Cfg.DclsCommonRegfile) begin: gen_dcls_common_regfile_dup
+      assign rdata = dcls_common_regfile_data_i;
+      assign dcls_common_regfile_ctrl_o = '{
+          raddr_pack,
+          wdata_pack,
+          waddr_pack,
+          we_pack
+      };
+    end else begin
+        ariane_regfile #(
+            .CVA6Cfg      (CVA6Cfg),
+            .DATA_WIDTH   (CVA6Cfg.XLEN),
+            .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
+            .ZERO_REG_ZERO(1)
+        ) i_ariane_regfile (
+            .clk_i,
+            .rst_ni,
+            .test_en_i(1'b0),
+            .raddr_i  (raddr_pack),
+            .rdata_o  (rdata),
+            .waddr_i  (waddr_pack),
+            .wdata_i  (wdata_pack),
+            .we_i     (we_pack)
+        );
+    end
   end
 
   // -----------------------------

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -27,7 +27,8 @@ module issue_stage
     parameter type x_issue_req_t = logic,
     parameter type x_issue_resp_t = logic,
     parameter type x_register_t = logic,
-    parameter type x_commit_t = logic
+    parameter type x_commit_t = logic,
+    parameter type regfile_inputs_t = logic
 ) (
     // Subsystem Clock - SUBSYSTEM
     input logic clk_i,
@@ -167,7 +168,10 @@ module issue_stage
     // Information dedicated to RVFI - RVFI
     output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs2_o,
     // Original instruction bits for AES
-    output logic [5:0] orig_instr_aes_bits
+    output logic [5:0] orig_instr_aes_bits,
+    // DCLS
+    input logic [CVA6Cfg.NrRgprPorts-1:0][CVA6Cfg.XLEN-1:0] dcls_common_regfile_data_i,
+    output regfile_inputs_t dcls_common_regfile_ctrl_o
 );
   // ---------------------------------------------------
   // Scoreboard (SB) <-> Issue and Read Operands (IRO)
@@ -249,7 +253,8 @@ module issue_stage
       .x_issue_req_t(x_issue_req_t),
       .x_issue_resp_t(x_issue_resp_t),
       .x_register_t(x_register_t),
-      .x_commit_t(x_commit_t)
+      .x_commit_t(x_commit_t),
+      .regfile_inputs_t    (regfile_inputs_t)
   ) i_issue_read_operands (
       .clk_i,
       .rst_ni,
@@ -306,7 +311,9 @@ module issue_stage
       .stall_issue_o,
       .rvfi_rs1_o              (rvfi_rs1_o),
       .rvfi_rs2_o              (rvfi_rs2_o),
-      .orig_instr_aes_bits     (orig_instr_aes_bits)
+      .orig_instr_aes_bits     (orig_instr_aes_bits),
+      .dcls_common_regfile_data_i,
+      .dcls_common_regfile_ctrl_o
   );
 
 endmodule

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -243,18 +243,18 @@ module issue_stage
   // 3. Issue instruction and read operand, also commit
   // ---------------------------------------------------------
   issue_read_operands #(
-      .CVA6Cfg(CVA6Cfg),
+      .CVA6Cfg            (CVA6Cfg),
       .branchpredict_sbe_t(branchpredict_sbe_t),
-      .fu_data_t(fu_data_t),
-      .scoreboard_entry_t(scoreboard_entry_t),
-      .rs3_len_t(rs3_len_t),
-      .writeback_t(writeback_t),
-      .forwarding_t(forwarding_t),
-      .x_issue_req_t(x_issue_req_t),
-      .x_issue_resp_t(x_issue_resp_t),
-      .x_register_t(x_register_t),
-      .x_commit_t(x_commit_t),
-      .regfile_inputs_t    (regfile_inputs_t)
+      .fu_data_t          (fu_data_t),
+      .scoreboard_entry_t (scoreboard_entry_t),
+      .rs3_len_t          (rs3_len_t),
+      .writeback_t        (writeback_t),
+      .forwarding_t       (forwarding_t),
+      .x_issue_req_t      (x_issue_req_t),
+      .x_issue_resp_t     (x_issue_resp_t),
+      .x_register_t       (x_register_t),
+      .x_commit_t         (x_commit_t),
+      .regfile_inputs_t   (regfile_inputs_t)
   ) i_issue_read_operands (
       .clk_i,
       .rst_ni,

--- a/flows/recipes/dc_shell_synth.py
+++ b/flows/recipes/dc_shell_synth.py
@@ -163,7 +163,7 @@ def dc_shell_synth(
     env_vars = {
         "TOP": "cva6",
         "TOP_ELABORATE": top_elaborate,
-        "TOP_SYNTHESIS": "cva6__*",
+        "TOP_SYNTHESIS": "cva6_top__*",
         "TARGET": target,
         "TARGET_CFG": target,
         "CVA6_REPO_DIR": str(repo_dir),

--- a/verif/tb/uvmt/cva6_tb_wrapper.sv
+++ b/verif/tb/uvmt/cva6_tb_wrapper.sv
@@ -159,6 +159,8 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
   static uvm_cmdline_processor uvcl = uvm_cmdline_processor::get_inst();
   string binary = "";
 
+  // DCLS ALARMS
+  logic [3:0] dcls_alarm;
 
   // DUT 
 
@@ -170,7 +172,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
     // TODO Is AXI agent in passive mode is required anymore in this testbench?
     assign axi_ariane_req = noc_axi_req;
 
-    cva6 #(
+    cva6_top #(
         .CVA6Cfg      (CVA6Cfg),
         .rvfi_probes_t(rvfi_probes_t),
         .noc_req_t    (noc_axi_req_t),
@@ -188,7 +190,8 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
         .cvxif_req_o(cvxif_req),
         .cvxif_resp_i(cvxif_resp),
         .noc_req_o(noc_axi_req),
-        .noc_resp_i(noc_axi_resp)
+        .noc_resp_i(noc_axi_resp),
+        .dcls_alarm_o(dcls_alarm)
     );
 
     //Response structs
@@ -294,7 +297,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
     assign noc_obi_resp.obi_mmu_ptw_rsp = obi_mmu_ptw_rsp;
     assign noc_obi_resp.obi_zcmt_rsp = obi_zcmt_rsp;
 
-    cva6 #(
+    cva6_top #(
         .CVA6Cfg      (CVA6Cfg),
         .rvfi_probes_t(rvfi_probes_t),
         .noc_req_t    (noc_obi_req_t),
@@ -312,7 +315,8 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
         .cvxif_req_o(cvxif_req),
         .cvxif_resp_i(cvxif_resp),
         .noc_req_o(noc_obi_req),
-        .noc_resp_i(noc_obi_resp)
+        .noc_resp_i(noc_obi_resp),
+        .dcls_alarm_o(dcls_alarm)
     );
 
     assign obi_fetch_slave.req               = obi_fetch_req.req;


### PR DESCRIPTION
Proposed base of work for common DCLS implementation.

Elaboration top becomes **cva6_top** which instantiate either a single CVA6 or a CVA6 DCLS with its logic control.

The \`dcls_logic\` module shifts the main core inputs by a configurable delay to drive the shadow core. it also performs the core outputs comparison.

The \`dcls_common\` instantiates common modules depending on whether they are configured to be shared or not. Both cores either instantiate the module or send their control signals and receive data from the dcls common modules at the top.

It compares the received control inputs from both cores and outputs and send the result to the cores, shifted by n cycles for the shadow core.

The comparators output synchronous alarms.

Current options are:

* Configurable delay between the 2 cores
* Common Regfile (without integrity or error correction)
* Common BHT

Target **cv32a60x** is set with:

* 2 Cycle of delay
* Common Regfile & Common BHT

Others configurations are left unchanged and function as before