### PR TITLE
docs: fix broken contributing link

### DIFF
--- a/docs/01_cva6_user/Introduction.rst
+++ b/docs/01_cva6_user/Introduction.rst
@@ -40,7 +40,7 @@ The current limitation of documentation on CVA6 is well understood.
 Rather than regretting this, the reader is encouraged to contribute to it to make CVA6 an even better core.
 To contribute to the project, refer to the Contributing_ guidelines and get in touch with the team.
 
-.. _Contributing: https://github.com/jquevremont/cva6/blob/master/CONTRIBUTING.md
+.. _Contributing: https://github.com/openhwgroup/cva6/blob/master/CONTRIBUTING.md
 
 Target Audience
 ---------------


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

<!-- Please indicate why this PR is needed for the project -->
### Description
Update Introduction.rst to point to CONTRIBUTING.md in the official OpenHW Foundation CVA6 repository.
Fixes #3503.

### Testing
Successfully built the documentation with `make sphinx` command.