### PR TITLE
Align Verilator uvm_warning macro with UVM

### DIFF
--- a/verif/tb/core/custom_uvm_macros.svh
+++ b/verif/tb/core/custom_uvm_macros.svh
@@ -29,9 +29,9 @@ typedef enum
         uvm_report_info(TOP, MSG, LVL, `uvm_file, `uvm_line); \
     end
 
-`define uvm_warning(TOP, MSG, LVL) \
+`define uvm_warning(TOP, MSG) \
     begin \
-        uvm_report_warning(TOP, MSG, LVL, `uvm_file, `uvm_line); \
+        uvm_report_warning(TOP, MSG, UVM_NONE, `uvm_file, `uvm_line); \
     end
 
 `define uvm_error(TOP, MSG) \


### PR DESCRIPTION
## Summary

Align the lightweight Verilator `uvm_warning` macro with the standard UVM two-argument interface.

## Problem

The Verilator TestHarness uses `verif/tb/core/custom_uvm_macros.svh` as a lightweight replacement for the full UVM macros. Its `uvm_warning` definition currently requires three arguments, while the standard UVM interface is `uvm_warning(ID, MSG)` and supplies `UVM_NONE` internally.

This incompatibility was exposed on August 13, 2026, when [core-v-verif#2745](https://github.com/openhwgroup/core-v-verif/pull/2745) changed a non-fatal RVFI tandem mismatch from `uvm_error` to the standard two-argument `uvm_warning` call. CVA6 [PR #3472](https://github.com/openhwgroup/cva6/pull/3472) then updated the `master_candidate` submodule to the corresponding `core-v-verif` commit (`69c5379`). Verilator therefore stops during preprocessing with `Define missing argument 'LVL' for: uvm_warning`.

The failure is specific to Verilator builds that select `custom_uvm_macros.svh` through the `VERILATOR` path. Other simulators include the standard `uvm_macros.svh` instead and are not affected.

## Change

Change the custom warning macro to the standard two-argument interface and forward `UVM_NONE` to `uvm_report_warning`. This does not change warning severity, tandem mismatch handling, or `core-v-verif`.