### PR TITLE
fix(mmu): re-check cached G-stage DTLB-hit permissions after HLVX

### DIFF
--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -506,6 +506,9 @@ module cva6_mmu
   logic [CVA6Cfg.GPLEN-1:0] lsu_gpaddr_n, lsu_gpaddr_q;
   logic [31:0] lsu_tinst_n, lsu_tinst_q;
   logic hs_ld_st_inst_n, hs_ld_st_inst_q;
+  logic hlvx_inst_n, hlvx_inst_q;
+  logic g_load_exec_as_read_ok;
+  logic g_load_access_ok;
   pte_cva6_t dtlb_pte_n, dtlb_pte_q;
   pte_cva6_t dtlb_gpte_n, dtlb_gpte_q;
   logic lsu_req_n, lsu_req_q;
@@ -548,9 +551,21 @@ module cva6_mmu
     if (CVA6Cfg.RVH) begin
       lsu_tinst_n = lsu_tinst_i;
       hs_ld_st_inst_n = hs_ld_st_inst_i;
+      hlvx_inst_n = hlvx_inst_i;
       lsu_gpaddr_n[(CVA6Cfg.IS_XLEN32 ? CVA6Cfg.VLEN: CVA6Cfg.GPLEN)-1:0] = dtlb_gpaddr[(CVA6Cfg.IS_XLEN32 ? CVA6Cfg.VLEN: CVA6Cfg.GPLEN)-1:0];
       csr_hs_ld_st_inst_o = hs_ld_st_inst_i || hs_ld_st_inst_q;
-      d_g_st_access_err = en_ld_st_g_translation_i && !dtlb_gpte_q.u;
+      // The PTW path has its own permission checks while populating translation
+      // state. Once a G-stage translation is cached and a later LSU access hits in
+      // the DTLB, the hit path still has to re-check permissions against the
+      // current access type. In particular, a prior HLVX hit must not cause a
+      // later plain HLV load to inherit execute-only permission.
+      g_load_exec_as_read_ok = dtlb_gpte_q.x && (mxr_i || hlvx_inst_q);
+      g_load_access_ok = dtlb_gpte_q.r || g_load_exec_as_read_ok;
+      d_g_st_access_err = en_ld_st_g_translation_i && (
+                          !dtlb_gpte_q.u ||
+                          !dtlb_gpte_q.a ||
+                          (!lsu_is_store_q && !g_load_access_ok)
+      );
       dtlb_gpte_n = dtlb_g_content;
     end
 
@@ -765,6 +780,7 @@ module cva6_mmu
       dtlb_is_page_q  <= '0;
       lsu_tinst_q     <= '0;
       hs_ld_st_inst_q <= '0;
+      hlvx_inst_q     <= '0;
       misaligned_ex_q <= '0;
     end else begin
       lsu_vaddr_q     <= lsu_vaddr_n;
@@ -778,6 +794,7 @@ module cva6_mmu
       if (CVA6Cfg.RVH) begin
         lsu_tinst_q     <= lsu_tinst_n;
         hs_ld_st_inst_q <= hs_ld_st_inst_n;
+        hlvx_inst_q     <= hlvx_inst_n;
         dtlb_gpte_q     <= dtlb_gpte_n;
         lsu_gpaddr_q    <= lsu_gpaddr_n;
       end


### PR DESCRIPTION
- [√] I have searched for similar pull requests
- [√ ] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

This PR fixes a guest-stage permission issue on the cached G-stage / DTLB-hit path after a prior legal `HLVX` access.

It latches `hlvx_inst_i` together with the saved LSU request and re-checks guest-stage DTLB-hit permissions against `U`, `A`, and the current load `R/X` rules. This prevents a prior legal `HLVX` access from causing a later plain `HLV` load to inherit execute-only permission on a cached translation.

Related issue: #3456 

Why this PR is still needed:

[#3435](https://github.com/openhwgroup/cva6/pull/3435) fixes a related but different PTW/page-walk path, where an implicit G-stage access happens while translating a VS-stage PTE address. However, the original CV-1 reproducer still hits an additional cached G-stage / DTLB-hit path in `cva6_mmu.sv`, which does not go back through that PTW logic.

Validation:

- the original CV-1 reproducer still reproduces on top of #3435
- the same reproducer passes with this patch applied (`tohost = 0`)

Current limitation:

This is a targeted fix for the cached guest-stage hit path exercised by the reproducer. It does not refactor the related PTW logic.