### PR TITLE
fix(csr): reject reserved CBIE encoding 2'b10 in menvcfg/senvcfg/henvcfg

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1453,9 +1453,6 @@ module csr_regfile
                 2'b00:   scbie_d = riscv::CBIE_ILLEGAL;
                 2'b01:   scbie_d = riscv::CBIE_FLUSH;
                 2'b11:   scbie_d = riscv::CBIE_INVAL;
-                // WARL: reject the reserved encoding 2'b10 by
-                // reverting to the previously held legal value
-                // instead of silently storing it (#3511).
                 default: scbie_d = scbie_q;
               endcase
               scbcfe_d = csr_wdata[6];

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1766,9 +1766,6 @@ module csr_regfile
               2'b00:   mcbie_d = riscv::CBIE_ILLEGAL;
               2'b01:   mcbie_d = riscv::CBIE_FLUSH;
               2'b11:   mcbie_d = riscv::CBIE_INVAL;
-              // WARL: reject the reserved encoding 2'b10 by
-              // reverting to the previously held legal value
-              // instead of silently storing it (#3511).
               default: mcbie_d = mcbie_q;
             endcase
             mcbcfe_d = csr_wdata[6];

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1419,7 +1419,10 @@ module csr_regfile
                 2'b00:   scbie_d = riscv::CBIE_ILLEGAL;
                 2'b01:   scbie_d = riscv::CBIE_FLUSH;
                 2'b11:   scbie_d = riscv::CBIE_INVAL;
-                default: scbie_d = riscv::CBIE_RSVD;
+                // WARL: reject the reserved encoding 2'b10 by
+                // reverting to the previously held legal value
+                // instead of silently storing it (#3511).
+                default: scbie_d = scbie_q;
               endcase
               scbcfe_d = csr_wdata[6];
             end
@@ -1546,7 +1549,10 @@ module csr_regfile
                 2'b00:   hcbie_d = riscv::CBIE_ILLEGAL;
                 2'b01:   hcbie_d = riscv::CBIE_FLUSH;
                 2'b11:   hcbie_d = riscv::CBIE_INVAL;
-                default: hcbie_d = riscv::CBIE_RSVD;
+                // WARL: reject the reserved encoding 2'b10 by
+                // reverting to the previously held legal value
+                // instead of silently storing it (#3511).
+                default: hcbie_d = hcbie_q;
               endcase
               hcbcfe_d = csr_wdata[6];
             end
@@ -1732,7 +1738,10 @@ module csr_regfile
               2'b00:   mcbie_d = riscv::CBIE_ILLEGAL;
               2'b01:   mcbie_d = riscv::CBIE_FLUSH;
               2'b11:   mcbie_d = riscv::CBIE_INVAL;
-              default: mcbie_d = riscv::CBIE_RSVD;
+              // WARL: reject the reserved encoding 2'b10 by
+              // reverting to the previously held legal value
+              // instead of silently storing it (#3511).
+              default: mcbie_d = mcbie_q;
             endcase
             mcbcfe_d = csr_wdata[6];
           end

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1580,9 +1580,6 @@ module csr_regfile
                 2'b00:   hcbie_d = riscv::CBIE_ILLEGAL;
                 2'b01:   hcbie_d = riscv::CBIE_FLUSH;
                 2'b11:   hcbie_d = riscv::CBIE_INVAL;
-                // WARL: reject the reserved encoding 2'b10 by
-                // reverting to the previously held legal value
-                // instead of silently storing it (#3511).
                 default: hcbie_d = hcbie_q;
               endcase
               hcbcfe_d = csr_wdata[6];


### PR DESCRIPTION
Per the RISC-V privileged spec, the Zicbom CBIE field is WARL with only three legal encodings (00/01/11); 2'b10 is reserved and must never survive a write-then-read cycle. The write logic for mcbie_d/scbie_d/hcbie_d stored the reserved encoding unchanged via an explicit riscv::CBIE_RSVD assignment in the case statement's default branch, so software writing 2'b10 would read it back unmodified.

Fix: on the reserved encoding, revert to the previously held (already-legal) value instead of storing CBIE_RSVD, matching standard WARL reject semantics.

Fixes #3511

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x]  I have searched for similar pull requests
- [x]  I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
Issue #3511 (opened by me) reported this WARL violation. Maintainer @cainria asked whether I'd like to open a PR for the fix, so I'm submitting one.
<!-- Is this PR related to existing issues? If so, link to them below -->
Fixes #3511 .
<!-- Are there limitations with the current state of this contribution? -->
- decoder.sv's CBO.INVAL permission check (which only explicitly matches CBIE_ILLEGAL/CBIE_FLUSH, implicitly falling through for anything else) was intentionally left untouched. After this fix, mcbie_q/scbie_q/hcbie_q can no longer hold CBIE_RSVD through any write path (reset already initializes them to CBIE_INVAL, a legal value), so that fallthrough branch is now provably unreachable for this specific value.
- HENVCFG isn't reachable by any in-tree official config (no config enables RVH+RVZiCbom together), so it was verified at the isolated_unit level (real csr_regfile.sv instantiated against a synthetic RVH+RVZiCbom config) rather than full-core black-box, unlike menvcfg/senvcfg which were confirmed on the real cv64a6_imafdc_sv39_hpdcache config.

## Testing

- Full-core black-box test on cv64a6_imafdc_sv39_hpdcache (the only in-tree config with RVZiCbom=1): before the fix, tohost=7 (menvcfg and senvcfg both retain the reserved encoding); after the fix, tohost=4 (both fixed; the positive-control bit confirming legal WARL writes still work is unaffected), reproduced identically across two independent reruns.
- HENVCFG confirmed at the isolated_unit level against a synthetic RVH+RVZiCbom config: writing 2'b10 now reads back 0x3 (CBIE_INVAL, the reset value) instead of the reserved encoding, two independent rebuilds, byte-identical.
- Re-ran the standard cv64a6_imafdc_sv39 config (RVZiCbom=0, so this code path is fully elaborated out) against the riscv-tests ISA suite to check for regressions. One test (rv64mi-p-csr) fails identically on both this fix and an unmodified rebuild of origin/master (same tohost=13 at cycle 25759 on both) -- pre-existing and unrelated to this change (a plain mscratch csrrw check, nothing CBIE/Zicbom-related).

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

