### PR TITLE
Fix Zcmt table jump target LSB

### DIFF
--- a/core/zcmt_decoder.sv
+++ b/core/zcmt_decoder.sv
@@ -97,8 +97,9 @@ module zcmt_decoder #(
       end
       TABLE_JUMP: begin
         if (req_port_i.data_rvalid) begin
-          // save the PC relative Xlen table jump address 
-          jump_address_o = $unsigned($signed(req_port_i.data_rdata) - $signed(pc_i));
+          // Clear bit 0 of the JVT target before converting it to a PC-relative offset.
+          jump_address_o =
+              $unsigned($signed({req_port_i.data_rdata[CVA6Cfg.XLEN-1:1], 1'b0}) - $signed(pc_i));
           if (instr_i[9:2] < 32) begin  // jal pc_offset, x0 for no return stack
             instr_o = {
               20'h0, 5'h0, riscv::OpcodeJal

--- a/verif/regress/issue-tests.sh
+++ b/verif/regress/issue-tests.sh
@@ -51,4 +51,39 @@ if [ "$zcmt_status" -ne 0 ]; then
   return "$zcmt_status" 2>/dev/null || exit "$zcmt_status"
 fi
 
+
+# Check that cm.jt clears bit 0 of the loaded JVT target.
+python3 cva6.py \
+  --testlist=../tests/testlist_issues.yaml \
+  --test zcmt-jt-target-lsb-rv32 \
+  --iss_yaml cva6.yaml \
+  --target hwconfig \
+  --hwconfig_opts="cv32a60x *RVZCMT=1" \
+  --iss=veri-testharness \
+  --linker="../../config/gen_from_riscv_config/cv32a60x/linker/link.ld"
+
+zcmt_jt_lsb_status=$?
+if [ "$zcmt_jt_lsb_status" -ne 0 ]; then
+  echo "Error: Zcmt cm.jt target LSB regression failed"
+  cd ../..
+  return "$zcmt_jt_lsb_status" 2>/dev/null || exit "$zcmt_jt_lsb_status"
+fi
+
+# Check that cm.jalt clears bit 0 of the loaded JVT target.
+python3 cva6.py \
+  --testlist=../tests/testlist_issues.yaml \
+  --test zcmt-jalt-target-lsb-rv32 \
+  --iss_yaml cva6.yaml \
+  --target hwconfig \
+  --hwconfig_opts="cv32a60x *RVZCMT=1" \
+  --iss=veri-testharness \
+  --linker="../../config/gen_from_riscv_config/cv32a60x/linker/link.ld"
+
+zcmt_jalt_lsb_status=$?
+if [ "$zcmt_jalt_lsb_status" -ne 0 ]; then
+  echo "Error: Zcmt cm.jalt target LSB regression failed"
+  cd ../..
+  return "$zcmt_jalt_lsb_status" 2>/dev/null || exit "$zcmt_jalt_lsb_status"
+fi
+
 cd -

--- a/verif/tests/custom/zcmt/cm_jalt_target_lsb.S
+++ b/verif/tests/custom/zcmt/cm_jalt_target_lsb.S
@@ -1,0 +1,78 @@
+.globl _start
+_start:
+    la t0, trap_handler
+    csrw mtvec, t0
+
+    # Configure the Jump Vector Table.
+    la t0, __jvt_base$
+
+    # JVT CSR = 0x017.
+    # Use the numeric CSR address so this test does not depend on
+    # assembler support for the Zcmt CSR name.
+    csrw 0x017, t0
+
+    fence.i
+
+    # JVT entry 64 contains cm_jalt_target + 1. cm.jalt must clear bit 0
+    # before using the loaded value as the jump target.
+    #
+    # cm.jalt 64 encoding = 0xa102
+    li s0, 0
+    .2byte 0xa102
+
+after_cm_jalt:
+    # The target must have executed and returned here.
+    beqz s0, fail
+    j pass
+
+.balign 2
+cm_jalt_target:
+    # Verify that the architectural PC has bit 0 cleared.
+    auipc t1, 0
+    andi t1, t1, 1
+    bnez t1, fail
+
+    li s0, 1
+
+    # cm.jalt links to the instruction following the compressed jump.
+    ret
+
+.balign 4
+trap_handler:
+    j fail
+
+pass:
+    # RISC-V test convention: tohost = 1 means success.
+    li x1, 1
+    j write_tohost
+
+fail:
+    # An odd value greater than one represents failure.
+    li x1, 3
+
+write_tohost:
+    la t0, tohost
+    sw x1, 0(t0)
+
+1:
+    j 1b
+
+.section .riscv.jvt, "a", @progbits
+.align 6
+__jvt_base$:
+    # Entries 0 through 63 are unused by this test.
+    .space 256
+
+    # Entry 64.
+    .word cm_jalt_target + 1
+
+.section .data
+.align 6
+.global tohost
+tohost:
+    .dword 0
+
+.align 6
+.global fromhost
+fromhost:
+    .dword 0

--- a/verif/tests/custom/zcmt/cm_jt_target_lsb.S
+++ b/verif/tests/custom/zcmt/cm_jt_target_lsb.S
@@ -1,0 +1,68 @@
+.globl _start
+_start:
+    la t0, trap_handler
+    csrw mtvec, t0
+
+    # Configure the Jump Vector Table.
+    la t0, __jvt_base$
+
+    # JVT CSR = 0x017.
+    # Use the numeric CSR address so this test does not depend on
+    # assembler support for the Zcmt CSR name.
+    csrw 0x017, t0
+
+    fence.i
+
+    # JVT entry 0 contains cm_jt_target + 1. cm.jt must clear bit 0
+    # before using the loaded value as the jump target.
+    #
+    # cm.jt 0 encoding = 0xa002
+    .2byte 0xa002
+
+    # cm.jt must not fall through.
+    j fail
+
+.balign 2
+cm_jt_target:
+    # Verify that the architectural PC has bit 0 cleared.
+    auipc t1, 0
+    andi t1, t1, 1
+    bnez t1, fail
+
+    j pass
+
+.balign 4
+trap_handler:
+    j fail
+
+pass:
+    # RISC-V test convention: tohost = 1 means success.
+    li x1, 1
+    j write_tohost
+
+fail:
+    # An odd value greater than one represents failure.
+    li x1, 3
+
+write_tohost:
+    la t0, tohost
+    sw x1, 0(t0)
+
+1:
+    j 1b
+
+.section .riscv.jvt, "a", @progbits
+.align 6
+__jvt_base$:
+    .word cm_jt_target + 1
+
+.section .data
+.align 6
+.global tohost
+tohost:
+    .dword 0
+
+.align 6
+.global fromhost
+fromhost:
+    .dword 0

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -89,3 +89,29 @@ testlist:
       -nostdlib
       -nostartfiles
       -I../tests/custom/env
+
+  - test: zcmt-jt-target-lsb-rv32
+    description: >
+      Check that cm.jt clears bit 0 of the loaded JVT target.
+    iterations: 1
+    path_var: TESTS_PATH
+    asm_tests: <path_var>/custom/zcmt/cm_jt_target_lsb.S
+    gcc_opts: >-
+      -static
+      -mcmodel=medany
+      -fvisibility=hidden
+      -nostdlib
+      -nostartfiles
+
+  - test: zcmt-jalt-target-lsb-rv32
+    description: >
+      Check that cm.jalt clears bit 0 of the loaded JVT target.
+    iterations: 1
+    path_var: TESTS_PATH
+    asm_tests: <path_var>/custom/zcmt/cm_jalt_target_lsb.S
+    gcc_opts: >-
+      -static
+      -mcmodel=medany
+      -fvisibility=hidden
+      -nostdlib
+      -nostartfiles


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

Zcmt table jumps currently use the JVT-loaded value directly when
calculating the jump target.

For `cm.jt` and `cm.jalt`, bit 0 of the value loaded from the JVT must
be cleared before it is used as the architectural target. Since CVA6
expands these table jumps to an internal `JAL`, they do not pass through
the existing `JALR` target-LSB clearing in the branch unit.

As a result, an odd address stored in a JVT entry can cause CVA6 to
jump to the odd address instead of the required address with bit 0
cleared.

## Changes

- Clear bit 0 of the JVT-loaded target in `core/zcmt_decoder.sv`
  before converting the target to the PC-relative offset used by the
  internal `JAL` expansion.
- Add an RV32 directed regression for `cm.jt` with an odd JVT target.
- Add an RV32 directed regression for `cm.jalt` with an odd JVT target.
- Check that the `cm.jalt` target executes and returns through the
  expected link address.
- Register both directed tests in `verif/tests/testlist_issues.yaml`.
- Add both regressions to `verif/regress/issue-tests.sh`.

## Validation

The permanent directed regressions were checked both before and after
the RTL change.

Before the fix:

- `zcmt-jt-target-lsb-rv32`: FAIL
- `zcmt-jalt-target-lsb-rv32`: FAIL

After the fix:

- `zcmt-jt-target-lsb-rv32`: PASS
- `zcmt-jalt-target-lsb-rv32`: PASS
- Existing `zcmt-jvt-index-rv32` regression: PASS

Additional checks:

- `verible-verilog-format --verify core/zcmt_decoder.sv`: PASS
- `bash -n verif/regress/issue-tests.sh`: PASS
- `git diff --check`: clean
- Rebasing against the current `upstream/master` required no changes.
- Working tree is clean after the final regression runs.

## Scope / limitations

This change is limited to Zcmt table-jump target handling.

It does not change the normal `JAL`, `JALR`, or branch-unit target
handling. Bit 0 is cleared specifically on the target loaded from the
JVT before that target is converted to the PC-relative offset used by
the Zcmt internal `JAL` expansion.

No known limitation is introduced by this change.

Fixes #3441
