### PR TITLE
Enforce dmode trigger write rules

### DIFF
--- a/core/trigger_module.sv
+++ b/core/trigger_module.sv
@@ -780,7 +780,7 @@ module trigger_module
       tselect_d = (tselect_i < CVA6Cfg.SdtrigNrTriggers) ?
           tselect_i[$clog2(CVA6Cfg.SdtrigNrTriggers)-1:0] : tselect_q;
     end
-    if (tdata1_we) begin
+    if (tdata1_we && (!trigger_32_tdata1_q[tselect_q].tdata1_type[27] || debug_mode_i)) begin
       if (CVA6Cfg.IS_XLEN32) begin
         if (CVA6Cfg.Sdtrig && CVA6Cfg.SdtrigNrTriggers > 0) begin
           if(   CVA6Cfg.SdtrigIcount && tdata1_i[31:28] == 4'd3
@@ -792,7 +792,7 @@ module trigger_module
           end
           if (CVA6Cfg.SdtrigIcount && trigger_type_d[tselect_q] == 4'd3) begin
             trigger_32_tdata1_d[tselect_q].icount_type.t_type = trigger_type_d[tselect_q];
-            trigger_32_tdata1_d[tselect_q].icount_type.dmode = tdata1_i[27];
+            trigger_32_tdata1_d[tselect_q].icount_type.dmode = debug_mode_i && tdata1_i[27];
             trigger_32_tdata1_d[tselect_q].icount_type.vs = 0;
             trigger_32_tdata1_d[tselect_q].icount_type.vu = 0;
             trigger_32_tdata1_d[tselect_q].icount_type.hit = tdata1_i[24];
@@ -805,7 +805,7 @@ module trigger_module
             flush_o = 1'b1;
           end else if (CVA6Cfg.SdtrigMcontrol6 && trigger_type_d[tselect_q] == 4'd6) begin
             trigger_32_tdata1_d[tselect_q].mc6_type.t_type = trigger_type_d[tselect_q];
-            trigger_32_tdata1_d[tselect_q].mc6_type.dmode = tdata1_i[27];
+            trigger_32_tdata1_d[tselect_q].mc6_type.dmode = debug_mode_i && tdata1_i[27];
             trigger_32_tdata1_d[tselect_q].mc6_type.uncertain = 0;
             trigger_32_tdata1_d[tselect_q].mc6_type.hit1 = tdata1_i[25];
             trigger_32_tdata1_d[tselect_q].mc6_type.vs = 0;
@@ -827,7 +827,7 @@ module trigger_module
             flush_o = 1'b1;
           end else if (CVA6Cfg.SdtrigEtrigger && trigger_type_d[tselect_q] == 4'd5) begin
             trigger_32_tdata1_d[tselect_q].etrigger_type.t_type = trigger_type_d[tselect_q];
-            trigger_32_tdata1_d[tselect_q].etrigger_type.dmode = tdata1_i[27];
+            trigger_32_tdata1_d[tselect_q].etrigger_type.dmode = debug_mode_i && tdata1_i[27];
             trigger_32_tdata1_d[tselect_q].etrigger_type.hit = tdata1_i[26];
             trigger_32_tdata1_d[tselect_q].etrigger_type.zeroes = '0;
             trigger_32_tdata1_d[tselect_q].etrigger_type.vs = 0;
@@ -840,7 +840,7 @@ module trigger_module
             trigger_32_tdata1_d[tselect_q].etrigger_type.action = tdata1_i[5:0];
           end else if (CVA6Cfg.SdtrigItrigger && trigger_type_d[tselect_q] == 4'd4) begin
             trigger_32_tdata1_d[tselect_q].itrigger_type.t_type = trigger_type_d[tselect_q];
-            trigger_32_tdata1_d[tselect_q].itrigger_type.dmode = tdata1_i[27];
+            trigger_32_tdata1_d[tselect_q].itrigger_type.dmode = debug_mode_i && tdata1_i[27];
             trigger_32_tdata1_d[tselect_q].itrigger_type.hit = tdata1_i[26];
             trigger_32_tdata1_d[tselect_q].itrigger_type.zeroed = '0;
             trigger_32_tdata1_d[tselect_q].itrigger_type.vs = 0;
@@ -857,7 +857,7 @@ module trigger_module
         if (CVA6Cfg.SdtrigIcount && tdata1_i[63:60] == 4'd3) begin
           trigger_type_d[tselect_q] = tdata1_i[63:60];
           trigger_32_tdata1_d[tselect_q].icount_type.t_type  = (tdata1_i[63:60] == 4'd3 || tdata1_i[63:60] == 4'd15) ? tdata1_i[63:60] : trigger_type_q[tselect_q];
-          trigger_32_tdata1_d[tselect_q].icount_type.dmode = tdata1_i[59];
+          trigger_32_tdata1_d[tselect_q].icount_type.dmode = debug_mode_i && tdata1_i[59];
           trigger_32_tdata1_d[tselect_q].icount_type.vs = 0;
           trigger_32_tdata1_d[tselect_q].icount_type.vu = 0;
           trigger_32_tdata1_d[tselect_q].icount_type.hit = tdata1_i[24];
@@ -871,7 +871,7 @@ module trigger_module
         end else if (CVA6Cfg.SdtrigMcontrol6 && tdata1_i[63:60] == 4'd6) begin
           trigger_type_d[tselect_q] = tdata1_i[63:60];
           trigger_32_tdata1_d[tselect_q].mc6_type.t_type  = (tdata1_i[63:60] == 4'd6 || tdata1_i[63:60] == 4'd15) ? tdata1_i[63:60] : trigger_type_q[tselect_q];
-          trigger_32_tdata1_d[tselect_q].mc6_type.dmode = tdata1_i[59];
+          trigger_32_tdata1_d[tselect_q].mc6_type.dmode = debug_mode_i && tdata1_i[59];
           trigger_32_tdata1_d[tselect_q].mc6_type.uncertain = 0;
           trigger_32_tdata1_d[tselect_q].mc6_type.hit1 = tdata1_i[25];
           trigger_32_tdata1_d[tselect_q].mc6_type.vs = 0;
@@ -894,7 +894,7 @@ module trigger_module
         end else if (CVA6Cfg.SdtrigEtrigger && tdata1_i[63:60] == 4'd5) begin
           trigger_type_d[tselect_q] = tdata1_i[63:60];
           trigger_32_tdata1_d[tselect_q].etrigger_type.t_type  = (tdata1_i[63:60] == 4'd5 || tdata1_i[63:60] == 4'd15) ? tdata1_i[63:60] : trigger_type_q[tselect_q];
-          trigger_32_tdata1_d[tselect_q].etrigger_type.dmode = tdata1_i[59];
+          trigger_32_tdata1_d[tselect_q].etrigger_type.dmode = debug_mode_i && tdata1_i[59];
           trigger_32_tdata1_d[tselect_q].etrigger_type.hit = tdata1_i[58];
           trigger_32_tdata1_d[tselect_q].etrigger_type.zeroes = '0;
           trigger_32_tdata1_d[tselect_q].etrigger_type.vs = 0;
@@ -908,7 +908,7 @@ module trigger_module
         end else if (CVA6Cfg.SdtrigItrigger && tdata1_i[63:60] == 4'd4) begin
           trigger_type_d[tselect_q] = tdata1_i[63:60];
           trigger_32_tdata1_d[tselect_q].itrigger_type.t_type  = (tdata1_i[63:60] == 4'd4 || tdata1_i[63:60] == 4'd15) ? tdata1_i[63:60] : trigger_type_q[tselect_q];
-          trigger_32_tdata1_d[tselect_q].itrigger_type.dmode = tdata1_i[59];
+          trigger_32_tdata1_d[tselect_q].itrigger_type.dmode = debug_mode_i && tdata1_i[59];
           trigger_32_tdata1_d[tselect_q].itrigger_type.hit = tdata1_i[58];
           trigger_32_tdata1_d[tselect_q].itrigger_type.zeroed = '0;
           trigger_32_tdata1_d[tselect_q].itrigger_type.vs = 0;
@@ -924,11 +924,11 @@ module trigger_module
         end
       end
     end
-    if (tdata2_we) begin
+    if (tdata2_we && (!trigger_32_tdata1_q[tselect_q].tdata1_type[27] || debug_mode_i)) begin
       tdata2_d[tselect_q] = tdata2_i;
       flush_o = 1'b1;
     end
-    if (CVA6Cfg.SdtrigSupportTextra && tdata3_we) begin
+    if (CVA6Cfg.SdtrigSupportTextra && tdata3_we && (!trigger_32_tdata1_q[tselect_q].tdata1_type[27] || debug_mode_i)) begin
       if (CVA6Cfg.IS_XLEN32) begin
         textra32_tdata3_d[tselect_q].mhvalue   = '0;
         textra32_tdata3_d[tselect_q].mhselect  = '0;

--- a/verif/tb/unit/Makefile
+++ b/verif/tb/unit/Makefile
@@ -1,0 +1,19 @@
+VERILATOR ?= verilator
+ROOT := ../../..
+BUILD_ROOT ?= .build
+TESTS := $(patsubst %.sv,%,$(notdir $(wildcard *_test.sv)))
+
+.PHONY: all clean $(TESTS)
+
+all: $(TESTS)
+
+trigger_dmode_test:
+	$(VERILATOR) --binary --assert --timing -Wno-fatal -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND -Wno-MULTIDRIVEN --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/config_pkg.sv $(ROOT)/core/include/cv64a6_imafdc_sv39_config_pkg.sv $(ROOT)/core/include/build_config_pkg.sv $(ROOT)/core/include/riscv_pkg.sv $(ROOT)/core/include/ariane_pkg.sv $(ROOT)/core/include/triggers_pkg.sv $(ROOT)/core/trigger_module.sv $@.sv
+	$(BUILD_ROOT)/$@/V$@
+
+trigger_napot_test:
+	$(VERILATOR) --binary --assert --timing --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/triggers_pkg.sv $@.sv
+	$(BUILD_ROOT)/$@/V$@
+
+clean:
+	rm -rf $(BUILD_ROOT)

--- a/verif/tb/unit/Makefile
+++ b/verif/tb/unit/Makefile
@@ -8,10 +8,12 @@ TESTS := $(patsubst %.sv,%,$(notdir $(wildcard *_test.sv)))
 all: $(TESTS)
 
 trigger_dmode_test:
+	mkdir -p $(BUILD_ROOT)
 	$(VERILATOR) --binary --assert --timing -Wno-fatal -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND -Wno-MULTIDRIVEN --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/config_pkg.sv $(ROOT)/core/include/cv64a6_imafdc_sv39_config_pkg.sv $(ROOT)/core/include/build_config_pkg.sv $(ROOT)/core/include/riscv_pkg.sv $(ROOT)/core/include/ariane_pkg.sv $(ROOT)/core/include/triggers_pkg.sv $(ROOT)/core/trigger_module.sv $@.sv
 	$(BUILD_ROOT)/$@/V$@
 
 trigger_napot_test:
+	mkdir -p $(BUILD_ROOT)
 	$(VERILATOR) --binary --assert --timing --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/triggers_pkg.sv $@.sv
 	$(BUILD_ROOT)/$@/V$@
 

--- a/verif/tb/unit/trigger_dmode_test.sv
+++ b/verif/tb/unit/trigger_dmode_test.sv
@@ -123,7 +123,7 @@ module trigger_dmode_test;
     write_tdata1(64'h6000_0000_0000_0000);
     assert (tdata1_o[59]);
     assert (tdata1_o[2]);
-    write_tdata2(64'haa);
+    write_tdata2(64'hAA);
     assert (tdata2_o == 64'h55);
 
     $finish;

--- a/verif/tb/unit/trigger_dmode_test.sv
+++ b/verif/tb/unit/trigger_dmode_test.sv
@@ -1,0 +1,131 @@
+module trigger_dmode_test;
+  typedef struct packed {
+    logic        valid;
+    logic [63:0] cause;
+  } exception_t;
+
+  function automatic config_pkg::cva6_cfg_t test_config();
+    config_pkg::cva6_cfg_t cfg;
+    cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg);
+    cfg.Sdtrig = 1;
+    cfg.SdtrigMcontrol6 = 1;
+    cfg.SdtrigNrTriggers = 2;
+    cfg.SdtrigSupportedActions = 2'b11;
+    cfg.SdtrigSupportedMatch = 10'b11_1111_1111;
+    return cfg;
+  endfunction
+
+  localparam config_pkg::cva6_cfg_t TestCfg = test_config();
+
+  logic clk = 0;
+  logic rst_n = 0;
+  logic debug_mode;
+  logic [63:0] tdata1_i;
+  logic [63:0] tdata2_i;
+  logic tdata1_we;
+  logic tdata2_we;
+  logic [63:0] tdata1_o;
+  logic [63:0] tdata2_o;
+
+  always #1 clk = !clk;
+
+  trigger_module #(
+      .CVA6Cfg(TestCfg),
+      .exception_t(exception_t)
+  ) dut (
+      .clk_i(clk),
+      .rst_ni(rst_n),
+      .commit_ack_i('0),
+      .ex_i('0),
+      .priv_lvl_i(riscv::PRIV_LVL_M),
+      .debug_mode_i(debug_mode),
+      .mret_i(1'b0),
+      .sret_i(1'b0),
+      .instr_count_d('0),
+      .instr_count_q('0),
+      .sdtrig_lsu_inputs_vaddr_i('0),
+      .sdtrig_lsu_inputs_data_i('0),
+      .sdtrig_lsu_inputs_fu_i(1'b0),
+      .sdtrig_lsu_inputs_valid_i(1'b0),
+      .sdtrig_load_data_i('0),
+      .sdtrig_load_valid_i(1'b0),
+      .scontext_i('0),
+      .tdata1_i(tdata1_i),
+      .tdata2_i(tdata2_i),
+      .tdata3_i('0),
+      .tselect_i('0),
+      .tselect_we(1'b0),
+      .tdata1_we(tdata1_we),
+      .tdata2_we(tdata2_we),
+      .tdata3_we(1'b0),
+      .tselect_o(),
+      .tdata1_o(tdata1_o),
+      .tdata2_o(tdata2_o),
+      .tdata3_o(),
+      .flush_o(),
+      .mepc_i('0),
+      .mcause_i('0),
+      .mtval_i('0),
+      .etrigger_context_saved_valid_o(),
+      .etrigger_context_mepc_o(),
+      .etrigger_context_mcause_o(),
+      .etrigger_context_mtval_o(),
+      .fetch_sdtrig_pc_i('0),
+      .fetch_sdtrig_instr_i('0),
+      .sdtrig_decoder_action_o(),
+      .sdtrig_load_stall_o(),
+      .sdtrig_load_cancel_o(),
+      .sdtrig_load_action_o(),
+      .sdtrig_store_stall_o(),
+      .sdtrig_store_action_o(),
+      .sdtrig_commit_std_exception_valid_o(),
+      .sdtrig_commit_icount_valid_o(),
+      .sdtrig_commit_action_o(),
+      .sdtrig_commit_icount_nr_instr_o()
+  );
+
+  task automatic write_tdata1(input logic [63:0] value);
+    tdata1_i  = value;
+    tdata1_we = 1;
+    @(posedge clk);
+    #1;
+    tdata1_we = 0;
+  endtask
+
+  task automatic write_tdata2(input logic [63:0] value);
+    tdata2_i  = value;
+    tdata2_we = 1;
+    @(posedge clk);
+    #1;
+    tdata2_we = 0;
+  endtask
+
+  initial begin
+    debug_mode = 0;
+    tdata1_i   = 0;
+    tdata2_i   = 0;
+    tdata1_we  = 0;
+    tdata2_we  = 0;
+    repeat (2) @(posedge clk);
+    rst_n = 1;
+
+    write_tdata1(64'h6800_0000_0000_0004);
+    assert (!tdata1_o[59]);
+    assert (tdata1_o[2]);
+
+    debug_mode = 1;
+    write_tdata1(64'h6800_0000_0000_0004);
+    assert (tdata1_o[59]);
+    write_tdata2(64'h55);
+    assert (tdata2_o == 64'h55);
+
+    debug_mode = 0;
+    write_tdata1(64'h6000_0000_0000_0000);
+    assert (tdata1_o[59]);
+    assert (tdata1_o[2]);
+    write_tdata2(64'haa);
+    assert (tdata2_o == 64'h55);
+
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
M-mode could set `dmode`. It could also rewrite a debug-only trigger.

Ignore locked trigger writes outside Debug Mode. Keep `dmode` clear on non-debug writes.

Test: `make -C verif/tb/unit`