### PR TITLE
Fix cm.mva01s equal-register decode

### DIFF
--- a/core/macro_decoder.sv
+++ b/core/macro_decoder.sv
@@ -133,7 +133,7 @@ module macro_decoder #(
 
       // Calculate xreg1 & xreg2 for move instructions
       if (macro_instr_type == MVSA01 || macro_instr_type == MVA01S) begin
-        if (instr_i[9:7] != instr_i[4:2]) begin
+        if (macro_instr_type == MVA01S || instr_i[9:7] != instr_i[4:2]) begin
           xreg1 = {instr_i[9:8] > 0, instr_i[9:8] == 0, instr_i[9:7]};
           xreg2 = {instr_i[4:3] > 0, instr_i[4:3] == 0, instr_i[4:2]};
         end else begin

--- a/verif/regress/cv32a6_tests.sh
+++ b/verif/regress/cv32a6_tests.sh
@@ -63,6 +63,24 @@ python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml 
   --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common" $DV_OPTS
 [[ $? > 0 ]] && ((errors++))
 
+# Regression for #3464: cm.mva01s permits equal compact-register operands.
+if [ "$DV_TARGET" = "cv32a60x" ]; then
+  # Rebuild for the generated hwconfig because the preceding tests use
+  # the default cv32a60x configuration, where RVZCMP is disabled.
+  make -C ../.. clean
+
+  env -u SPIKE_TANDEM python3 cva6.py \
+    --testlist=../tests/testlist_issues.yaml \
+    --test zcmp-mva01s-equal-regs-rv32 \
+    --iss_yaml cva6.yaml \
+    --target hwconfig \
+    --hwconfig_opts="cv32a60x *RVZCMP=1" \
+    --iss=veri-testharness \
+    --linker="../../config/gen_from_riscv_config/cv32a60x/linker/link.ld" \
+    $DV_OPTS
+  [[ $? > 0 ]] && ((errors++))
+fi
+
 make -C ../.. clean
 make clean_all
 

--- a/verif/tests/custom/Zcmp/cm_mva01s_equal_regs_test.S
+++ b/verif/tests/custom/Zcmp/cm_mva01s_equal_regs_test.S
@@ -1,0 +1,33 @@
+#include "riscv_test.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+    li s1, 9
+    .2byte 0xace6    # cm.mva01s s1, s1
+
+    bne a0, s1, failure
+    bne a1, s1, failure
+
+    j success
+failure:
+    li x1, 1
+	slli x1, x1, 1
+	addi x1, x1, 1
+	sw x1, tohost, t5
+	self_loop_2: j self_loop_2
+
+success:
+    li x1, 0
+	slli x1, x1, 1
+	addi x1, x1, 1
+	sw x1, tohost, t5
+	self_loop: j self_loop
+
+RVTEST_CODE_END
+
+.data
+
+RVTEST_DATA_BEGIN
+
+RVTEST_DATA_END

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -75,3 +75,17 @@ testlist:
       -I<path_var>/riscv-tests/isa/macros/scalar/
       -I<path_var>/riscv-tests/env/p/
       -march=rv64gh
+
+  - test: zcmp-mva01s-equal-regs-rv32
+    description: >
+      Check that cm.mva01s accepts equal r1s' and r2s' encodings.
+    iterations: 1
+    path_var: TESTS_PATH
+    asm_tests: <path_var>/custom/Zcmp/cm_mva01s_equal_regs_test.S
+    gcc_opts: >-
+      -static
+      -mcmodel=medany
+      -fvisibility=hidden
+      -nostdlib
+      -nostartfiles
+      -I../tests/custom/env


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

`cm.mva01s` currently rejects encodings where `r1s' == r2s'`.

The inequality restriction applies to `cm.mvsa01`, but the current
`macro_decoder` applies the same restriction to both `MVSA01` and
`MVA01S`. As a result, legal equal-register `cm.mva01s` encodings are
reported as illegal instructions.

## Changes

- Update the move-instruction legality check in `core/macro_decoder.sv`
  so equal source registers are accepted for `MVA01S`.
- Preserve the `r1s' != r2s'` restriction for `MVSA01`.
- Add `verif/tests/custom/Zcmp/cm_mva01s_equal_regs_test.S` to cover
  `cm.mva01s s1, s1`.
- Verify that both `a0` and `a1` receive the expected source-register
  value.

## Validation

Tested with the `cv32a6_imac_sv32` configuration with `RVZCMP=1`.

- New equal-register `cm.mva01s` regression:
  - CVA6/Verilator: PASS
  - Spike: PASS
  - ISS comparison: PASS (`20 matched`)
- Existing `cm_mva01s_test.S`: PASS (`21 matched`)
- Existing `cm_mvsa01_test.S`: PASS (`21 matched`)
- `cm.mvsa01 s1, s1` is rejected by GNU assembler as an illegal operand.
- A raw equal-register `cm.mvsa01` encoding (`0xaca6`) was also checked
  on CVA6 and triggers the expected illegal-instruction trap, confirming
  that the `MVSA01` restriction remains intact.
- `git diff --check`: clean.

## Scope / limitations

This change is limited to the legality check for the Zcmp move
instructions and adds a focused regression for the reported issue.
No other decoder behavior is changed.

Fixes #3464
