### PR TITLE
Block TLB updates after PTW faults

### DIFF
--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -516,6 +516,8 @@ module cva6_ptw
                 end
               end
 
+              if (CVA6Cfg.SvnapotEn && pte.n && !is_napot_64k) shared_tlb_update_valid = 1'b0;
+
               // if there is a misaligned page, propagate error
               if (|misaligned_page) begin
                 state_d = PROPAGATE_ERROR;
@@ -528,6 +530,7 @@ module cva6_ptw
                 if (((v_i && is_instr_ptw_q) || (ld_st_v_i && !is_instr_ptw_q)) && ptw_stage_q == S_STAGE && !((|pte.ppn[CVA6Cfg.PPNW-1:CVA6Cfg.GPPNW]) == 1'b0)) begin
                   state_d = PROPAGATE_ERROR;
                   ptw_stage_d = G_FINAL_STAGE;
+                  shared_tlb_update_valid = 1'b0;
                 end
               end
               // this is a pointer to the next TLB level


### PR DESCRIPTION
PTW faults could still install a stale shared TLB entry.

Block updates after invalid Svnapot leaves. Apply the same guard to out-of-range guest PPNs.