### PR TITLE
Fix PMP LSU response metadata alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           - testcase: dv-riscv-arch-test
             config: cv64a6_imafdc_sv39_hpdcache_wb
             simulator: veri-testharness
+          - testcase: pmp_lsu_transaction
+            config: cv64a6_imafdc_sv39
+            simulator: veri-testharness
     needs:
       build-riscv-tests
     steps:

--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -59,9 +59,13 @@ module cva6_mmu
     // Cycle 0
     output logic lsu_dtlb_hit_o,  // sent in same cycle as the request if translation hits in DTLB
     output logic [CVA6Cfg.PPNW-1:0] lsu_dtlb_ppn_o,  // ppn (send same cycle as hit)
-    // Cycle 1
+    // Cycle 1 response
     output logic lsu_valid_o,  // translation is valid
     output logic [CVA6Cfg.PLEN-1:0] lsu_paddr_o,  // translated address
+    // Metadata for the same response transaction as lsu_valid_o, lsu_paddr_o,
+    // and lsu_exception_o.
+    output logic [CVA6Cfg.VLEN-1:0] lsu_vaddr_o,
+    output logic lsu_is_store_o,
     output exception_t lsu_exception_o,  // address translation threw an exception
     // General control signals
     input riscv::priv_lvl_t priv_lvl_i,
@@ -513,6 +517,9 @@ module cva6_mmu
   logic dtlb_hit_n, dtlb_hit_q;
   logic [CVA6Cfg.PtLevels-2:0] dtlb_is_page_n, dtlb_is_page_q;
   exception_t misaligned_ex_n, misaligned_ex_q;
+
+  assign lsu_vaddr_o = lsu_vaddr_q;
+  assign lsu_is_store_o = lsu_is_store_q;
 
   // check if we need to do translation or if we are always ready (e.g.: we are not translating anything)
   assign lsu_dtlb_hit_o = (en_ld_st_translation_i || en_ld_st_g_translation_i) ? dtlb_lu_hit : 1'b1;

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -227,9 +227,11 @@ module load_store_unit
   logic translation_valid, cva6_translation_valid;
   logic [CVA6Cfg.VLEN-1:0] mmu_vaddr, cva6_mmu_vaddr, acc_mmu_vaddr;
   logic [CVA6Cfg.PLEN-1:0] mmu_paddr, cva6_mmu_paddr, acc_mmu_paddr, lsu_paddr;
-  logic [31:0] mmu_tinst;
-  logic        mmu_hs_ld_st_inst;
-  logic        mmu_hlvx_inst;
+  logic [CVA6Cfg.VLEN-1:0] pmp_vaddr_q;
+  logic                    pmp_is_store_q;
+  logic [            31:0] mmu_tinst;
+  logic                    mmu_hs_ld_st_inst;
+  logic                    mmu_hlvx_inst;
   exception_t mmu_exception, cva6_mmu_exception, acc_mmu_exception;
   exception_t   pmp_exception;
   icache_areq_t pmp_icache_areq_i;
@@ -297,6 +299,8 @@ module load_store_unit
 
         .lsu_valid_o    (pmp_translation_valid),
         .lsu_paddr_o    (lsu_paddr),
+        .lsu_vaddr_o    (pmp_vaddr_q),
+        .lsu_is_store_o (pmp_is_store_q),
         .lsu_exception_o(pmp_exception),
 
         .priv_lvl_i      (priv_lvl_i),
@@ -350,6 +354,8 @@ module load_store_unit
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (~rst_ni) begin
         lsu_paddr <= '0;
+        pmp_vaddr_q <= '0;
+        pmp_is_store_q <= 1'b0;
         pmp_exception <= '0;
         pmp_translation_valid <= 1'b0;
       end else begin
@@ -358,6 +364,8 @@ module load_store_unit
         end else begin
           lsu_paddr <= CVA6Cfg.PLEN'(mmu_vaddr);
         end
+        pmp_vaddr_q <= mmu_vaddr;
+        pmp_is_store_q <= st_translation_req;
         pmp_exception <= misaligned_exception;
         pmp_translation_valid <= translation_req;
       end
@@ -398,9 +406,9 @@ module load_store_unit
       .icache_fetch_vaddr_i(icache_areq_i.fetch_vaddr),
       .lsu_valid_i         (pmp_translation_valid),
       .lsu_paddr_i         (lsu_paddr),
-      .lsu_vaddr_i         (mmu_vaddr),
+      .lsu_vaddr_i         (pmp_vaddr_q),
       .lsu_exception_i     (pmp_exception),
-      .lsu_is_store_i      (st_translation_req),
+      .lsu_is_store_i      (pmp_is_store_q),
       .lsu_valid_o         (translation_valid),
       .lsu_paddr_o         (mmu_paddr),
       .lsu_exception_o     (mmu_exception),

--- a/verif/regress/pmp_lsu_transaction.sh
+++ b/verif/regress/pmp_lsu_transaction.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright 2026 OpenHW Group
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+set -eo pipefail
+
+if [[ -z "${RISCV:-}" ]]; then
+  echo "Error: RISCV variable undefined" >&2
+  exit 1
+fi
+
+source verif/sim/setup-env.sh
+set -u
+
+# These are self-checking architectural tests.  Do not enable Spike tandem
+# execution because the OpenHW RV64 Spike target does not describe these PMP
+# regions.
+unset SPIKE_TANDEM
+
+readonly standard_target="${DV_TARGET:-cv64a6_imafdc_sv39}"
+readonly linker="../../config/gen_from_riscv_config/linker/link.ld"
+readonly testlist="../tests/testlist_issues.yaml"
+readonly no_mmu_options="${standard_target}"\
+" +CVA6ConfigDcacheFlushOnFence=0"\
+" +CVA6ConfigDcacheFlushOnFenceI=0"\
+" +CVA6ConfigDcacheInvalidateOnFlush=0"\
+" *MmuPresent=0"
+
+cd verif/sim
+
+run_test() {
+  local test_name="$1"
+  local target="$2"
+  shift 2
+
+  python3 cva6.py \
+    --testlist="${testlist}" \
+    --test="${test_name}" \
+    --target="${target}" \
+    --iss_yaml=cva6.yaml \
+    --iss=veri-testharness \
+    --linker="${linker}" \
+    --issrun_opts=+debug_disable=1 \
+    "$@"
+}
+
+# Discard a model left by a previous run with a different configuration.
+make -C ../.. clean
+
+run_test pmp-lsu-transaction-rv64 "${standard_target}"
+run_test pmp-amo-access-fault-rv64 "${standard_target}"
+
+# The generated model does not track configuration variables as dependencies,
+# so discard it before switching to the no-MMU configuration.
+make -C ../.. clean
+
+run_test pmp-lsu-transaction-no-mmu-rv64 hwconfig \
+  --hwconfig_opts="${no_mmu_options}"

--- a/verif/tests/custom/pmp/amo_access_fault_test.S
+++ b/verif/tests/custom/pmp/amo_access_fault_test.S
@@ -1,0 +1,100 @@
+// Copyright 2026 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+    .equ STORE_AMO_ACCESS_FAULT, 7
+    .equ AMO_RESULT_SENTINEL,    0x5a5a5a5a5a5a5a5a
+
+    .section .text
+    .globl main
+main:
+    // Entry 0 is a locked four-KiB NAPOT region with no permissions.  Entry 1
+    // covers the remaining address space so that the load adjacent to the AMO
+    // is allowed.
+    la t0, target_no_access
+    srli t0, t0, 2
+    ori t0, t0, 0x1ff
+    csrw pmpaddr0, t0
+    li t0, -1
+    csrw pmpaddr1, t0
+    li t0, 0x00001f98
+    csrw pmpcfg0, t0
+
+    la t0, trap_count
+    sw zero, 0(t0)
+
+    // A PMP-denied AMO must report a store/AMO access fault, not a load
+    // access fault.  Keep an allowed load immediately behind it to expose
+    // request/response access-type and tval misalignment.
+    la t0, target_no_access
+    call set_expected_tval
+    li t1, 1
+    li t3, AMO_RESULT_SENTINEL
+    la t2, allowed_data
+    .option push
+    .option norvc
+    amoadd.d t3, t1, (t0)
+    ld t4, 0(t2)
+    .option pop
+    li t0, 1
+    call check_trap_count
+    li t0, AMO_RESULT_SENTINEL
+    bne t3, t0, fail
+
+pass:
+    li a0, 0
+    tail exit
+
+fail:
+    li a0, 1
+    tail exit
+
+set_expected_tval:
+    la t1, expected_tval
+    sd t0, 0(t1)
+    ret
+
+check_trap_count:
+    la t1, trap_count
+    lw t1, 0(t1)
+    bne t0, t1, fail
+    ret
+
+    .globl handle_trap
+handle_trap:
+    li t0, STORE_AMO_ACCESS_FAULT
+    bne a0, t0, trap_fail
+
+    csrr t0, mtval
+    la t1, expected_tval
+    ld t1, 0(t1)
+    bne t0, t1, trap_fail
+
+    la t0, trap_count
+    lw t1, 0(t0)
+    addi t1, t1, 1
+    sw t1, 0(t0)
+
+    // crt.S writes the returned address to mepc before executing mret.
+    addi a0, a1, 4
+    ret
+
+trap_fail:
+    li a0, 1
+    tail exit
+
+    .section .data, "aw", @progbits
+    .align 3
+expected_tval:
+    .dword 0
+trap_count:
+    .word 0
+    .align 3
+allowed_data:
+    .dword 0
+
+    .balign 4096
+target_no_access:
+    .dword 0

--- a/verif/tests/custom/pmp/lsu_pipeline_store_no_mmu_test.S
+++ b/verif/tests/custom/pmp/lsu_pipeline_store_no_mmu_test.S
@@ -1,0 +1,8 @@
+// Copyright 2026 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+#define PMP_NO_MMU
+#include "lsu_pipeline_store_test.S"

--- a/verif/tests/custom/pmp/lsu_pipeline_store_test.S
+++ b/verif/tests/custom/pmp/lsu_pipeline_store_test.S
@@ -1,0 +1,183 @@
+// Copyright 2026 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+    .equ STORE_ACCESS_FAULT, 7
+    .equ MSTATUS_MPP,       0x00001800
+    .equ MSTATUS_MPRV,      0x00020000
+    .equ MSTATUS_MPP_S,     0x00000800
+    .equ SATP_MODE_SV39,    0x8000000000000000
+
+    .equ DENIED_PADDR,      0x90000000
+    .equ ALLOWED_PADDR,     0x80000000
+    .equ DENIED_VADDR,      0x50000000
+    .equ ALLOWED_VADDR,     0x40000000
+    .equ INITIAL_VALUE,     0x13579bdf
+    .equ STORE_VALUE,       0x2468ace0
+
+    .section .text
+    .globl main
+main:
+    // Initialize the location before locking its PMP entry.
+    li t1, DENIED_PADDR
+    li t2, INITIAL_VALUE
+    sw t2, 0(t1)
+
+    // Entry 0 allows [0, 0x90000000), entry 1 makes
+    // [0x90000000, 0x90001000) locked and read-only, and entry 2 allows the
+    // remainder through 0xc0000000.  The surrounding entries allow S-mode
+    // page-table walks and the load paired with each denied store.
+    li t0, 0x24000000
+    csrw pmpaddr0, t0
+    li t0, 0x24000400
+    csrw pmpaddr1, t0
+    li t0, 0x30000000
+    csrw pmpaddr2, t0
+    li t0, 0x000f890f
+    csrw pmpcfg0, t0
+
+    la t0, trap_count
+    sw zero, 0(t0)
+
+#ifdef PMP_NO_MMU
+    // Exercise the no-MMU response path.
+    li t0, DENIED_PADDR
+    call set_expected_tval
+    li t1, DENIED_PADDR
+    li t2, STORE_VALUE
+    li t4, ALLOWED_PADDR
+    .option push
+    .option norvc
+    sw t2, 0(t1)
+    lw t3, 0(t4)
+    .option pop
+    li t0, 1
+    call check_result
+#else
+    // Install a one-GiB Sv39 leaf mapping [0x40000000, 0x80000000) to
+    // [0x80000000, 0xc0000000).  DENIED_VADDR therefore translates to the
+    // PMP-protected DENIED_PADDR.
+    la t0, root_page_table
+    srli t0, t0, 12
+    li t1, SATP_MODE_SV39
+    or t0, t0, t1
+    csrw satp, t0
+
+    // Flush the DTLB so that the denied store itself takes the miss/PTW path.
+    sfence.vma
+    li t0, DENIED_VADDR
+    call set_expected_tval
+    call enable_s_data_translation
+    li t1, DENIED_VADDR
+    li t2, STORE_VALUE
+    li t4, ALLOWED_VADDR
+    .option push
+    .option norvc
+    sw t2, 0(t1)
+    lw t3, 0(t4)
+    .option pop
+    call disable_data_translation
+    li t0, 1
+    call check_result
+
+    // Refill the DTLB with an allowed read, then repeat the adjacent
+    // denied-store/allowed-load sequence on the hit path.
+    sfence.vma
+    li t0, DENIED_VADDR
+    call set_expected_tval
+    call enable_s_data_translation
+    li t1, DENIED_VADDR
+    lw t3, 0(t1)
+    li t2, STORE_VALUE
+    li t4, ALLOWED_VADDR
+    .option push
+    .option norvc
+    sw t2, 0(t1)
+    lw t3, 0(t4)
+    .option pop
+    call disable_data_translation
+    li t0, 2
+    call check_result
+#endif
+
+pass:
+    li a0, 0
+    tail exit
+
+fail:
+    li a0, 1
+    tail exit
+
+set_expected_tval:
+    la t1, expected_tval
+    sd t0, 0(t1)
+    ret
+
+enable_s_data_translation:
+    li t0, MSTATUS_MPP | MSTATUS_MPRV
+    csrc mstatus, t0
+    li t0, MSTATUS_MPP_S | MSTATUS_MPRV
+    csrs mstatus, t0
+    ret
+
+disable_data_translation:
+    li t0, MSTATUS_MPRV
+    csrc mstatus, t0
+    ret
+
+check_result:
+    la t1, trap_count
+    lw t1, 0(t1)
+    bne t0, t1, fail
+    li t1, DENIED_PADDR
+    lw t1, 0(t1)
+    li t2, INITIAL_VALUE
+    bne t1, t2, fail
+    ret
+
+    .globl handle_trap
+handle_trap:
+    li t0, MSTATUS_MPRV
+    csrc mstatus, t0
+
+    li t0, STORE_ACCESS_FAULT
+    bne a0, t0, trap_fail
+
+    csrr t0, mtval
+    la t1, expected_tval
+    ld t1, 0(t1)
+    bne t0, t1, trap_fail
+
+    la t0, trap_count
+    lw t1, 0(t0)
+    addi t1, t1, 1
+    sw t1, 0(t0)
+
+    // crt.S writes the returned address to mepc before executing mret.
+    addi a0, a1, 4
+    ret
+
+trap_fail:
+    li a0, 1
+    tail exit
+
+    .section .data
+    .align 3
+expected_tval:
+    .dword 0
+trap_count:
+    .word 0
+
+#ifndef PMP_NO_MMU
+    // Sv39 root entry 1 is a one-GiB leaf with PPN 0x80000 and V/R/W/X/A/D.
+    .section .page_table, "aw", @progbits
+    .balign 4096
+root_page_table:
+    .dword 0
+    .dword 0x00000000200000cf
+    .rept 510
+    .dword 0
+    .endr
+#endif

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -34,7 +34,44 @@ common_test_config: &common_test_config
   path_var: TESTS_PATH
   gcc_opts: "-static -misa-spec=2.2 -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../../config/gen_from_riscv_config/linker/link.ld -lgcc"
 
+pmp_test_config: &pmp_test_config
+  <<: *common_test_config
+  iterations: 1
+  gcc_opts: >-
+    -static
+    -misa-spec=2.2
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
+    ../tests/custom/common/syscalls.c
+    ../tests/custom/common/crt.S
+    -I../tests/custom/env
+    -I../tests/custom/common
+    -lgcc
+
 testlist:
+  - test: pmp-lsu-transaction-rv64
+    description: >
+      Check that PMP uses the access type and virtual address belonging to the
+      MMU response on DTLB-miss and DTLB-hit store transactions.
+    <<: *pmp_test_config
+    asm_tests: <path_var>/custom/pmp/lsu_pipeline_store_test.S
+
+  - test: pmp-lsu-transaction-no-mmu-rv64
+    description: >
+      Check that the no-MMU LSU response keeps PMP address, access type, and
+      valid metadata aligned.
+    <<: *pmp_test_config
+    asm_tests: <path_var>/custom/pmp/lsu_pipeline_store_no_mmu_test.S
+
+  - test: pmp-amo-access-fault-rv64
+    description: >
+      Check that a PMP-denied AMO reports a store/AMO access fault with the
+      matching tval and does not update its destination register.
+    <<: *pmp_test_config
+    asm_tests: <path_var>/custom/pmp/amo_access_fault_test.S
+
   - test: compressed-fpreg-commits-rv64
     <<: *common_test_config
     iterations: 1


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Summary

This PR fix the transaction metadata alignment problem between LSU translation response and PMP data access check.

The PMP data interface currently combine response stage signals (pmp_translation_valid, physical address, translation exception) with LSU current request virtual address and access type. When another LSU request already exist, these signals maybe describe different transactions.

So, a PMP denied store or AMO may be checked as load, then get wrong exception cause or tval. For store case, denied operation maybe continue without access fault.

Fixes #3234
Fixes #3338

## Implementation

Export the MMU's saved LSU virtual address and store indication as metadata for the same response transaction as `lsu_valid_o`, `lsu_paddr_o`, and `lsu_exception_o`. The LSU now supplies these response-side values to the PMP data interface
instead of using the current request metadata.

For configurations with `MmuPresent=0`, the virtual address and access type are registered together with the PMP valid, physical address, and exception signals. This preserves the same transaction alignment in both MMU and no-MMU configurations.

The fix uses the MMU's saved request metadata rather than assuming a fixed translation latency, preserving the association across DTLB misses and page-table walks.

## Relationship to #3384

This PR isolates the PMP-related correction also addressed in draft PR #3384 into a separate, focused bug fix.

This version additionally:

- pairs both the access type and virtual address with the MMU response;
- covers the `MmuPresent=0` path;
- adds focused RV64 regressions for DTLB miss, DTLB hit, AMO, and no-MMU
  behavior; and
- integrates the regressions into the upstream CI matrix.

It does not include the unrelated Svadu, Svpbmt, or Svinval changes from #3384.

## Verification

The following self-checking regression was run locally:

```sh
bash verif/regress/pmp_lsu_transaction.sh
```

It covers:

- a PMP-denied store on the DTLB miss/PTW path;
- a PMP-denied store on the DTLB hit path;
- a PMP-denied AMO;
- the no-MMU LSU response path;
- store/AMO access-fault cause checking;
- matching `mtval`;
- prevention of a denied store memory update; and
- prevention of AMO destination-register writeback.

All three regression invocations passed with:

- Verilator 5.008
- RISC-V GCC 16.1

The modified RTL files also pass `verible-verilog-format`.