### PR TITLE
Fix PMP TOR matching and add RV64 regression test

### DIFF
--- a/core/pmp/src/pmp_entry.sv
+++ b/core/pmp/src/pmp_entry.sv
@@ -29,11 +29,16 @@ module pmp_entry #(
     output logic match_o
 );
   logic [CVA6Cfg.PLEN-1:0] conf_addr_n;
+  logic [CVA6Cfg.PLEN-3:0] tor_conf_addr;
+  logic [CVA6Cfg.PLEN-3:0] tor_conf_addr_prev;
   logic [$clog2(CVA6Cfg.PLEN)-1:0] trail_ones;
   logic [CVA6Cfg.PLEN-1:0] base;
   logic [CVA6Cfg.PLEN-1:0] mask;
   int unsigned size;
   assign conf_addr_n = {2'b11, ~conf_addr_i};
+  // CVA6 implements G=1. Bit 0 does not participate in either TOR boundary.
+  assign tor_conf_addr = {conf_addr_i[CVA6Cfg.PLEN-3:1], 1'b0};
+  assign tor_conf_addr_prev = {conf_addr_prev_i[CVA6Cfg.PLEN-3:1], 1'b0};
   lzc #(
       .WIDTH(CVA6Cfg.PLEN),
       .MODE (1'b0)
@@ -51,15 +56,15 @@ module pmp_entry #(
         size = '0;
         // check that the requested address is in between the two
         // configuration addresses
-        if (addr_i >= ({2'b0, conf_addr_prev_i} << 2) && addr_i < ({2'b0, conf_addr_i} << 2)) begin
+        if (addr_i >= ({2'b0, tor_conf_addr_prev} << 2) && addr_i < ({2'b0, tor_conf_addr} << 2)) begin
           match_o = 1'b1;
         end else match_o = 1'b0;
 
         // synthesis translate_off
         if (match_o == 0) begin
-          assert (addr_i >= ({2'b0, conf_addr_i} << 2) || addr_i < ({2'b0, conf_addr_prev_i} << 2));
+          assert (addr_i >= ({2'b0, tor_conf_addr} << 2) || addr_i < ({2'b0, tor_conf_addr_prev} << 2));
         end else begin
-          assert (addr_i < ({2'b0, conf_addr_i} << 2) && addr_i >= ({2'b0, conf_addr_prev_i} << 2));
+          assert (addr_i < ({2'b0, tor_conf_addr} << 2) && addr_i >= ({2'b0, tor_conf_addr_prev} << 2));
         end
         // synthesis translate_on
 

--- a/verif/regress/cv64a6_imafdc_tests.sh
+++ b/verif/regress/cv64a6_imafdc_tests.sh
@@ -66,6 +66,18 @@ python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml 
   --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../../config/gen_from_riscv_config/linker/link.ld" $DV_OPTS
 [[ $? > 0 ]] && ((errors++))
 
+# Regression for #3342: pmpaddr bit 0 must not affect either TOR boundary
+# when the PMP grain is eight bytes. Run the DUT alone because the default
+# CV64 Spike configuration does not describe CVA6's PMP granularity.
+env -u SPIKE_TANDEM python3 cva6.py \
+  --testlist=../tests/testlist_issues.yaml \
+  --test pmp-tor-grain-rv64 \
+  --iss_yaml cva6.yaml \
+  --target ${DV_TARGET} \
+  --iss=veri-testharness \
+  $DV_OPTS
+[[ $? > 0 ]] && ((errors++))
+
 make -C ../.. clean
 make clean_all
 

--- a/verif/tests/custom/issues/pmp-tor-grain-rv64.S
+++ b/verif/tests/custom/issues/pmp-tor-grain-rv64.S
@@ -1,0 +1,191 @@
+# Regression test for CVA6 issue #3342.
+#
+# CVA6 implements an eight-byte PMP grain (G=1), so pmpaddr[0] must not
+# affect either boundary of a TOR region. Check a denied partial boundary,
+# an allowed complete doubleword, and a lower boundary shared by two entries.
+
+#include "encoding.h"
+
+  .equ MSTATUS_MPP_S,          (PRV_S << 11)
+  .equ CAUSE_LOAD_ACCESS_FAULT, 5
+  .equ PMP_RWX_TOR,            (PMP_TOR | PMP_R | PMP_W | PMP_X)
+  .equ PMP_X_TOR,              (PMP_TOR | PMP_X)
+  .equ PMP_RW_TOR,             (PMP_TOR | PMP_R | PMP_W)
+  .equ SECRET,                 0x89abcdef01234567
+
+  # Keep this complete test in the first load segment. This makes the PMP
+  # regression independent of ELF segment preloading in the test harness.
+  .section .text.init, "ax", @progbits
+  .align 2
+  .globl main
+
+main:
+  la      t0, trap_handler
+  csrw    mtvec, t0
+  csrw    medeleg, zero
+  csrw    mideleg, zero
+  csrw    satp, zero
+  sfence.vma
+
+  li      t0, 1
+  csrw    mscratch, t0
+  j       setup_partial_top
+
+# Phase 1: pmpaddr0 contains (target + 4) >> 2. Its low bit must be ignored,
+# so the effective top is target and an S-mode load at target must fault.
+setup_partial_top:
+  csrw    pmpcfg0, zero
+
+  la      t0, target
+  addi    t0, t0, 4
+  srli    t0, t0, PMP_SHIFT
+  csrw    pmpaddr0, t0
+
+  la      t0, target_end
+  srli    t0, t0, PMP_SHIFT
+  csrw    pmpaddr1, t0
+
+  li      t0, (PMP_TOR << 8) | PMP_RWX_TOR
+  csrw    pmpcfg0, t0
+  fence
+
+  la      t0, probe_partial_top
+  j       enter_s_mode
+
+probe_partial_top:
+  li      a0, 11
+  la      t0, target
+  ld      t1, 0(t0)
+  ecall
+
+# Phase 2: moving the effective top to target + 8 must allow the complete,
+# naturally aligned doubleword.
+setup_complete_top:
+  csrw    pmpcfg0, zero
+
+  la      t0, target
+  addi    t0, t0, 8
+  srli    t0, t0, PMP_SHIFT
+  csrw    pmpaddr0, t0
+  csrw    pmpaddr1, t0
+
+  li      t0, (PMP_TOR << 8) | PMP_RWX_TOR
+  csrw    pmpcfg0, t0
+  fence
+
+  la      t0, probe_complete_top
+  j       enter_s_mode
+
+probe_complete_top:
+  li      a0, 21
+  la      t0, target
+  ld      t1, 0(t0)
+  li      t2, SECRET
+  bne     t1, t2, report_complete_top
+  li      a0, 0
+report_complete_top:
+  ecall
+
+# Phase 3: the same raw pmpaddr0 value is the top of an execute-only entry
+# and the bottom of a read/write entry. Both uses must ignore bit 0, making
+# target readable through entry 1 rather than denied by entry 0.
+setup_shared_boundary:
+  csrw    pmpcfg0, zero
+
+  la      t0, target
+  addi    t0, t0, 4
+  srli    t0, t0, PMP_SHIFT
+  csrw    pmpaddr0, t0
+
+  la      t0, target_end
+  srli    t0, t0, PMP_SHIFT
+  csrw    pmpaddr1, t0
+
+  li      t0, (PMP_RW_TOR << 8) | PMP_X_TOR
+  csrw    pmpcfg0, t0
+  fence
+
+  la      t0, probe_shared_boundary
+  j       enter_s_mode
+
+probe_shared_boundary:
+  li      a0, 31
+  la      t0, target
+  ld      t1, 0(t0)
+  li      t2, SECRET
+  bne     t1, t2, report_shared_boundary
+  li      a0, 0
+report_shared_boundary:
+  ecall
+
+enter_s_mode:
+  li      t1, MSTATUS_MPP
+  csrc    mstatus, t1
+  li      t1, MSTATUS_MPP_S
+  csrs    mstatus, t1
+  csrw    mepc, t0
+  mret
+
+  .align 2
+trap_handler:
+  csrr    t0, mscratch
+  li      t1, 1
+  beq     t0, t1, handle_partial_top
+  li      t1, 2
+  beq     t0, t1, handle_complete_top
+  li      t1, 3
+  beq     t0, t1, handle_shared_boundary
+  li      a0, 40
+  j       finish
+
+handle_partial_top:
+  csrr    t0, mcause
+  li      t1, CAUSE_LOAD_ACCESS_FAULT
+  bne     t0, t1, finish
+
+  li      t0, 2
+  csrw    mscratch, t0
+  j       setup_complete_top
+
+handle_complete_top:
+  csrr    t0, mcause
+  li      t1, CAUSE_SUPERVISOR_ECALL
+  bne     t0, t1, fail_complete_top
+  bnez    a0, finish
+
+  li      t0, 3
+  csrw    mscratch, t0
+  j       setup_shared_boundary
+
+fail_complete_top:
+  li      a0, 22
+  j       finish
+
+handle_shared_boundary:
+  csrr    t0, mcause
+  li      t1, CAUSE_SUPERVISOR_ECALL
+  bne     t0, t1, fail_shared_boundary
+  bnez    a0, finish
+  li      a0, 0
+  j       finish
+
+fail_shared_boundary:
+  li      a0, 32
+
+finish:
+  csrw    pmpcfg0, zero
+  fence
+
+  # Encode a0 using the RISC-V test convention and terminate through tohost.
+  slli    a0, a0, 1
+  ori     a0, a0, 1
+  la      t0, tohost
+  sd      a0, 0(t0)
+1:
+  j       1b
+
+  .align 3
+target:
+  .dword  SECRET
+target_end:
+  .dword  0

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -50,6 +50,14 @@ testlist:
     iterations: 1
     asm_tests: <path_var>/custom/issues/mret-mpv-rv64.S
 
+  - test: pmp-tor-grain-rv64
+    <<: *common_test_config
+    description: >
+      Check that pmpaddr bit 0 does not affect either TOR boundary when the
+      PMP grain is eight bytes.
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/pmp-tor-grain-rv64.S
+
   - test: zcmt-jvt-index-rv32
     description: >
       Check that cm.jalt uses the complete eight-bit JVT table index.


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

CVA6 implements an 8-byte PMP granularity, but TOR matching still uses pmpaddr[0]. This can incorrectly allow an aligned 8-byte access across a TOR boundary. The change ignores that bit for both TOR boundaries and adds a regression test.
This PR fixes #3342. 
