### PR TITLE
tb: fix out-of-bounds loop in rvfi_tracer debug signal tracing

### DIFF
--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -212,7 +212,7 @@ module rvfi_tracer #(
 
   always_ff @(posedge clk_i) begin
     if (cycles > DEBUG_START && cycles < DEBUG_STOP)
-      for (int index = 0; index < 100; index++)
+      for (int index = 0; index < $size(debug); index++)
         if (debug_previous[index] != debug[index])
           $fwrite(f, "%d %s %x\n", cycles, name[index], debug[index]);
     debug_previous <= debug;


### PR DESCRIPTION
Fixes #3446.

The debug loop in `corev_apu/tb/rvfi_tracer.sv` iterated up to index 99:

```systemverilog
for (int index = 0; index < 100; index++)
```

However, all three arrays — `name[]`, `debug[]`, and `debug_previous[]` — are declared with range `[0:10]` (11 elements). Accessing indices 11 through 99 is out-of-bounds, resulting in X propagation in simulation and potential tool warnings.

This replaces the hardcoded bound with `$size(debug)`, which evaluates to the actual array size at elaboration time. This is the standard SystemVerilog idiom: correct, tool-independent, and resilient to future changes in array size.