### PR TITLE
Integration of Error Correction Mechanisms of the HPDcache with the CVA6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,8 @@ incdir := $(CVA6_REPO_DIR)/vendor/pulp-platform/common_cells/include/ $(CVA6_REP
           $(CVA6_REPO_DIR)/verif/core-v-verif/lib/uvm_agents/uvma_core_cntrl/ \
           $(CVA6_REPO_DIR)/verif/tb/core/ \
           $(CVA6_REPO_DIR)/core/include/ \
+          $(HPDCACHE_DIR)/rtl/include \
+          $(HPDCACHE_DIR)/rtl/src/utils/ecc \
           $(CVA6_REPO_DIR)/corev_apu/instr_tracing/ITI/include \
           $(SPIKE_INSTALL_DIR)/include/disasm/
 
@@ -533,6 +535,8 @@ XRUN_RUN_LOG       ?= xrun_run.log
 CVA6_HOME	   ?= $(realpath -s $(root-dir))
 
 XRUN_INCDIR :=+incdir+$(CVA6_HOME)/core/include 			\
+	+incdir+$(HPDCACHE_DIR)/rtl/include				\
+	+incdir+$(HPDCACHE_DIR)/rtl/src/utils/ecc			\
 	+incdir+$(CVA6_HOME)/vendor/pulp-platform/axi/include/		\
 	+incdir+$(CVA6_HOME)/corev_apu/register_interface/include
 

--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -37,6 +37,7 @@ ${CVA6_REPO_DIR}/vendor/pulp-platform/fpga-support/rtl/SyncDpRam_ind_r_w.sv
 +incdir+${CVA6_REPO_DIR}/vendor/pulp-platform/common_cells/src/
 +incdir+${CVA6_REPO_DIR}/vendor/pulp-platform/axi/include/
 +incdir+${CVA6_REPO_DIR}/common/local/util/
++incdir+${HPDCACHE_DIR}/rtl/src/utils/ecc
 
 // Floating point unit
 ${CVA6_REPO_DIR}/core/cvfpu/src/fpnew_pkg.sv
@@ -198,6 +199,15 @@ ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_icache_axi_wrapper.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/std_cache_subsystem.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/std_nbdcache.sv
 -F ${HPDCACHE_DIR}/rtl/hpdcache.Flist
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_36_29_dec.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_36_29_enc.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_39_32_dec.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_39_32_enc.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_55_48_dec.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_55_48_enc.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_72_64_dec.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_72_64_enc.sv
+${HPDCACHE_DIR}/rtl/src/utils/ecc/prim_secded_pkg.sv
 ${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_resp_demux.sv
 ${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_to_axi_read.sv
 ${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_to_axi_write.sv
@@ -209,6 +219,9 @@ ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_wrapper.sv
 ${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_1rw.sv
 ${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_wbyteenable_1rw.sv
 ${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_wmask_1rw.sv
+${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_ecc_1rw.sv
+${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_wbyteenable_ecc_1rw.sv
+${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_wmask_ecc_1rw.sv
 
 // Physical Memory Protection
 // NOTE: pmp.sv modified for DSIM (unchanged for other simulators)

--- a/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
@@ -113,6 +113,7 @@ module cva6_hpdcache_if_adapter
       assign cva6_req_o.data_rvalid = hpdcache_rsp_valid_i;
       assign cva6_req_o.data_rdata = hpdcache_rsp_i.rdata;
       assign cva6_req_o.data_rid = hpdcache_rsp_i.tid;
+      assign cva6_req_o.data_error = hpdcache_rsp_i.error;
       assign cva6_req_o.data_gnt = hpdcache_req_ready_i;
 
       //  Assertions

--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -532,12 +532,6 @@ module cva6_hpdcache_subsystem
   //  {{{
   //  pragma translate_off
   initial begin : initial_assertions
-    assert (HPDcacheCfg.u.reqSrcIdWidth >= $clog2(HPDcacheCfg.u.nRequesters))
-    else $fatal(1, "HPDCACHE_REQ_SRC_ID_WIDTH is not wide enough");
-    assert (CVA6Cfg.MEM_TID_WIDTH >= ($clog2(HPDcacheCfg.u.mshrSets * HPDcacheCfg.u.mshrWays) + 1))
-    else $fatal(1, "MEM_TID_WIDTH shall allow to uniquely identify all D$ and I$ miss requests ");
-    assert (CVA6Cfg.MEM_TID_WIDTH >= ($clog2(HPDcacheCfg.u.wbufDirEntries) + 1))
-    else $fatal(1, "MEM_TID_WIDTH shall allow to uniquely identify all D$ write requests ");
     assert (CVA6Cfg.MEM_TID_WIDTH <= CVA6Cfg.AxiIdWidth)
     else $fatal(1, "MEM_TID_WIDTH shall be less or equal to the AxiIdWidth");
   end

--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -229,8 +229,8 @@ module cva6_hpdcache_subsystem
         (CVA6Cfg.DCacheType == config_pkg::HPDCACHE_WB) ||
         (CVA6Cfg.DCacheType == config_pkg::HPDCACHE_WT_WB);
     userCfg.lowLatency = 1'b1;
-    userCfg.eccEn = 1'b0;  /*FIXME add additional CVA6 parameter*/
-    userCfg.eccScrubberEn = 1'b0;  /*FIXME: add additional CVA6 parameter*/
+    userCfg.eccEn = CVA6Cfg.DcacheEccEnable;
+    userCfg.eccScrubberEn = CVA6Cfg.DcacheEccScrubberEnable;
     return userCfg;
   endfunction
 

--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -77,13 +77,27 @@ module cva6_hpdcache_subsystem
     //  {{{
     //    Cache management
     // Data cache enable - CSR_REGFILE
-    input  logic dcache_enable_i,
+    input logic dcache_enable_i,
     // Data cache flush - CONTROLLER
-    input  logic dcache_flush_i,
+    input logic dcache_flush_i,
     // Flush acknowledge - CONTROLLER
     output logic dcache_flush_ack_o,
     // Load or store miss - PERF_COUNTERS
     output logic dcache_miss_o,
+    // Data cache scrubber enable - CSR_REGFILE
+    input logic dcache_scrub_enable_i,
+    // Data cache scrubber period - CSR_REGFILE
+    input logic [5:0] dcache_scrub_period_i,
+    // Data cache scrubber cycle - CSR_REGFILE
+    output logic dcache_scrub_cycle_o,
+    // Data cache data error corrected - CSR_REGFILE
+    output logic dcache_dat_cor_err_o,
+    // Data cache data error detected but not corrected - CSR_REGFILE
+    output logic dcache_dat_unc_err_o,
+    // Data cache tag error corrected - CSR_REGFILE
+    output logic dcache_dir_cor_err_o,
+    // Data cache tag error detected but not corrected - CSR_REGFILE
+    output logic dcache_dir_unc_err_o,
 
     // AMO request - EX_STAGE
     input  ariane_pkg::amo_req_t                 dcache_amo_req_i,
@@ -318,6 +332,13 @@ module cva6_hpdcache_subsystem
       .dcache_amo_resp_o(dcache_amo_resp_o),
       .dcache_req_ports_i(dcache_req_ports_i),
       .dcache_req_ports_o(dcache_req_ports_o),
+      .dcache_scrub_enable_i,
+      .dcache_scrub_period_i,
+      .dcache_scrub_cycle_o,
+      .dcache_dat_cor_err_o,
+      .dcache_dat_unc_err_o,
+      .dcache_dir_cor_err_o,
+      .dcache_dir_unc_err_o,
       .wbuffer_empty_o(wbuffer_empty_o),
       .wbuffer_not_ni_o(wbuffer_not_ni_o),
       .hwpf_base_set_i(hwpf_base_set_i),

--- a/core/cache_subsystem/cva6_hpdcache_wrapper.sv
+++ b/core/cache_subsystem/cva6_hpdcache_wrapper.sv
@@ -74,9 +74,24 @@ module cva6_hpdcache_wrapper
     // Data cache input request/response ports - EX_STAGE
     input  dcache_req_i_t         [NumPorts-1:0] dcache_req_ports_i,
     output dcache_req_o_t         [NumPorts-1:0] dcache_req_ports_o,
+    // Data cache scrubber enable - CSR_REGFILE
+    input  logic                                 dcache_scrub_enable_i,
+    // Data cache scrubber period - CSR_REGFILE
+    input  logic                  [         5:0] dcache_scrub_period_i,
+    // Data cache scrub cycle - CSR_REGFILE
+    output logic                                 dcache_scrub_cycle_o,
+    // Data cache data error corrected - CSR_REGFILE
+    output logic                                 dcache_dat_cor_err_o,
+    // Data cache data error detected but not corrected - CSR_REGFILE
+    output logic                                 dcache_dat_unc_err_o,
+    // Data cache tag error corrected - CSR_REGFILE
+    output logic                                 dcache_dir_cor_err_o,
+    // Data cache tag error detected but not corrected - CSR_REGFILE
+    output logic                                 dcache_dir_unc_err_o,
+
     // Write buffer status - EX_STAGE
-    output logic                                 wbuffer_empty_o,
-    output logic                                 wbuffer_not_ni_o,
+    output logic wbuffer_empty_o,
+    output logic wbuffer_not_ni_o,
 
     //  Hardware memory prefetcher configuration
     input  logic [NrHwPrefetchers-1:0]       hwpf_base_set_i,
@@ -347,11 +362,11 @@ module cva6_hpdcache_wrapper
 
       .evt_cache_write_miss_o (dcache_write_miss),
       .evt_cache_read_miss_o  (dcache_read_miss),
-      .evt_cache_dir_unc_err_o(  /* unused */),
-      .evt_cache_dir_cor_err_o(  /* unused */),
-      .evt_cache_dat_unc_err_o(  /* unused */),
-      .evt_cache_dat_cor_err_o(  /* unused */),
-      .evt_scrub_complete_o   (  /* unused */),
+      .evt_cache_dir_unc_err_o(dcache_dir_unc_err_o),
+      .evt_cache_dir_cor_err_o(dcache_dir_cor_err_o),
+      .evt_cache_dat_unc_err_o(dcache_dat_unc_err_o),
+      .evt_cache_dat_cor_err_o(dcache_dat_cor_err_o),
+      .evt_scrub_complete_o   (dcache_scrub_cycle_o),
       .evt_uncached_req_o     (  /* unused */),
       .evt_cmo_req_o          (  /* unused */),
       .evt_write_req_o        (  /* unused */),
@@ -373,8 +388,8 @@ module cva6_hpdcache_wrapper
       .cfg_error_on_cacheable_amo_i       (1'b0),
       .cfg_rtab_single_entry_i            (1'b0),
       .cfg_default_wb_i                   (1'b0),
-      .cfg_scrub_enable_i                 (1'b0),
-      .cfg_scrub_period_i                 ('0),
+      .cfg_scrub_enable_i                 (dcache_scrub_enable_i),
+      .cfg_scrub_period_i                 (dcache_scrub_period_i),
       .cfg_scrub_restart_i                (1'b0)
   );
 

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -166,6 +166,13 @@ module csr_regfile
     output logic icache_en_o,
     // L1 DCache Enable - CACHE
     output logic dcache_en_o,
+    output logic dcache_scrub_en_o,
+    output logic [5:0] dcache_scrub_period_o,
+    input logic dcache_scrub_cycle_i,
+    input logic dcache_dat_cor_err_i,
+    input logic dcache_dat_unc_err_i,
+    input logic dcache_dir_cor_err_i,
+    input logic dcache_dir_unc_err_i,
     // Accelerator memory consistent mode - ACC_DISPATCHER
     output logic acc_cons_en_o,
     // read/write address to performance counter module - PERF_COUNTERS
@@ -233,6 +240,20 @@ module csr_regfile
     logic [CVA6Cfg.VMIDW-1:0] vmid;
     logic [CVA6Cfg.PPNW-1:0]  ppn;
   } hgatp_t;
+
+  typedef struct packed {
+    logic                     eccPresent;
+    logic                     eccScrubberPresent;
+    logic [CVA6Cfg.XLEN-1:30] rsvd;
+    logic [3:0]               dirCorErr;
+    logic [3:0]               dirUncErr;
+    logic [3:0]               datCorErr;
+    logic [3:0]               datUncErr;
+    logic [3:0]               scrubCycles;
+    logic [5:0]               scrubPeriod;
+    logic                     scrubEn;
+    logic                     cacheEn;
+  } dcache_cfg_t;
 
   // internal signal to keep track of access exceptions
   logic read_access_exception, update_access_exception, privilege_violation;
@@ -306,7 +327,7 @@ module csr_regfile
   logic [CVA6Cfg.XLEN-1:0] vscause_q, vscause_d;
   logic [CVA6Cfg.XLEN-1:0] vstval_q, vstval_d;
 
-  logic [CVA6Cfg.XLEN-1:0] dcache_q, dcache_d;
+  dcache_cfg_t dcache_q, dcache_d;
   logic [CVA6Cfg.XLEN-1:0] icache_q, icache_d;
   logic [CVA6Cfg.XLEN-1:0] acc_cons_q, acc_cons_d;
 
@@ -1010,6 +1031,8 @@ module csr_regfile
     // --------------------
     cycle_d         = cycle_q;
     instret_d       = instret_q;
+    dcache_d        = dcache_q;
+
     if (!(CVA6Cfg.DebugEn && debug_mode_q)) begin
       // increase instruction retired counter
       for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
@@ -1021,6 +1044,18 @@ module csr_regfile
       if (!CVA6Cfg.PerfCounterEn || (CVA6Cfg.PerfCounterEn && !mcountinhibit_q[0]))
         cycle_d = cycle_q + 1'b1;
       else cycle_d = cycle_q;
+    end
+
+    dcache_d.eccPresent = CVA6Cfg.DcacheEccEnable;
+    dcache_d.eccScrubberPresent = CVA6Cfg.DcacheEccEnable && CVA6Cfg.DcacheEccScrubberEnable;
+    if (CVA6Cfg.DcacheEccEnable) begin
+      if (dcache_dat_cor_err_i && (dcache_q.datCorErr != '1)) dcache_d.datCorErr++;
+      if (dcache_dat_unc_err_i && (dcache_q.datUncErr != '1)) dcache_d.datUncErr++;
+      if (dcache_dir_cor_err_i && (dcache_q.dirCorErr != '1)) dcache_d.dirCorErr++;
+      if (dcache_dir_unc_err_i && (dcache_q.dirUncErr != '1)) dcache_d.dirUncErr++;
+      if (CVA6Cfg.DcacheEccScrubberEnable) begin
+        if (dcache_scrub_cycle_i && (dcache_q.scrubCycles != '1)) dcache_d.scrubCycles++;
+      end
     end
 
     eret_o                          = 1'b0;
@@ -1083,7 +1118,6 @@ module csr_regfile
     end
 
     fiom_d     = fiom_q;
-    dcache_d   = dcache_q;
     icache_d   = icache_q;
     acc_cons_d = acc_cons_q;
 
@@ -1854,7 +1888,7 @@ module csr_regfile
           else update_access_exception = 1'b1;
         end
 
-        riscv::CSR_DCACHE: dcache_d = {{CVA6Cfg.XLEN - 1{1'b0}}, csr_wdata[0]};  // enable bit
+        riscv::CSR_DCACHE: dcache_d = csr_wdata;  // enable bit
         riscv::CSR_ICACHE: icache_d = {{CVA6Cfg.XLEN - 1{1'b0}}, csr_wdata[0]};  // enable bit
         riscv::CSR_ACC_CONS: begin
           if (CVA6Cfg.EnableAccelerator) begin
@@ -2762,7 +2796,9 @@ module csr_regfile
 `else
   assign icache_en_o = icache_q[0] & ~(CVA6Cfg.DebugEn && debug_mode_q);
 `endif
-  assign dcache_en_o = dcache_q[0];
+  assign dcache_en_o = dcache_q.cacheEn;
+  assign dcache_scrub_en_o = dcache_q.scrubEn;
+  assign dcache_scrub_period_o = dcache_q.scrubPeriod;
   assign acc_cons_en_o = CVA6Cfg.EnableAccelerator ? acc_cons_q[0] : 1'b0;
 
   // determine if mprv needs to be considered if in debug mode
@@ -2803,7 +2839,7 @@ module csr_regfile
       mscratch_q       <= {CVA6Cfg.XLEN{1'b0}};
       if (CVA6Cfg.TvalEn) mtval_q <= {CVA6Cfg.XLEN{1'b0}};
       fiom_q          <= '0;
-      dcache_q        <= {{CVA6Cfg.XLEN - 1{1'b0}}, 1'b1};
+      dcache_q        <= '{cacheEn: 1'b1, default: '0};
       icache_q        <= {{CVA6Cfg.XLEN - 1{1'b0}}, 1'b1};
       mcountinhibit_q <= '0;
       acc_cons_q      <= {{CVA6Cfg.XLEN - 1{1'b0}}, CVA6Cfg.EnableAccelerator};

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -590,7 +590,14 @@ module cva6
   logic tsr_csr_id;
   logic hu;
   irq_ctrl_t irq_ctrl_csr_id;
-  logic dcache_en_csr_nbdcache;
+  logic dcache_en_csr;
+  logic dcache_scrub_en_csr;
+  logic [5:0] dcache_scrub_period_csr;
+  logic dcache_scrub_cycle_csr;
+  logic dcache_dat_cor_err_csr;
+  logic dcache_dat_unc_err_csr;
+  logic dcache_dir_cor_err_csr;
+  logic dcache_dir_unc_err_csr;
   logic csr_write_fflags_commit_cs;
   logic icache_en_csr;
   logic acc_cons_en_csr;
@@ -1274,7 +1281,14 @@ module cva6
       .debug_mode_o                       (debug_mode),
       .single_step_o                      (single_step_csr_commit),
       .icache_en_o                        (icache_en_csr),
-      .dcache_en_o                        (dcache_en_csr_nbdcache),
+      .dcache_en_o                        (dcache_en_csr),
+      .dcache_scrub_en_o                  (dcache_scrub_en_csr),
+      .dcache_scrub_period_o              (dcache_scrub_period_csr),
+      .dcache_scrub_cycle_i               (dcache_scrub_cycle_csr),
+      .dcache_dat_cor_err_i               (dcache_dat_cor_err_csr),
+      .dcache_dat_unc_err_i               (dcache_dat_unc_err_csr),
+      .dcache_dir_cor_err_i               (dcache_dir_cor_err_csr),
+      .dcache_dir_unc_err_i               (dcache_dir_unc_err_csr),
       .acc_cons_en_o                      (acc_cons_en_csr),
       .perf_addr_o                        (addr_csr_perf),
       .perf_data_o                        (data_csr_perf),
@@ -1478,7 +1492,7 @@ module cva6
         .icache_dreq_i     (icache_dreq_if_cache),
         .icache_dreq_o     (icache_dreq_cache_if),
         // D$
-        .dcache_enable_i   (dcache_en_csr_nbdcache),
+        .dcache_enable_i   (dcache_en_csr),
         .dcache_flush_i    (dcache_flush_ctrl_cache),
         .dcache_flush_ack_o(dcache_flush_ack_cache_ctrl),
         // to commit stage
@@ -1500,6 +1514,11 @@ module cva6
         .inval_valid_i     (inval_valid),
         .inval_ready_o     (inval_ready)
     );
+    assign dcache_scrub_cycle_csr = 1'b0;
+    assign dcache_dat_cor_err_csr = 1'b0;
+    assign dcache_dat_unc_err_csr = 1'b0;
+    assign dcache_dir_cor_err_csr = 1'b0;
+    assign dcache_dir_unc_err_csr = 1'b0;
   end else if (
         CVA6Cfg.DCacheType == config_pkg::HPDCACHE_WT ||
         CVA6Cfg.DCacheType == config_pkg::HPDCACHE_WB ||
@@ -1536,10 +1555,17 @@ module cva6
         .icache_dreq_i (icache_dreq_if_cache),
         .icache_dreq_o (icache_dreq_cache_if),
 
-        .dcache_enable_i   (dcache_en_csr_nbdcache),
-        .dcache_flush_i    (dcache_flush_ctrl_cache),
-        .dcache_flush_ack_o(dcache_flush_ack_cache_ctrl),
-        .dcache_miss_o     (dcache_miss_cache_perf),
+        .dcache_enable_i      (dcache_en_csr),
+        .dcache_flush_i       (dcache_flush_ctrl_cache),
+        .dcache_flush_ack_o   (dcache_flush_ack_cache_ctrl),
+        .dcache_miss_o        (dcache_miss_cache_perf),
+        .dcache_scrub_enable_i(dcache_scrub_en_csr),
+        .dcache_scrub_period_i(dcache_scrub_period_csr),
+        .dcache_scrub_cycle_o (dcache_scrub_cycle_csr),
+        .dcache_dat_cor_err_o (dcache_dat_cor_err_csr),
+        .dcache_dat_unc_err_o (dcache_dat_unc_err_csr),
+        .dcache_dir_cor_err_o (dcache_dir_cor_err_csr),
+        .dcache_dir_unc_err_o (dcache_dir_unc_err_csr),
 
         .dcache_amo_req_i (amo_req),
         .dcache_amo_resp_o(amo_resp),
@@ -1600,7 +1626,7 @@ module cva6
         .icache_dreq_i     (icache_dreq_if_cache),
         .icache_dreq_o     (icache_dreq_cache_if),
         // D$
-        .dcache_enable_i   (dcache_en_csr_nbdcache),
+        .dcache_enable_i   (dcache_en_csr),
         .dcache_flush_i    (dcache_flush_ctrl_cache),
         .dcache_flush_ack_o(dcache_flush_ack_cache_ctrl),
         // to commit stage
@@ -1617,6 +1643,11 @@ module cva6
         .axi_resp_i        (noc_resp_i)
     );
     assign dcache_commit_wbuffer_not_ni = 1'b1;
+    assign dcache_scrub_cycle_csr       = 1'b0;
+    assign dcache_dat_cor_err_csr       = 1'b0;
+    assign dcache_dat_unc_err_csr       = 1'b0;
+    assign dcache_dir_cor_err_csr       = 1'b0;
+    assign dcache_dir_unc_err_csr       = 1'b0;
     assign inval_ready                  = 1'b1;
     assign miss_vld_bits                = '0;
   end

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -223,6 +223,7 @@ module cva6
       logic [CVA6Cfg.DcacheIdWidth-1:0]     data_rid;
       logic [CVA6Cfg.XLEN-1:0]              data_rdata;
       logic [CVA6Cfg.DCACHE_USER_WIDTH-1:0] data_ruser;
+      logic                                 data_error;
     },
 
     // Accelerator - CVA6

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -176,6 +176,9 @@ package build_config_pkg;
     cfg.DcacheFlushOnFenceI = CVA6Cfg.DcacheFlushOnFenceI;
     cfg.DcacheInvalidateOnFlush = CVA6Cfg.DcacheInvalidateOnFlush;
 
+    cfg.DcacheEccEnable = CVA6Cfg.DcacheEccEnable;
+    cfg.DcacheEccScrubberEnable = CVA6Cfg.DcacheEccScrubberEnable;
+
     cfg.DATA_USER_EN = CVA6Cfg.DataUserEn;
     cfg.WtDcacheWbufDepth = CVA6Cfg.WtDcacheWbufDepth;
     cfg.FETCH_USER_WIDTH = CVA6Cfg.FetchUserWidth;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -223,6 +223,10 @@ package config_pkg;
     bit          DcacheFlushOnFence;
     bit          DcacheFlushOnFenceI;
     bit          DcacheInvalidateOnFlush;
+    // Is Error Detection and Correction enabled in the L1D ?
+    bit          DcacheEccEnable;
+    // Is Error Detection and Correction scrubber integrated in the L1D ?
+    bit          DcacheEccScrubberEnable;
     // User field on data bus enable
     int unsigned DataUserEn;
     // Write-through data cache write buffer depth
@@ -424,6 +428,9 @@ package config_pkg;
     bit DcacheFlushOnFence;
     bit DcacheFlushOnFenceI;
     bit DcacheInvalidateOnFlush;
+
+    bit DcacheEccEnable;
+    bit DcacheEccScrubberEnable;
 
     int unsigned DATA_USER_EN;
     int unsigned WtDcacheWbufDepth;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -113,6 +113,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: bit'(0),
       DcacheFlushOnFenceI: bit'(0),
       DcacheInvalidateOnFlush: bit'(0),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(1),
       WtDcacheWbufDepth: int'(8),
       FetchUserWidth: unsigned'(32),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -113,6 +113,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: bit'(0),
       DcacheFlushOnFenceI: bit'(0),
       DcacheInvalidateOnFlush: bit'(0),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(1),
       WtDcacheWbufDepth: int'(8),
       FetchUserWidth: unsigned'(32),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -166,6 +166,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: bit'(0),
       DcacheFlushOnFenceI: bit'(0),
       DcacheInvalidateOnFlush: bit'(0),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -165,6 +165,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: bit'(0),
       DcacheFlushOnFenceI: bit'(0),
       DcacheInvalidateOnFlush: bit'(0),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a60ax_config_pkg.sv
+++ b/core/include/cv64a60ax_config_pkg.sv
@@ -121,6 +121,8 @@ localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
    DcacheFlushOnFence: bit'(0),
    DcacheFlushOnFenceI: bit'(0),
    DcacheInvalidateOnFlush: bit'(0),
+   DcacheEccEnable: bit'(0),
+   DcacheEccScrubberEnable: bit'(0),
    DataUserEn: unsigned'(0),
    WtDcacheWbufDepth: int'(8),
    FetchUserWidth: unsigned'(32),

--- a/core/include/cv64a60ax_config_pkg_cvfpu-uvm.sv
+++ b/core/include/cv64a60ax_config_pkg_cvfpu-uvm.sv
@@ -121,6 +121,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: bit'(0),
       DcacheFlushOnFenceI: bit'(0),
       DcacheInvalidateOnFlush: bit'(0),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(0),
       WtDcacheWbufDepth: int'(8),
       FetchUserWidth: unsigned'(32),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -170,6 +170,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: unsigned'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: unsigned'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -177,6 +177,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: bit'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: bit'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -179,6 +179,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: bit'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: bit'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -170,6 +170,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: unsigned'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: unsigned'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -170,6 +170,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: unsigned'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: unsigned'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -170,6 +170,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: unsigned'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: unsigned'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -170,6 +170,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: unsigned'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: unsigned'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -171,6 +171,8 @@ package cva6_config_pkg;
       DcacheFlushOnFence: unsigned'(CVA6ConfigDcacheFlushOnFence),
       DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
       DcacheInvalidateOnFlush: unsigned'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -349,6 +349,7 @@ package riscv;
   localparam logic [XLEN-1:0] INSTR_PAGE_FAULT = 12;  // Instruction page fault
   localparam logic [XLEN-1:0] LOAD_PAGE_FAULT = 13;  // Load page fault
   localparam logic [XLEN-1:0] STORE_PAGE_FAULT = 15;  // Store page fault
+  localparam logic [XLEN-1:0] HARDWARE_ERROR = 19;  // Transient error (e.g., bit-flip error in caches' SRAMs)
   localparam logic [XLEN-1:0] INSTR_GUEST_PAGE_FAULT = 20;  // Instruction guest-page fault
   localparam logic [XLEN-1:0] LOAD_GUEST_PAGE_FAULT = 21;  // Load guest-page fault
   localparam logic [XLEN-1:0] VIRTUAL_INSTRUCTION = 22;  // virtual instruction

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -104,9 +104,9 @@ module load_unit
   // in order to decouple the response interface from the request interface,
   // we need a a buffer which can hold all inflight memory load requests
   typedef struct packed {
-    logic [CVA6Cfg.TRANS_ID_BITS-1:0]    trans_id;        // scoreboard identifier
-    logic [CVA6Cfg.XLEN_ALIGN_BYTES-1:0] address_offset;  // least significant bits of the address
-    fu_op                                operation;       // type of load
+    logic [CVA6Cfg.TRANS_ID_BITS-1:0] trans_id;   // scoreboard identifier
+    logic [CVA6Cfg.VLEN-1:0]          vaddr;      // virtual address
+    fu_op                             operation;  // type of load
   } ldbuf_t;
 
 
@@ -211,9 +211,7 @@ module load_unit
   assign req_port_o.data_wdata = '0;
   assign req_port_o.cbo_op = ariane_pkg::CBO_NONE;
   // compose the load buffer write data, control is handled in the FSM
-  assign ldbuf_wdata = {
-    lsu_ctrl_i.trans_id, lsu_ctrl_i.vaddr[CVA6Cfg.XLEN_ALIGN_BYTES-1:0], lsu_ctrl_i.operation
-  };
+  assign ldbuf_wdata = {lsu_ctrl_i.trans_id, lsu_ctrl_i.vaddr, lsu_ctrl_i.operation};
   // output address
   // we can now output the lower 12 bit as the index to the cache
   assign req_port_o.address_index = lsu_ctrl_i.vaddr[CVA6Cfg.DCACHE_INDEX_WIDTH-1:0];
@@ -225,13 +223,6 @@ module load_unit
   assign req_port_o.data_id = ldbuf_windex;
   // user field not used
   assign req_port_o.data_wuser = '0;
-  // directly forward exception fields (valid bit is set below)
-  assign ex_o.cause = (sdtrig_load_action_i != '0) ? sdtrig_load_action_i : ex_i.cause;
-  assign ex_o.tval = (CVA6Cfg.TvalEn && (sdtrig_load_action_i != '0)) ? lsu_ctrl_i.vaddr : ex_i.tval;
-  assign ex_o.tval2 = CVA6Cfg.RVH ? ex_i.tval2 : '0;
-  assign ex_o.tinst = CVA6Cfg.RVH ? ex_i.tinst : '0;
-  assign ex_o.gva = CVA6Cfg.RVH ? ex_i.gva : 1'b0;
-  assign ex_o.timing = (sdtrig_load_stall_i && req_port_i.data_rvalid && sdtrig_load_action_i != '0) ? 1'b1 : 1'b0;
 
   // Check that NI operations follow the necessary conditions
   logic paddr_ni;
@@ -479,27 +470,46 @@ module load_unit
   // ---------------
   // Retire Load
   // ---------------
-  assign ldbuf_rindex = (CVA6Cfg.NrLoadBufEntries > 1) ? ldbuf_id_t'(req_port_i.data_rid) : 1'b0,
-      ldbuf_rdata = ldbuf_q[ldbuf_rindex];
+  assign ldbuf_rindex = (CVA6Cfg.NrLoadBufEntries > 1) ? ldbuf_id_t'(req_port_i.data_rid) : 1'b0;
+  assign ldbuf_rdata = ldbuf_q[ldbuf_rindex];
 
   // decoupled rvalid process
   always_comb begin : rvalid_output
     //  read the pending load buffer
-    ldbuf_r    = req_port_i.data_rvalid;
+    ldbuf_r = req_port_i.data_rvalid;
     trans_id_o = ldbuf_q[ldbuf_rindex].trans_id;
-    valid_o    = 1'b0;
+    valid_o = 1'b0;
+
+    // directly forward exception fields (valid bit is set below)
     ex_o.valid = 1'b0;
+    ex_o.cause = (sdtrig_load_action_i != '0) ? sdtrig_load_action_i : ex_i.cause;
+    ex_o.tval = (CVA6Cfg.TvalEn && (sdtrig_load_action_i != '0)) ? lsu_ctrl_i.vaddr : ex_i.tval;
+    ex_o.tval2 = CVA6Cfg.RVH ? ex_i.tval2 : '0;
+    ex_o.tinst = CVA6Cfg.RVH ? ex_i.tinst : '0;
+    ex_o.gva = CVA6Cfg.RVH ? ex_i.gva : 1'b0;
+    ex_o.timing = (sdtrig_load_stall_i && req_port_i.data_rvalid && sdtrig_load_action_i != '0) ? 1'b1 : 1'b0;
 
     // we got an rvalid and its corresponding request was not flushed
     if (req_port_i.data_rvalid && !ldbuf_flushed_q[ldbuf_rindex]) begin
       // if the response corresponds to the last request, check that we are not killing it
-      if ((ldbuf_last_id_q != ldbuf_rindex) || !req_port_o.kill_req) valid_o = 1'b1;
+      if ((ldbuf_last_id_q != ldbuf_rindex) || !req_port_o.kill_req) begin
+        valid_o = 1'b1;
+        ex_o.valid = req_port_i.data_error;
+        ex_o.cause = riscv::HARDWARE_ERROR;
+        if (CVA6Cfg.TvalEn) begin
+          ex_o.tval = ldbuf_rdata.vaddr;
+        end
+      end
       // the output is also valid if we got an exception. An exception arrives one cycle after
       // dtlb_hit_i is asserted, i.e. when we are in SEND_TAG. Otherwise, the exception
       // corresponds to the next request that is already being translated (see below).
-      if (ex_i.valid && (state_q == SEND_TAG)) begin
+      if ((state_q == SEND_TAG) && (ex_i.valid || req_port_i.data_error)) begin
         valid_o    = 1'b1;
         ex_o.valid = 1'b1;
+        ex_o.cause = req_port_i.data_error ? riscv::HARDWARE_ERROR : ex_i.cause;
+        if (CVA6Cfg.TvalEn && req_port_i.data_error) begin
+          ex_o.tval = ldbuf_rdata.vaddr;
+        end
       end
     end
 
@@ -535,10 +545,13 @@ module load_unit
   // Sign Extend
   // ---------------
   logic [CVA6Cfg.XLEN-1:0] shifted_data;
+  logic [CVA6Cfg.XLEN_ALIGN_BYTES-1:0] ldbuf_addroff;
+
+  assign ldbuf_addroff = ldbuf_rdata.vaddr[CVA6Cfg.XLEN_ALIGN_BYTES-1:0];
 
   // realign as needed
   // ldbuf_rdata.address_offset is just the last three bits of the load address which select the byte address within the word
-  assign shifted_data = req_port_i.data_rdata >> {ldbuf_rdata.address_offset, 3'b000};
+  assign shifted_data  = req_port_i.data_rdata >> {ldbuf_addroff, 3'b000};
 
   // The code here is legacy - from the days before CVA6 was Big Endian Capable :)
   /*// result mux (leaner code, but more logic stages.
@@ -609,9 +622,9 @@ module load_unit
   assign rdata_is_signed    =   ldbuf_rdata.operation inside {ariane_pkg::LW,  ariane_pkg::LH,  ariane_pkg::LB, ariane_pkg::HLV_W, ariane_pkg::HLV_H, ariane_pkg::HLV_B};
   assign rdata_is_fp_signed =   ldbuf_rdata.operation inside {ariane_pkg::FLW, ariane_pkg::FLH, ariane_pkg::FLB};
   // If we are in Big Endian Mode, we don't need to add anything to the address offset to find the byte that contains the sign bit, as it is always the lowest addressed byte that has the sign bit.
-  assign rdata_offset       = ((ldbuf_rdata.operation inside {ariane_pkg::LW,  ariane_pkg::FLW, ariane_pkg::HLV_W}) && CVA6Cfg.IS_XLEN64 && (~mbe_i)) ? ldbuf_rdata.address_offset + 3 :
-                                ( ldbuf_rdata.operation inside {ariane_pkg::LH,  ariane_pkg::FLH, ariane_pkg::HLV_H} && (~mbe_i))                     ? ldbuf_rdata.address_offset + 1 :
-                                                                                                                         ldbuf_rdata.address_offset;
+  assign rdata_offset       = ((ldbuf_rdata.operation inside {ariane_pkg::LW,  ariane_pkg::FLW, ariane_pkg::HLV_W}) && CVA6Cfg.IS_XLEN64 && (~mbe_i)) ? ldbuf_addroff + 3 :
+                                ( ldbuf_rdata.operation inside {ariane_pkg::LH,  ariane_pkg::FLH, ariane_pkg::HLV_H} && (~mbe_i))                     ? ldbuf_addroff + 1 :
+                                                                                                                         ldbuf_addroff;
 
   for (genvar i = 0; i < (CVA6Cfg.XLEN / 8); i++) begin : gen_sign_bits
     assign rdata_sign_bits[i] = req_port_i.data_rdata[(i+1)*8-1];
@@ -667,15 +680,18 @@ module load_unit
   // check invalid offsets, but only issue a warning as these conditions actually trigger a load address misaligned exception
   addr_offset0 :
   assert property (@(posedge clk_i) disable iff (~rst_ni)
-        ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LW, ariane_pkg::LWU}) |-> ldbuf_wdata.address_offset < 5)
+        ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LW, ariane_pkg::LWU})
+        |-> ldbuf_wdata.vaddr[CVA6Cfg.XLEN_ALIGN_BYTES-1:0] < 5)
   else $fatal(1, "invalid address offset used with {LW, LWU}");
   addr_offset1 :
   assert property (@(posedge clk_i) disable iff (~rst_ni)
-        ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LH, ariane_pkg::LHU}) |-> ldbuf_wdata.address_offset < 7)
+        ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LH, ariane_pkg::LHU})
+        |-> ldbuf_wdata.vaddr[CVA6Cfg.XLEN_ALIGN_BYTES-1:0] < 7)
   else $fatal(1, "invalid address offset used with {LH, LHU}");
   addr_offset2 :
   assert property (@(posedge clk_i) disable iff (~rst_ni)
-        ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LB, ariane_pkg::LBU}) |-> ldbuf_wdata.address_offset < 8)
+        ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LB, ariane_pkg::LBU})
+        |-> ldbuf_wdata.vaddr[CVA6Cfg.XLEN_ALIGN_BYTES-1:0] < 8)
   else $fatal(1, "invalid address offset used with {LB, LBU}");
   //pragma translate_on
 

--- a/corev_apu/fpga/scripts/run.tcl
+++ b/corev_apu/fpga/scripts/run.tcl
@@ -46,6 +46,7 @@ set_property include_dirs { \
 	"../../vendor/pulp-platform/common_cells/include" \
 	"../../vendor/pulp-platform/axi/include" \
 	"../../core/cache_subsystem/hpdcache/rtl/include" \
+	"../../core/cache_subsystem/hpdcache/rtl/src/utils/ecc" \
 	"../register_interface/include" \
       "../instr_tracing/ITI/include" \
 	"../../core/include" \

--- a/verif/regress/smoke-tests-cv64a6_imafdc_sv39.sh
+++ b/verif/regress/smoke-tests-cv64a6_imafdc_sv39.sh
@@ -13,6 +13,10 @@ if ! [ -n "$RISCV" ]; then
   return
 fi
 
+if ! [ -n "$TARGET" ]; then
+  TARGET=cv64a6_imafdc_sv39
+fi
+
 if ! [ -n "$DV_SIMULATORS" ]; then
   DV_SIMULATORS=vcs-testharness,spike
 fi
@@ -46,13 +50,13 @@ cd verif/sim/
 
 make -C ../.. clean
 make clean_all
-python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-add --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64ui-p-add --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64si-p-noncanonical --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml --test rv64i_m-add-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS  --linker=../../config/gen_from_riscv_config/linker/link.ld
-python3 cva6.py --testlist=../tests/testlist_custom.yaml --test custom_test_template --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --gcc_opts="$CC_OPTS -nostdlib -lgcc" $DV_OPTS --linker=../../config/gen_from_riscv_config/linker/link.ld
+python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target ${TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-add --iss_yaml cva6.yaml --target ${TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64ui-p-add --iss_yaml cva6.yaml --target ${TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64si-p-noncanonical --iss_yaml cva6.yaml --target ${TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml --test rv64i_m-add-01 --iss_yaml cva6.yaml --target ${TARGET} --iss=$DV_SIMULATORS $DV_OPTS  --linker=../../config/gen_from_riscv_config/linker/link.ld
+python3 cva6.py --testlist=../tests/testlist_custom.yaml --test custom_test_template --iss_yaml cva6.yaml --target ${TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target ${TARGET} --iss=$DV_SIMULATORS --gcc_opts="$CC_OPTS -nostdlib -lgcc" $DV_OPTS --linker=../../config/gen_from_riscv_config/linker/link.ld
 make -C ../.. clean
 make clean_all
 

--- a/verif/tests/custom/dcache_csr_test/dcache_csr_test.c
+++ b/verif/tests/custom/dcache_csr_test/dcache_csr_test.c
@@ -1,0 +1,118 @@
+// vim: ts=4 : sts=4 : sw=4 : et
+/*
+** Copyright 2026 Inria, Universite Grenoble-Alpes
+**
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     https://solderpad.org/licenses/
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+/*
+** Author: Cesar Fuguet - Inria, Univ. Grenoble-Alpes
+**/
+#include <stdint.h>
+#include <stdio.h>
+
+static const unsigned int TEST_TIMEOUT = 10000;
+
+/*  DCACHE CSR
+ *  XLEN-1           XLEN-2           XLEN-3 ..  28   27  .. 24   23  .. 20
+ *  -----------------------------------------------------------------------
+ *  eccPresent | eccScrubberPresent |   RESERVED    | dirCorErr | dirUncErr
+ *  -----------------------------------------------------------------------
+ *
+ *  19  .. 16   15  ..  12  11   ..    8  7   ..    2      1           0
+ *  -----------------------------------------------------------------------
+ *  datCorErr | datUncErr | scrubCycles | scrubPeriod | scrubEn  |  cacheEn
+ *  -----------------------------------------------------------------------
+ */
+static const unsigned int CSR_DCACHE = 0x7c1u;
+
+#define __csr_rw(opcode, val) ({              \
+    register uintptr_t ret;                   \
+    asm volatile(                             \
+        #opcode " %[rd], %[rs1], %[rs2]\n"    \
+        : [rd]"=r"(ret)                       \
+        : [rs1]"i"(CSR_DCACHE), [rs2]"r"(val) \
+        : "memory");                          \
+    ret;                                      \
+    })
+
+static inline uintptr_t csr_dcache_read_wr(uintptr_t val)
+{
+    return __csr_rw(csrrw, val);
+}
+
+static inline uintptr_t csr_dcache_read_set(uintptr_t mask)
+{
+    return __csr_rw(csrrs, mask);
+}
+
+static inline uintptr_t csr_dcache_read_clr(uintptr_t mask)
+{
+    return __csr_rw(csrrc, mask);
+}
+
+
+static int testScrubPeriod(int period, int max_cycles)
+{
+    //  program scrubEn and scrubPeriod (clear then set)
+    csr_dcache_read_clr(0x7f << 1);
+    csr_dcache_read_clr(0xf << 8); // clear scrubCycles counter
+    csr_dcache_read_set((period << 2) | 0x2);
+
+    //  wait for a given number of scrub cycles
+    int ret = 1;
+    for (int i = 0; i < TEST_TIMEOUT; i++) {
+        uintptr_t scrubCycles;
+        uintptr_t tmp = csr_dcache_read_set(0);
+        scrubCycles = (tmp >> 8) & 0xf;
+        if (scrubCycles >= max_cycles) {
+            ret = 0;
+            break;
+        }
+    }
+    csr_dcache_read_clr(0x2); // disable scrubber
+    return ret;
+}
+
+int main(int argc, char* arg[])
+{
+    int scrubPeriod; // Power of two value (2**N) -> 32 if period=5
+    const int xlen = sizeof(uintptr_t) * 8;
+    uintptr_t tmp;
+    int ret = 0;
+
+    printf("[BEG] Test DCACHE CSR\n");
+    tmp = csr_dcache_read_set(0);
+
+    //  check that eccPresent bit is set
+    if (((tmp >> (xlen - 1)) & 0x1) == 0) {
+        printf("[WARNING] DCACHE ECC not supported\n");
+        goto exitTest;
+    }
+
+    //  check that eccScrubberPresent bit is set
+    if (((tmp >> (xlen - 2)) & 0x1) == 0) {
+        printf("[WARNING] DCACHE Scrubbing mechanism not supported\n");
+        goto exitTest;
+    }
+
+    //  start tests
+    printf("Enabling scrubbing (period=%d)\n", scrubPeriod);
+    ret = testScrubPeriod(5/*32*/, 3);
+    if (ret > 0) goto exitTest;
+    ret = testScrubPeriod(4/*16*/, 5);
+
+exitTest:
+    if (ret > 0) printf("[FAILURE] Test DCACHE CSR\n");
+    else         printf("[SUCCESS] Test DCACHE CSR\n");
+    return ret;
+}


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

This PR introduces the following mechanisms in the CVA6:
- Add different configuration bits in the existing custom DCACHE CSR to control and monitor the different error correction mechanisms in the Dcache (HPDcache).
- Add two additional configuration parameters to the CVA6: DcacheEccEnable, DcacheEccScrubberEnable
- Trigger an exception in the core in case of a load access on the cache that responds with an error. An error in this case may indicate an uncorrected error due to a transient error in the cache, or due to an error propagated from the NoC through the cache (e.g., ECC error in DRAM, access to an illegal physical address).
- Add C test with simple sanity check for the scrubbing mechanism in the HPDcache
- Add pre-generated ECC encoders/decoders in the Flist file for common configurations of the cache

These features support both 32-bit and 64-bit configurations of the CVA6.

I did not modify any existing configuration in the core/include directory to enable ECC (but any of them can benefit from error correction in the Dcache by setting the DcacheEccEnable and DcacheEccScrubberEnable parameters to 1).

**If accepted, I suggest that this PR is rebased and merged (not squashed). Each commit is functional separately and introduces the different functionalities mentioned above.**