### PR TITLE
csr_regfile: mask epc[1] when C extension is disabled

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1296,7 +1296,9 @@ module csr_regfile
         if (CVA6Cfg.RVH) vsscratch_d = csr_wdata;
         else update_access_exception = 1'b1;
         riscv::CSR_VSEPC:
-        if (CVA6Cfg.RVH) vsepc_d = {csr_wdata[CVA6Cfg.XLEN-1:1], 1'b0};
+        // bit[1] stays writable only with RVC; without RVC (IALIGN=32) vsepc[1:0] are always zero
+        if (CVA6Cfg.RVH)
+          vsepc_d = {csr_wdata[CVA6Cfg.XLEN-1:2], csr_wdata[1] & CVA6Cfg.RVC, 1'b0};
         else update_access_exception = 1'b1;
         riscv::CSR_VSCAUSE:
         if (CVA6Cfg.RVH) vscause_d = csr_wdata;
@@ -1382,7 +1384,9 @@ module csr_regfile
         if (CVA6Cfg.RVS) sscratch_d = csr_wdata;
         else update_access_exception = 1'b1;
         riscv::CSR_SEPC:
-        if (CVA6Cfg.RVS) sepc_d = {csr_wdata[CVA6Cfg.XLEN-1:1], 1'b0};
+        // bit[1] stays writable only with RVC; without RVC (IALIGN=32) sepc[1:0] are always zero
+        if (CVA6Cfg.RVS)
+          sepc_d = {csr_wdata[CVA6Cfg.XLEN-1:2], csr_wdata[1] & CVA6Cfg.RVC, 1'b0};
         else update_access_exception = 1'b1;
         riscv::CSR_SCAUSE:
         if (CVA6Cfg.RVS) scause_d = csr_wdata;
@@ -1694,8 +1698,9 @@ module csr_regfile
 
         riscv::CSR_MSCRATCH: mscratch_d = csr_wdata;
         riscv::CSR_MEPC:
+        // bit[1] stays writable only with RVC; without RVC (IALIGN=32) mepc[1:0] are always zero
         mepc_d = (CVA6Cfg.SdtrigEtrigger && sdtrig_etrigger_context_saved_valid && mret) ? sdtrig_etrigger_context_mepc
-        : {csr_wdata[CVA6Cfg.XLEN-1:1], 1'b0};
+        : {csr_wdata[CVA6Cfg.XLEN-1:2], csr_wdata[1] & CVA6Cfg.RVC, 1'b0};
         riscv::CSR_MCAUSE:
         mcause_d = (CVA6Cfg.SdtrigEtrigger && sdtrig_etrigger_context_saved_valid && mret) ? sdtrig_etrigger_context_mcause : {csr_wdata[CVA6Cfg.XLEN - 1], {CVA6Cfg.XLEN - 6{1'b0}}, csr_wdata[4:0]};
         riscv::CSR_MTVAL: begin


### PR DESCRIPTION
When the C extension is compiled out (CVA6Cfg.RVC == 0) the core supports only IALIGN=32, so the two low bits of mepc/sepc/vsepc must always read as zero. The CSR write path only forced bit[0] to zero and kept bit[1] from csr_wdata, letting software store an *epc value whose bit[1] == 1. That value is read back verbatim and is also fed directly to MRET/SRET to set the PC, resuming at a 2-mod-4 address that is not a legal instruction address on a machine without compressed instructions.

Gate bit[1] with CVA6Cfg.RVC on the mepc/sepc/vsepc write paths so it stays writable only when RVC is enabled (IALIGN=16) and is forced to zero otherwise. Configurations with C keep bit-identical behaviour. The trap write path is unaffected because pc_i is always 4-byte aligned when IALIGN=32, so the register never stores bit[1] == 1 and the read path is correct transitively.

Priv. spec (mepc/sepc): "On implementations that support only IALIGN=32, the two low bits (mepc[1:0]) are always zero." vsepc is WARL and must hold the same set of values as sepc.

Fixes #3316

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

