### PR TITLE
Retain LoadAddr trigger across cancellation

### DIFF
--- a/core/trigger_module.sv
+++ b/core/trigger_module.sv
@@ -155,6 +155,7 @@ module trigger_module
   logic [$clog2(CVA6Cfg.SdtrigNrTriggers)-1:0] previous_trigg_i;
   logic sdtrig_commit_icount_valid_d;
   logic [CVA6Cfg.XLEN-1:0] sdtrig_commit_action_d;
+  logic [CVA6Cfg.XLEN-1:0] sdtrig_load_action_d, sdtrig_load_action_q;
   logic [$clog2(CVA6Cfg.NrCommitPorts)-1:0] sdtrig_commit_icount_nr_instr_d;
   logic e_matched_q, e_matched_d;
   logic
@@ -233,7 +234,8 @@ module trigger_module
     sdtrig_commit_icount_nr_instr_d = '0;
     sdtrig_commit_action_d = '0;
     sdtrig_commit_std_exception_valid_d = 1'b0;
-    sdtrig_load_action_o = '0;
+    sdtrig_load_action_d = sdtrig_load_action_q;
+    sdtrig_load_action_o = sdtrig_load_cancel_q ? sdtrig_load_action_q : '0;
     sdtrig_store_action_o = '0;
     flush_o = 1'b0;
 
@@ -593,7 +595,7 @@ module trigger_module
                                       trigger_32_tdata1_d[i].mc6_type.match);
                 end
                 //Load trigger on address fire logic
-                if (priv_match[i] && matchLA || sdtrig_load_cancel_q) begin
+                if (priv_match[i] && matchLA) begin
                   trigger_32_tdata1_d[i].mc6_type.hit0 = 1'b1;  //before
                   trigger_32_tdata1_d[i].mc6_type.hit1 = 1'b0;
                   if (CVA6Cfg.SdtrigTriggerChaining) begin
@@ -766,7 +768,8 @@ module trigger_module
       if (CVA6Cfg.SdtrigMcontrol6LoadAddr && fire_req_LA.valid || CVA6Cfg.SdtrigMcontrol6Store && fire_req_SX.valid) begin
         if (CVA6Cfg.SdtrigMcontrol6LoadAddr && fire_req_LA.valid) begin
           sdtrig_load_cancel_d = (sdtrig_load_cancel_q) ? 1'b0 : 1'b1;
-          sdtrig_load_action_o = fire_req_LA.action;
+          if (!sdtrig_load_cancel_q) sdtrig_load_action_d = fire_req_LA.action;
+          sdtrig_load_action_o = sdtrig_load_cancel_q ? sdtrig_load_action_q : fire_req_LA.action;
         end
         if (CVA6Cfg.SdtrigMcontrol6Store && fire_req_SX.valid) begin
           sdtrig_store_action_o = fire_req_SX.action;
@@ -987,6 +990,7 @@ module trigger_module
         sdtrig_commit_action_o <= '0;
         sdtrig_load_stall_s <= '0;
         sdtrig_load_cancel_q <= '0;
+        sdtrig_load_action_q <= '0;
         etrigger_context_saved_valid_q <= 1'b0;
         etrigger_context_mepc_q <= '0;
         etrigger_context_mcause_q <= '0;
@@ -1027,6 +1031,7 @@ module trigger_module
         mret_reg_q                          <= mret_reg_d;
         sdtrig_load_stall_s                 <= sdtrig_load_stall_o;
         sdtrig_load_cancel_q                <= sdtrig_load_cancel_d;
+        sdtrig_load_action_q                <= sdtrig_load_action_d;
         if (CVA6Cfg.SdtrigTriggerChaining) trigger_chain_vector_q <= trigger_chain_vector_d;
       end
     end

--- a/verif/tb/unit/Makefile
+++ b/verif/tb/unit/Makefile
@@ -1,0 +1,16 @@
+VERILATOR ?= verilator
+ROOT := ../../..
+BUILD_ROOT ?= .build
+TESTS := $(patsubst %.sv,%,$(notdir $(wildcard *_test.sv)))
+
+.PHONY: all clean $(TESTS)
+
+all: $(TESTS)
+
+trigger_loadaddr_test:
+	mkdir -p $(BUILD_ROOT)
+	$(VERILATOR) --binary --assert --timing -Wno-fatal -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND -Wno-MULTIDRIVEN --top-module $@ --Mdir $(BUILD_ROOT)/$@ $(ROOT)/core/include/config_pkg.sv $(ROOT)/core/include/cv64a6_imafdc_sv39_config_pkg.sv $(ROOT)/core/include/build_config_pkg.sv $(ROOT)/core/include/riscv_pkg.sv $(ROOT)/core/include/ariane_pkg.sv $(ROOT)/core/include/triggers_pkg.sv $(ROOT)/core/trigger_module.sv $@.sv
+	$(BUILD_ROOT)/$@/V$@
+
+clean:
+	rm -rf $(BUILD_ROOT)

--- a/verif/tb/unit/trigger_loadaddr_test.sv
+++ b/verif/tb/unit/trigger_loadaddr_test.sv
@@ -1,0 +1,158 @@
+module trigger_loadaddr_test;
+  function automatic config_pkg::cva6_cfg_t test_config();
+    config_pkg::cva6_cfg_t cfg;
+    cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg);
+    cfg.Sdtrig = 1;
+    cfg.SdtrigMcontrol6 = 1;
+    cfg.SdtrigMcontrol6LoadAddr = 1;
+    cfg.SdtrigNrTriggers = 2;
+    cfg.SdtrigSupportedActions = 2'b11;
+    cfg.SdtrigSupportedMatch = 10'b11_1111_1111;
+    return cfg;
+  endfunction
+
+  localparam config_pkg::cva6_cfg_t TestCfg = test_config();
+
+  typedef struct packed {
+    logic        valid;
+    logic [63:0] cause;
+    logic [63:0] tval;
+    logic [63:0] tval2;
+    logic [31:0] tinst;
+    logic        gva;
+    logic        timing;
+  } exception_t;
+
+  logic clk = 0;
+  logic rst_n = 0;
+  logic [63:0] tdata1_i = 0;
+  logic [63:0] tdata2_i = 0;
+  logic [63:0] tselect_i = 0;
+  logic tdata1_we = 0;
+  logic tdata2_we = 0;
+  logic tselect_we = 0;
+  logic [63:0] tdata1_o;
+  logic lsu_valid = 0;
+  logic [63:0] lsu_vaddr = 0;
+  logic trigger_cancel;
+  logic [63:0] trigger_action;
+
+  always #1 clk = !clk;
+
+  trigger_module #(
+      .CVA6Cfg(TestCfg),
+      .exception_t(exception_t)
+  ) dut (
+      .clk_i(clk),
+      .rst_ni(rst_n),
+      .commit_ack_i('0),
+      .ex_i('0),
+      .priv_lvl_i(riscv::PRIV_LVL_M),
+      .debug_mode_i(1'b0),
+      .mret_i(1'b0),
+      .sret_i(1'b0),
+      .instr_count_d('0),
+      .instr_count_q('0),
+      .sdtrig_lsu_inputs_vaddr_i(lsu_vaddr),
+      .sdtrig_lsu_inputs_data_i('0),
+      .sdtrig_lsu_inputs_fu_i(1'b0),
+      .sdtrig_lsu_inputs_valid_i(lsu_valid),
+      .sdtrig_load_data_i('0),
+      .sdtrig_load_valid_i(1'b0),
+      .scontext_i('0),
+      .tdata1_i(tdata1_i),
+      .tdata2_i(tdata2_i),
+      .tdata3_i('0),
+      .tselect_i(tselect_i),
+      .tselect_we(tselect_we),
+      .tdata1_we(tdata1_we),
+      .tdata2_we(tdata2_we),
+      .tdata3_we(1'b0),
+      .tselect_o(),
+      .tdata1_o(tdata1_o),
+      .tdata2_o(),
+      .tdata3_o(),
+      .flush_o(),
+      .mepc_i('0),
+      .mcause_i('0),
+      .mtval_i('0),
+      .etrigger_context_saved_valid_o(),
+      .etrigger_context_mepc_o(),
+      .etrigger_context_mcause_o(),
+      .etrigger_context_mtval_o(),
+      .fetch_sdtrig_pc_i('0),
+      .fetch_sdtrig_instr_i('0),
+      .sdtrig_decoder_action_o(),
+      .sdtrig_load_stall_o(),
+      .sdtrig_load_cancel_o(trigger_cancel),
+      .sdtrig_load_action_o(trigger_action),
+      .sdtrig_store_stall_o(),
+      .sdtrig_store_action_o(),
+      .sdtrig_commit_std_exception_valid_o(),
+      .sdtrig_commit_icount_valid_o(),
+      .sdtrig_commit_action_o(),
+      .sdtrig_commit_icount_nr_instr_o()
+  );
+
+  task automatic write_tdata1(input logic [63:0] value);
+    tdata1_i = value;
+    tdata1_we = 1;
+    @(posedge clk);
+    #1;
+    tdata1_we = 0;
+  endtask
+
+  task automatic write_tselect(input logic [63:0] value);
+    tselect_i = value;
+    tselect_we = 1;
+    @(posedge clk);
+    #1;
+    tselect_we = 0;
+  endtask
+
+  task automatic write_tdata2(input logic [63:0] value);
+    tdata2_i = value;
+    tdata2_we = 1;
+    @(posedge clk);
+    #1;
+    tdata2_we = 0;
+  endtask
+
+  initial begin
+    repeat (2) @(posedge clk);
+    rst_n = 1;
+
+    write_tselect(0);
+    write_tdata2(64'h1234);
+    write_tdata1(64'h6000_0000_0000_0041);
+    write_tselect(1);
+    write_tdata2(64'h5678);
+    write_tdata1(64'h6000_0000_0000_1041);
+
+    lsu_vaddr = 64'h1234;
+    lsu_valid = 1;
+    @(posedge clk);
+    #1;
+
+    assert (trigger_cancel)
+      else $fatal(1, "LoadAddr match did not produce cancel");
+    assert (trigger_action == riscv::BREAKPOINT)
+      else $fatal(1, "cancel used an unrelated trigger action");
+
+    lsu_valid = 0;
+    @(posedge clk);
+    #1;
+    assert (!trigger_cancel)
+      else $fatal(1, "cancel pulse did not clear");
+
+    write_tselect(0);
+    assert (tdata1_o[22])
+      else $fatal(1, "matching trigger did not record hit0");
+    write_tselect(1);
+    assert (!tdata1_o[22])
+      else $fatal(1, "unmatched trigger recorded hit0");
+
+    $display("PASS: LoadAddr cancel retains its trigger");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
A LoadAddr cancel marked every LoadAddr trigger as hit. A later trigger could replace the selected action.

Retain the initiating action. Only mark the matching trigger.

Test: `make -C verif/tb/unit trigger_loadaddr_test`