### PR TITLE
cva6_ptw: reject A/D/U in non-leaf PTEs

### DIFF
--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -577,9 +577,9 @@ module cva6_ptw
                   endcase
                 end else ptw_pptr_n = {pte.ppn, vaddr_lvl[0][ptw_lvl_q[0]], (CVA6Cfg.PtLevels)'(0)};
 
-                if (CVA6Cfg.RVH && (pte.a || pte.d || pte.u)) begin
+                if (pte.a || pte.d || pte.u) begin
                   state_d = PROPAGATE_ERROR;
-                  ptw_stage_d = ptw_stage_q;
+                  if (CVA6Cfg.RVH) ptw_stage_d = ptw_stage_q;
                 end
 
               end


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why is this PR needed?

Fixes #3420.

The PTW checked the reserved A, D, and U bits of a non-leaf PTE only when CVA6Cfg.RVH=1.

with RVH=0, the check was skipped and the PTW could follow the malformed PTE to the next page-table level instead of raising a page fault. This affects paged-MMU configurations without the H extension, including cv64a6_imafdc_sv39.

[the RISC-V address-translation algorithm](https://docs.riscv.org/reference/isa/v20260120/priv/supervisor.html#sv32algorithm) requires a page fault when reserved PTE bits are set. It reserves A, D, and U in non-leaf PTEs regardless of the H extension.

## What changed?

The `A`/`D`/`U` check is now unconditional. The stage assignment remains conditional because it is only used with the H extension. At `RVH=0`, leaving out the explicit assignment has no effect because `ptw_stage_d` already defaults to `ptw_stage_q` earlier in the same `always_comb`.

There is no behavior change when `RVH=1`. When `RVH=0`, the malformed PTE now transitions to `PROPAGATE_ERROR`.

## Verification

Two PTW properties were checked with symbiYosys and Boolector on cv64a6_imafdc_sv39 at e4184b66:

```systemverilog
!bad_nonleaf || state_d == PROPAGATE_ERROR
!bad_nonleaf || state_d != WAIT_GRANT
```
 `bad_nonleaf` means the PTW is consuming a PTE in `PTE_LOOKUP`: `rvalid` is asserted, no flush is active, PMP allows the access, the PTE passes the existing invalid-PTE check, `R=X=0`, at least one of `A`/`D`/`U` is set, and another page-table level is available.

| Check                  | Unpatched                | Patched   |
| ---------------------- | ------------------------ | --------- |
| BMC                    | reachable counterexample | passes    |
| Induction              | fails                    | passes    |
| Malformed descent case | reachable                | reachable |

Both runs use the same base commit and differ only by this RTL change. The malformed case remains reachable after the patch, but the PTW can no longer continue the walk from it.

commands, logs and traces: [formal evidence](https://github.com/codeadpool/cva6-priv-sva/tree/cdb9fbfa25f8c4c3377ec56db929ec61393e4fba)


## Limitations

The formal checks are block-level, use an `RVH=0` configuration, and do not include an in-repository directed regression.

the existing `verif/tests/custom/sv32/vm_nonleaf_pte.S` does not cover this case because its intermediate PTE contains only `PTE_V`.