### PR TITLE
mmu: re-check load R/X against current MXR on DTLB hit

### DIFF
--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -511,8 +511,11 @@ module cva6_mmu
   logic lsu_req_n, lsu_req_q;
   logic lsu_is_store_n, lsu_is_store_q;
   logic dtlb_hit_n, dtlb_hit_q;
+  logic hlvx_inst_n, hlvx_inst_q;
   logic [CVA6Cfg.PtLevels-2:0] dtlb_is_page_n, dtlb_is_page_q;
   exception_t misaligned_ex_n, misaligned_ex_q;
+  // Cached DTLB load permission is stale w.r.t. the current MXR (see below).
+  logic dtlb_mxr_load_err;
 
   // check if we need to do translation or if we are always ready (e.g.: we are not translating anything)
   assign lsu_dtlb_hit_o = (en_ld_st_translation_i || en_ld_st_g_translation_i) ? dtlb_lu_hit : 1'b1;
@@ -527,6 +530,7 @@ module cva6_mmu
     dtlb_hit_n = dtlb_lu_hit;
     lsu_is_store_n = lsu_is_store_i;
     dtlb_is_page_n = dtlb_is_page;
+    hlvx_inst_n = hlvx_inst_i;
     misaligned_ex_n = misaligned_ex_i;
 
     lsu_valid_o = lsu_req_q;
@@ -544,6 +548,16 @@ module cva6_mmu
     daccess_err = en_ld_st_translation_i &&
               ((ld_st_priv_lvl_i == riscv::PRIV_LVL_S && (ld_st_v_i ? !vs_sum_i : !sum_i ) && dtlb_pte_q.u) || // SUM is not set and we are trying to access a user page in supervisor mode
     (ld_st_priv_lvl_i == riscv::PRIV_LVL_U && !dtlb_pte_q.u));
+
+    // Re-evaluate the load permission of a cached DTLB entry against the *current*
+    // MXR. Changes to mstatus.MXR/sstatus.MXR take effect immediately without an
+    // SFENCE.VMA, so an execute-only page (r=0, x=1) that is loadable while MXR=1
+    // must fault on a load once MXR is cleared. A virtualized (V=1) access reads the
+    // VS-stage leaf, so it is relaxed by vsstatus.MXR (vmxr_i), mirroring how SUM
+    // selects vs_sum_i/sum_i above. Readable pages (r=1) are unaffected, and HLVX
+    // loads intentionally read executable pages.
+    dtlb_mxr_load_err = en_ld_st_translation_i && !dtlb_pte_q.r && !hlvx_inst_q &&
+        !(dtlb_pte_q.x && (ld_st_v_i ? vmxr_i : mxr_i));
 
     if (CVA6Cfg.RVH) begin
       lsu_tinst_n = lsu_tinst_i;
@@ -640,7 +654,7 @@ module cva6_mmu
               lsu_exception_o.gva = ld_st_v_i;
             end
             // check for sufficient access privileges - throw a page fault if necessary
-          end else if (daccess_err || canonical_addr_check) begin
+          end else if (daccess_err || canonical_addr_check || dtlb_mxr_load_err) begin
             lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
@@ -763,6 +777,7 @@ module cva6_mmu
       dtlb_hit_q      <= '0;
       lsu_is_store_q  <= '0;
       dtlb_is_page_q  <= '0;
+      hlvx_inst_q     <= '0;
       lsu_tinst_q     <= '0;
       hs_ld_st_inst_q <= '0;
       misaligned_ex_q <= '0;
@@ -773,6 +788,7 @@ module cva6_mmu
       dtlb_hit_q      <= dtlb_hit_n;
       lsu_is_store_q  <= lsu_is_store_n;
       dtlb_is_page_q  <= dtlb_is_page_n;
+      hlvx_inst_q     <= hlvx_inst_n;
       misaligned_ex_q <= misaligned_ex_n;
 
       if (CVA6Cfg.RVH) begin


### PR DESCRIPTION
The DTLB caches the leaf PTE of an execute-only page (R=0, X=1) independently of mstatus.MXR. On a later DTLB hit the load path only checked privilege/SUM/U and the canonical address, never re-evaluating pte.r/pte.x against the current MXR. Clearing mstatus.MXR (or its sstatus view) therefore did not take effect until the entry was evicted, so a load from an execute-only page kept succeeding with a stale "readable" permission.

Re-evaluate the cached leaf permission on every DTLB-hit load, exactly as SUM is already handled dynamically: raise a load page-fault when the entry is not readable (r=0) and is not made readable by the current MXR (x & MXR), while leaving readable pages (r=1) and HLVX loads untouched. A virtualized (V=1) access reads the VS-stage leaf, so it is relaxed by vsstatus.MXR: the effective bit is selected as (ld_st_v_i ? vmxr_i : mxr_i), mirroring how SUM selects vs_sum_i/sum_i. This makes the DTLB-cached translation indistinguishable from re-running the walk.

The privileged spec requires this: "Changes to the sstatus fields SUM and MXR take effect immediately, without the need to execute an SFENCE.VMA instruction", and "When MXR=0, only loads from pages marked readable (R=1 ...) will succeed."

Fixes #3298

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

