### PR TITLE
RTD: Update OS version to ubuntu-lts-latest

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ submodules:
   recursive: true
 
 build:
-  os: "ubuntu-lts-latest"
+  os: "ubuntu-26.04"
   tools:
     python: "3.9"
     nodejs: "20"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ submodules:
   recursive: true
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
     python: "3.9"
     nodejs: "20"


### PR DESCRIPTION
Automatic re-generation of CVA6 documentation on ReadTheDocs is failing because of Ubuntu-20.04 is no longer supported.