### PR TITLE
Reject reserved Zcmp rlist encodings

### DIFF
--- a/core/macro_decoder.sv
+++ b/core/macro_decoder.sv
@@ -162,6 +162,12 @@ module macro_decoder #(
         default: reg_numbers = '0;
       endcase
 
+      // rlist values 0-3 are reserved for Zcmp push/pop-family instructions.
+      if ((instr_i[12:10] == 3'b110 || instr_i[12:10] == 3'b111) && instr_i[7:4] < 4'b0100) begin
+        illegal_instr_o = 1'b1;
+        instr_o_reg     = instr_i;
+      end
+
       if (CVA6Cfg.IS_XLEN32) begin
         unique case (instr_i[7:4])
           4'b0100, 4'b0101, 4'b0110, 4'b0111: begin
@@ -272,7 +278,7 @@ module macro_decoder #(
 
     unique case (state_q)
       IDLE: begin
-        if (is_macro_instr_i) begin
+        if (is_macro_instr_i && !illegal_instr_o) begin
           reg_numbers_d = reg_numbers - 1'b1;
           state_d = issue_ack_i ? INIT : IDLE;
           case (macro_instr_type)

--- a/core/macro_decoder.sv
+++ b/core/macro_decoder.sv
@@ -82,6 +82,11 @@ module macro_decoder #(
       unique case (instr_i[12:10])
         // push or pop
         3'b110: begin
+          if (instr_i[7:4] < 4'b0100) begin
+            illegal_instr_o = 1'b1;
+            instr_o_reg     = instr_i;
+          end
+
           unique case (instr_i[9:8])
             2'b00: begin
               macro_instr_type = PUSH;
@@ -97,6 +102,11 @@ module macro_decoder #(
         end
         // popret or popretz
         3'b111: begin
+          if (instr_i[7:4] < 4'b0100) begin
+            illegal_instr_o = 1'b1;
+            instr_o_reg     = instr_i;
+          end
+
           unique case (instr_i[9:8])
             2'b00: begin
               macro_instr_type = POPRETZ;
@@ -161,12 +171,6 @@ module macro_decoder #(
         4'b1111: reg_numbers = 4'b1100;  // 15
         default: reg_numbers = '0;
       endcase
-
-      // rlist values 0-3 are reserved for Zcmp push/pop-family instructions.
-      if ((instr_i[12:10] == 3'b110 || instr_i[12:10] == 3'b111) && instr_i[7:4] < 4'b0100) begin
-        illegal_instr_o = 1'b1;
-        instr_o_reg     = instr_i;
-      end
 
       if (CVA6Cfg.IS_XLEN32) begin
         unique case (instr_i[7:4])

--- a/verif/regress/cv32a6_tests.sh
+++ b/verif/regress/cv32a6_tests.sh
@@ -81,6 +81,20 @@ if [ "$DV_TARGET" = "cv32a60x" ]; then
   [[ $? > 0 ]] && ((errors++))
 fi
 
+# Regression for #3465: reserved Zcmp rlist values must trap as illegal.
+if [ "$DV_TARGET" = "cv32a60x" ]; then
+  python3 cva6.py \
+    --testlist=../tests/testlist_issues.yaml \
+    --test zcmp-reserved-rlist-rv32 \
+    --iss_yaml cva6.yaml \
+    --target hwconfig \
+    --hwconfig_opts="cv32a60x *RVZCMP=1" \
+    --iss=$DV_SIMULATORS \
+    --linker="../../config/gen_from_riscv_config/cv32a60x/linker/link.ld" \
+    $DV_OPTS
+  [[ $? > 0 ]] && ((errors++))
+fi
+
 make -C ../.. clean
 make clean_all
 

--- a/verif/tests/custom/Zcmp/cm_reserved_rlist_test.S
+++ b/verif/tests/custom/Zcmp/cm_reserved_rlist_test.S
@@ -1,0 +1,72 @@
+#include "riscv_test.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+    # Count the number of expected illegal-instruction traps.
+    li s0, 0
+
+    # Zcmp reserves rlist values 0 through 3 for the
+    # cm.push/cm.pop/cm.popretz/cm.popret instruction families.
+    #
+    # rlist occupies bits [7:4].
+    # spimm is kept at zero because this test targets rlist legality.
+
+    # cm.push, rlist = 0..3
+    .2byte 0xb802
+    .2byte 0xb812
+    .2byte 0xb822
+    .2byte 0xb832
+
+    # cm.pop, rlist = 0..3
+    .2byte 0xba02
+    .2byte 0xba12
+    .2byte 0xba22
+    .2byte 0xba32
+
+    # cm.popretz, rlist = 0..3
+    .2byte 0xbc02
+    .2byte 0xbc12
+    .2byte 0xbc22
+    .2byte 0xbc32
+
+    # cm.popret, rlist = 0..3
+    .2byte 0xbe02
+    .2byte 0xbe12
+    .2byte 0xbe22
+    .2byte 0xbe32
+
+    # Every reserved instruction above must have trapped.
+    li t0, 16
+    bne s0, t0, failure
+
+    RVTEST_PASS
+
+failure:
+    li TESTNUM, 1
+    RVTEST_FAIL
+
+mtvec_handler:
+    # Only illegal-instruction exceptions are expected.
+    csrr t0, mcause
+    li t1, CAUSE_ILLEGAL_INSTRUCTION
+    bne t0, t1, failure
+
+    # Record this expected trap.
+    addi s0, s0, 1
+
+    # Every injected instruction is a 16-bit compressed instruction.
+    # Advance mepc so execution continues at the following encoding.
+    csrr t0, mepc
+    addi t0, t0, 2
+    csrw mepc, t0
+
+    mret
+
+RVTEST_CODE_END
+
+.data
+
+RVTEST_DATA_BEGIN
+
+RVTEST_DATA_END

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -132,3 +132,18 @@ testlist:
       offset assertions.
     iterations: 1
     asm_tests: <path_var>/custom/issues/load-misaligned-warning.S
+
+  - test: zcmp-reserved-rlist-rv32
+    description: >
+      Check that reserved Zcmp push/pop rlist values 0 through 3
+      raise illegal-instruction exceptions.
+    iterations: 1
+    path_var: TESTS_PATH
+    asm_tests: <path_var>/custom/Zcmp/cm_reserved_rlist_test.S
+    gcc_opts: >-
+      -static
+      -mcmodel=medany
+      -fvisibility=hidden
+      -nostdlib
+      -nostartfiles
+      -I../tests/custom/env


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

Reserved Zcmp `rlist` values 0 through 3 for the push/pop-family macro
instructions currently reach the macro expansion path without being
reported as illegal instructions.

The register-count decode maps valid `rlist` values 4 through 15 to
register counts 1 through 12. Reserved values 0 through 3 fall through
with `reg_numbers = 0`.

When such an instruction enters the macro FSM, the IDLE state subtracts
one from this value. This underflows the 4-bit counter from 0 to 15.
The following expansion states have no valid path for that value, which
leaves instruction fetch stalled instead of raising an illegal-instruction
exception.

The reserved encodings should therefore be rejected before they enter
the macro expansion FSM.

## Changes

- Flag Zcmp push/pop-family instructions with `rlist` values 0 through 3
  as illegal.
- Prevent illegal macro instructions from entering the macro expansion
  FSM.
- Scope the reserved-`rlist` check to the Zcmp push/pop families so that
  the overlapping `cm.mva01s` and `cm.mvsa01` encodings remain unchanged.
- Add a directed regression covering all 16 reserved encodings across
  `cm.push`, `cm.pop`, `cm.popretz`, and `cm.popret`.
- Add the regression to the `cv32a60x` Tier-1 regression flow.

## Validation

The reserved encodings were tested with Zcmp enabled in the `cv32a60x`
hardware configuration using Spike and the Verilator test harness.

- Fail-before reproduction: timed out after `2,000,013` cycles.
- Pass-after fix: completed successfully after `1,066` cycles.
- CVA6 + Spike tandem comparison: PASS (`180 matched`).
- `cm_push_pop_test.S`: PASS.
- `cm_popret_test.S`: PASS.
- `cm_popretz_test.S`: PASS.
- `cm_mva01s_test.S`: PASS.
- `cm_mvsa01_test.S`: PASS.
- Full local `cv32a6_tests.sh`: PASS (`8 PASSED, 0 FAILED`).
- GitHub `RV32 Tier1 cv32a60x / cv32a6_tests`: PASS.
- GitHub Tier-1 workflow: PASS.
- GitHub `ci` workflow: PASS.
- GitHub Verible workflow: PASS.
- GitHub `bender-up-to-date` workflow: PASS.
- `verible-verilog-format --verify core/macro_decoder.sv`: PASS.
- `git diff --check`: clean.
- YAML and shell syntax checks: PASS.

The directed regression can be run with:

```sh
python3 cva6.py \
  --testlist=../tests/testlist_issues.yaml \
  --test zcmp-reserved-rlist-rv32 \
  --iss_yaml cva6.yaml \
  --target hwconfig \
  --hwconfig_opts="cv32a60x *RVZCMP=1" \
  --iss=veri-testharness,spike \
  --linker="../../config/gen_from_riscv_config/cv32a60x/linker/link.ld"
````

## Scope / limitations

The RTL change is limited to Zcmp macro decoding and prevents reserved
push/pop-family `rlist` encodings from entering the expansion FSM.

The legality check is intentionally scoped to instruction families with
`instr_i[12:10]` equal to `3'b110` or `3'b111`. Bits `instr_i[7:4]`
overlap fields used by the Zcmp move-family instructions, so treating
every value below 4 as globally illegal would incorrectly affect
`cm.mva01s` and `cm.mvsa01`.

The directed test uses raw 16-bit `.2byte` encodings because the tested
operands are architecturally reserved and therefore cannot be expressed
reliably using normal assembler mnemonics.

The Tier-1 toolchain does not need assembler support for the `zcmp`
extension because the test uses raw encodings. Zcmp is enabled in the
CVA6 hardware configuration through `RVZCMP=1`.

Fixes #3465