### PR TITLE
Fix NAPOT trigger matching

### DIFF
--- a/core/include/triggers_pkg.sv
+++ b/core/include/triggers_pkg.sv
@@ -96,23 +96,15 @@ package triggers_pkg;
 
   function automatic logic napot_match32(logic [31:0] base, logic [31:0] value);
     logic [31:0] mask;
-    logic is_valid_napot;
 
-    is_valid_napot = ((base & (base + 1)) == 0);
-    if (!is_valid_napot) return 0;
-
-    mask = ~(base & ~(base + 1));
+    mask = ~(base ^ (base + 1));
     return (value & mask) == (base & mask);
   endfunction
 
   function automatic logic napot_match64(logic [63:0] base, logic [63:0] value);
     logic [63:0] mask;
-    logic is_valid_napot;
 
-    is_valid_napot = ((base & (base + 1)) == 0);
-    if (!is_valid_napot) return 0;
-
-    mask = ~(base & ~(base + 1));
+    mask = ~(base ^ (base + 1));
     return (value & mask) == (base & mask);
   endfunction
 

--- a/verif/tb/unit/Makefile
+++ b/verif/tb/unit/Makefile
@@ -1,0 +1,19 @@
+VERILATOR ?= verilator
+ROOT := ../../..
+BUILD_ROOT ?= .build
+TESTS := $(patsubst %.sv,%,$(notdir $(wildcard *_test.sv)))
+
+.PHONY: all clean $(TESTS)
+
+all: $(TESTS)
+
+trigger_dmode_test:
+	$(VERILATOR) --binary --assert --timing -Wno-fatal -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND -Wno-MULTIDRIVEN --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/config_pkg.sv $(ROOT)/core/include/cv64a6_imafdc_sv39_config_pkg.sv $(ROOT)/core/include/build_config_pkg.sv $(ROOT)/core/include/riscv_pkg.sv $(ROOT)/core/include/ariane_pkg.sv $(ROOT)/core/include/triggers_pkg.sv $(ROOT)/core/trigger_module.sv $@.sv
+	$(BUILD_ROOT)/$@/V$@
+
+trigger_napot_test:
+	$(VERILATOR) --binary --assert --timing --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/triggers_pkg.sv $@.sv
+	$(BUILD_ROOT)/$@/V$@
+
+clean:
+	rm -rf $(BUILD_ROOT)

--- a/verif/tb/unit/Makefile
+++ b/verif/tb/unit/Makefile
@@ -8,10 +8,12 @@ TESTS := $(patsubst %.sv,%,$(notdir $(wildcard *_test.sv)))
 all: $(TESTS)
 
 trigger_dmode_test:
+	mkdir -p $(BUILD_ROOT)
 	$(VERILATOR) --binary --assert --timing -Wno-fatal -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND -Wno-MULTIDRIVEN --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/config_pkg.sv $(ROOT)/core/include/cv64a6_imafdc_sv39_config_pkg.sv $(ROOT)/core/include/build_config_pkg.sv $(ROOT)/core/include/riscv_pkg.sv $(ROOT)/core/include/ariane_pkg.sv $(ROOT)/core/include/triggers_pkg.sv $(ROOT)/core/trigger_module.sv $@.sv
 	$(BUILD_ROOT)/$@/V$@
 
 trigger_napot_test:
+	mkdir -p $(BUILD_ROOT)
 	$(VERILATOR) --binary --assert --timing --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/triggers_pkg.sv $@.sv
 	$(BUILD_ROOT)/$@/V$@
 

--- a/verif/tb/unit/trigger_napot_test.sv
+++ b/verif/tb/unit/trigger_napot_test.sv
@@ -1,0 +1,12 @@
+module trigger_napot_test;
+  import triggers_pkg::*;
+
+  initial begin
+    assert (napot_match32(32'h0000_0017, 32'h0000_0010));
+    assert (napot_match32(32'h0000_0017, 32'h0000_001f));
+    assert (!napot_match32(32'h0000_0017, 32'h0000_0020));
+    assert (napot_match64(64'h0000_0000_8000_1007, 64'h0000_0000_8000_100f));
+    assert (!napot_match64(64'h0000_0000_8000_1007, 64'h0000_0000_8000_1010));
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
NAPOT matching rejected every nonzero region and used the wrong comparison mask.

Decode the least-significant zero as the range boundary.

Test: `make -C verif/tb/unit`