### PR TITLE
csr: mideleg VS bits read-only-one from reset

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -628,7 +628,7 @@ module csr_regfile
         if (CVA6Cfg.RVS) csr_rdata = medeleg_q;
         else read_access_exception = 1'b1;
         riscv::CSR_MIDELEG:
-        if (CVA6Cfg.RVS) csr_rdata = mideleg_q;
+        if (CVA6Cfg.RVS) csr_rdata = (CVA6Cfg.RVH) ? mideleg_q | HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0] : mideleg_q;
         else read_access_exception = 1'b1;
         riscv::CSR_MIE: csr_rdata = mie_q;
         riscv::CSR_MTVEC: csr_rdata = mtvec_q;
@@ -2814,7 +2814,7 @@ module csr_regfile
       // supervisor mode registers
       if (CVA6Cfg.RVS) begin
         medeleg_q    <= {CVA6Cfg.XLEN{1'b0}};
-        mideleg_q    <= {CVA6Cfg.XLEN{1'b0}};
+        mideleg_q    <= (CVA6Cfg.RVH) ? CVA6Cfg.XLEN'(HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0]) : {CVA6Cfg.XLEN{1'b0}};
         sepc_q       <= {CVA6Cfg.XLEN{1'b0}};
         scause_q     <= {CVA6Cfg.XLEN{1'b0}};
         stvec_q      <= {CVA6Cfg.XLEN{1'b0}};

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -649,7 +649,8 @@ module csr_regfile
         if (CVA6Cfg.RVS) csr_rdata = medeleg_q;
         else read_access_exception = 1'b1;
         riscv::CSR_MIDELEG:
-        if (CVA6Cfg.RVS) csr_rdata = (CVA6Cfg.RVH) ? mideleg_q | HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0] : mideleg_q;
+        if (CVA6Cfg.RVS)
+          csr_rdata = (CVA6Cfg.RVH) ? mideleg_q | HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0] : mideleg_q;
         else read_access_exception = 1'b1;
         riscv::CSR_MIE: csr_rdata = mie_q;
         riscv::CSR_MTVEC: csr_rdata = mtvec_q;
@@ -2849,15 +2850,15 @@ module csr_regfile
       end
       // supervisor mode registers
       if (CVA6Cfg.RVS) begin
-        medeleg_q    <= {CVA6Cfg.XLEN{1'b0}};
+        medeleg_q <= {CVA6Cfg.XLEN{1'b0}};
         mideleg_q    <= (CVA6Cfg.RVH) ? CVA6Cfg.XLEN'(HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0]) : {CVA6Cfg.XLEN{1'b0}};
-        sepc_q       <= {CVA6Cfg.XLEN{1'b0}};
-        scause_q     <= {CVA6Cfg.XLEN{1'b0}};
-        stvec_q      <= {CVA6Cfg.XLEN{1'b0}};
+        sepc_q <= {CVA6Cfg.XLEN{1'b0}};
+        scause_q <= {CVA6Cfg.XLEN{1'b0}};
+        stvec_q <= {CVA6Cfg.XLEN{1'b0}};
         scounteren_q <= {CVA6Cfg.XLEN{1'b0}};
-        sscratch_q   <= {CVA6Cfg.XLEN{1'b0}};
-        stval_q      <= {CVA6Cfg.XLEN{1'b0}};
-        satp_q       <= {CVA6Cfg.XLEN{1'b0}};
+        sscratch_q <= {CVA6Cfg.XLEN{1'b0}};
+        stval_q <= {CVA6Cfg.XLEN{1'b0}};
+        satp_q <= {CVA6Cfg.XLEN{1'b0}};
         if (CVA6Cfg.RVZiCbom) begin
           scbie_q  <= riscv::CBIE_INVAL;
           scbcfe_q <= 1'b1;

--- a/verif/tests/custom/issues/i3317_reg_write.S
+++ b/verif/tests/custom/issues/i3317_reg_write.S
@@ -1,0 +1,24 @@
+  .section .text
+  .align 2
+  .option norvc
+  .globl main
+main:
+  csrw mideleg, zero
+  csrr t0, mideleg
+  li t1, 0x444
+  and t2, t0, t1
+  bne t2, t1, fail          # RO-1 bits (2,6,10) survive a zero write
+  li t3, 0x200              # SEIP delegation (bit 9) - a real writable mideleg bit
+  csrw mideleg, t3
+  csrr t0, mideleg
+  and t2, t0, t3
+  bne t2, t3, fail          # writable bit takes
+  li t1, 0x444
+  and t2, t0, t1
+  bne t2, t1, fail          # RO-1 bits still set alongside
+  li a0, 0
+  j fin
+fail:
+  li a0, 1
+fin:
+  jal exit

--- a/verif/tests/custom/issues/i3317_reg_write.S
+++ b/verif/tests/custom/issues/i3317_reg_write.S
@@ -3,9 +3,12 @@
   .option norvc
   .globl main
 main:
-  csrw mideleg, zero
   csrr t0, mideleg
   li t1, 0x444
+  and t2, t0, t1
+  bne t2, t1, fail          # RO-1 bits (2,6,10) are set after reset
+  csrw mideleg, zero
+  csrr t0, mideleg
   and t2, t0, t1
   bne t2, t1, fail          # RO-1 bits (2,6,10) survive a zero write
   li t3, 0x200              # SEIP delegation (bit 9) - a real writable mideleg bit


### PR DESCRIPTION
Fixes #3317 

Directed test `test/i3317_reg_write.S` (bare `crt.S`, no `env/p`), run under
`cva6.py --iss=veri-testharness` on the `cv64a6_imafdch_sv39` (rv64gh)
target:

- **baseline (unpatched)**: first `csrr mideleg` after reset returns a value
  with bits 10/6/2 = 0 → test FAILS.
- **patched**: returns bits 10/6/2 = 1 → test PASSES (`*** SUCCESS ***`).
