### PR TITLE
Fix PMPADDR63 out-of-bounds access

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1996,8 +1996,14 @@ module csr_regfile
           // index is calculated using PMPADDR0 as the offset
           automatic logic [11:0] index = csr_addr.address[11:0] - riscv::CSR_PMPADDR0;
           // check if the entry or the entry above is locked
-          if (!pmpcfg_q[index].locked && !(pmpcfg_q[index+1].locked && pmpcfg_q[index+1].addr_mode == riscv::TOR)) begin
-            pmpaddr_d[index] = csr_wdata[CVA6Cfg.PLEN-3:0];
+          if (!pmpcfg_q[index].locked) begin
+            if (index < 63) begin
+              if (!(pmpcfg_q[index+1].locked && pmpcfg_q[index+1].addr_mode == riscv::TOR)) begin
+                pmpaddr_d[index] = csr_wdata[CVA6Cfg.PLEN-3:0];
+              end
+            end else begin
+              pmpaddr_d[index] = csr_wdata[CVA6Cfg.PLEN-3:0];
+            end
           end
         end
         default: update_access_exception = 1'b1;

--- a/verif/tests/custom/pmp/exact_csrr_test.S
+++ b/verif/tests/custom/pmp/exact_csrr_test.S
@@ -70,6 +70,13 @@ main:
     bne t0, t1, fail
     csrw pmpaddr7, zero
 
+    # Checking PMP ADDR 63 boundary
+    li t0, 0xFACADE7E
+    csrw pmpaddr63, t0
+    csrr t1, pmpaddr63
+    bnez t1, fail
+    csrw pmpaddr63, zero
+
 
     # Write in configurations and check what is written, except for the reserved combinations with R=0 and W=1.
 


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

Writing `CSR_PMPADDR63` currently calculates an index of 63, while the
existing PMP address lock check also accesses `pmpcfg_q[index+1]`.

For `CSR_PMPADDR63`, this evaluates `pmpcfg_q[64]`, which is outside the
declared `pmpcfg_q[63:0]` array. The successor-entry TOR/lock check should
therefore only be performed when a following PMP entry exists.

## Changes

- Guard the successor PMP configuration access with `index < 63`.
- Preserve the existing locked-TOR protection for `PMPADDR0` through
  `PMPADDR62`.
- Handle `PMPADDR63` using only its own lock state because there is no
  successor PMP entry.
- Extend `verif/tests/custom/pmp/exact_csrr_test.S` with a `PMPADDR63`
  boundary access.

## Validation

Tested with the `cv32a65x` configuration using Spike and the Verilator
test harness.

- `decreasing_entries_test`: PASS (`329 matched`)
- `exact_csrr_test`: PASS (`333 matched`)
- `granularity_test`: PASS (`305 matched`)
- `locked_outside_tor_test`: PASS (`315 matched`)
- `lsu_tor_test`: PASS (`345 matched`)
- Full enabled PMP regression: PASS (`5 PASSED, 0 FAILED`)
- `git diff --check`: clean.

The regression was run with:

```sh
python3 cva6.py \
  --target cv32a65x \
  --testlist ../tests/testlist_pmp-cv32a65x.yaml \
  --test all \
  --iss_yaml cva6.yaml \
  --iss veri-testharness,spike
````

## Scope / limitations

The change is limited to the PMP address CSR write path and prevents the
out-of-bounds successor configuration access at the `PMPADDR63`
boundary.

The `cv32a65x` configuration implements fewer than 64 PMP entries, so
`PMPADDR63` is not an implemented PMP entry for this target and reads as
zero. The added test therefore exercises the `PMPADDR63` CSR boundary
path, while the reported defect itself is the static RTL out-of-bounds
array access.

The existing `locked_outside_tor_test` regression verifies that the
locked-TOR behavior for implemented PMP entries remains unchanged.

Fixes #3452
