### PR TITLE
Fix single-step WFI stall

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -2652,7 +2652,7 @@ module csr_regfile
       wfi_d = 1'b0;
       // or alternatively if there is no exception pending and we are not in debug mode wait here
       // for the interrupt
-    end else if (((CVA6Cfg.DebugEn && !debug_mode_q) && csr_op_i == WFI && !ex_i.valid) || (!CVA6Cfg.DebugEn && csr_op_i == WFI && !ex_i.valid)) begin
+    end else if (((CVA6Cfg.DebugEn && !debug_mode_q && !dcsr_q.step) && csr_op_i == WFI && !ex_i.valid) || (!CVA6Cfg.DebugEn && csr_op_i == WFI && !ex_i.valid)) begin
       wfi_d = 1'b1;
     end
   end

--- a/verif/tests/unit/csr_wfi/README.md
+++ b/verif/tests/unit/csr_wfi/README.md
@@ -1,0 +1,63 @@
+# CSR WFI single-step regression
+
+This test instantiates the real `core/csr_regfile.sv` to reproduce CVA6 issue
+#3497. It uses the `cv32a6_imac_sv32` configuration and a second instance of
+that configuration with `DebugEn=0`. It does not force internal DUT state.
+
+The driver supplies decoded CSR operations, commit acknowledgements, and
+exceptions at the CSR boundary. Debug entry is requested through the normal
+CSR inputs; `dcsr` is programmed through CSR accesses, preserving its other
+fields and selecting machine privilege, and execution resumes through `DRET`.
+
+Checks cover:
+
+- Stepped WFI with no interrupts or debug request, for both `stepie` values.
+- Debug-entry redirect, single-step cause, saved privilege, and exact `DPC=PC+4`.
+- No WFI halt immediately after debug re-entry or on following clocks.
+- Continued debug CSR accesses and ordinary WFI after single-step is disabled.
+- WFI in Debug Mode, with single-step clear and set.
+- Ordinary WFI stall and wake through an enabled pending software interrupt,
+  `irq_i[1]`, and a debug request, including the debug-disabled case.
+- Exception suppression of the WFI wait state and reset state.
+
+This is a CSR unit regression. It does not execute instructions through the
+decoder/pipeline, execute the Debug ROM, validate trigger priority, run the
+VCS/UVM debug suite, or claim coverage of other configurations. The minimal
+scoreboard type includes the fields consumed by this module with triggers
+disabled; the driver checks that the selected configuration disables triggers.
+
+## Requirements
+
+Use a Verilator 5 installation supporting `--binary --timing`, GNU Make, and
+a C++20 compiler. The `core/cvfpu` submodule must be initialized for its package.
+No RISC-V compiler, Spike libraries, or VCS license is needed.
+
+## Run
+
+From the repository root:
+
+```bash
+bash verif/tests/unit/csr_wfi/run.sh /tmp/cva6-csr-wfi
+```
+
+The runner accepts an optional second argument selecting a different CSR RTL
+file. `VERILATOR` may select an alternative Verilator executable. All generated
+files go into the selected build directory, and compilation uses one job.
+
+To prove failure before the patch and success after it, supply an unpatched
+baseline commit compatible with the remaining source tree:
+
+```bash
+bash verif/tests/unit/csr_wfi/compare.sh \
+  /tmp/cva6-3497-regression 40ac92ccc09534fb0c6b139a613f65868af9f499
+```
+
+The comparator obtains only the baseline CSR file with `git show`; it never
+replaces the working-tree RTL. It requires the baseline to fail at the specific
+issue-3497 assertion, then requires the working-tree test to exit successfully
+with the final pass marker. A compile failure cannot count as a reproduction.
+Logs are `before.log` and `after.log` in the specified build directory. Keep
+this directory outside the repository and retain it for review.
+
+On a machine with limited memory, run the comparator inside a systemd scope
+with suitable memory limits, as with the main Verilator build.

--- a/verif/tests/unit/csr_wfi/compare.sh
+++ b/verif/tests/unit/csr_wfi/compare.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+set -euo pipefail
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_dir=$(cd -- "$script_dir/../../../.." && pwd)
+if [[ $# -ne 2 ]]; then
+  printf 'Usage: bash %s BUILD_DIRECTORY BASELINE_GIT_REF\n' "$0" >&2
+  exit 2
+fi
+mkdir -p -- "$1"
+build_dir=$(cd -- "$1" && pwd)
+baseline_ref=$2
+baseline_dir=$(mktemp -d "$build_dir/baseline-source.XXXXXX")
+git -C "$repo_dir" show "$baseline_ref:core/csr_regfile.sv" > "$baseline_dir/csr_regfile.sv"
+printf 'Baseline commit: %s\n' "$(git -C "$repo_dir" rev-parse "$baseline_ref^{commit}")"
+printf 'Build logs: %s\n' "$build_dir"
+printf 'Building and running the pre-fix CSR module (one build job)...\n'
+if bash "$script_dir/run.sh" "$build_dir/before" "$baseline_dir/csr_regfile.sv" \
+    > "$build_dir/before.log" 2>&1; then
+  printf 'FAIL: baseline unexpectedly passed; reproduction was not established.\n' >&2
+  exit 1
+else
+  before_status=$?
+fi
+if ! grep -Fq 'ISSUE3497: stepped WFI leaked halt into Debug Mode' "$build_dir/before.log"; then
+  tail -n 40 "$build_dir/before.log" >&2
+  printf 'FAIL: baseline failed for another reason (exit %s).\n' "$before_status" >&2
+  exit 1
+fi
+printf 'PASS: original RTL reproduced issue #3497 (exit %s).\n' "$before_status"
+printf 'Building and running the working-tree CSR module (one build job)...\n'
+if bash "$script_dir/run.sh" "$build_dir/after" "$repo_dir/core/csr_regfile.sv" \
+    > "$build_dir/after.log" 2>&1; then
+  if ! grep -Fxq 'PASS: CVA6 CSR WFI regression' "$build_dir/after.log"; then
+    printf 'FAIL: simulator exited without the final pass marker.\n' >&2
+    exit 1
+  fi
+else
+  after_status=$?
+  tail -n 40 "$build_dir/after.log" >&2
+  printf 'FAIL: working-tree test exited with status %s.\n' "$after_status" >&2
+  exit 1
+fi
+grep '^PASS' "$build_dir/after.log"
+printf 'PASS: before/after CSR WFI regression comparison\n'

--- a/verif/tests/unit/csr_wfi/csr_wfi_tb.sv
+++ b/verif/tests/unit/csr_wfi/csr_wfi_tb.sv
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// CSR-level regression for CVA6 issue #3497. No forced DUT state or UVM.
+`include "rvfi_types.svh"
+
+module csr_wfi_case #(
+    parameter bit DebugEn = 1'b1
+) (
+    output bit done_o
+);
+  import ariane_pkg::*;
+  timeunit 1ns; timeprecision 1ps;
+
+  function automatic config_pkg::cva6_cfg_t test_config();
+    config_pkg::cva6_cfg_t cfg;
+    cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg);
+    cfg.DebugEn = DebugEn;
+    return cfg;
+  endfunction
+  localparam config_pkg::cva6_cfg_t Cfg = test_config();
+  typedef logic [Cfg.XLEN-1:0] xlen_t;
+  typedef struct packed {
+    xlen_t cause;
+    xlen_t tval;
+    logic [Cfg.GPLEN-1:0] tval2;
+    logic [31:0] tinst;
+    logic gva;
+    logic valid;
+    logic timing;
+  } exception_t;
+  // Only the scoreboard fields consumed by csr_regfile (triggers disabled).
+  typedef struct packed {
+    logic [Cfg.VLEN-1:0] pc;
+    fu_t fu;
+    struct packed {logic [Cfg.VLEN-1:0] predict_address;} bp;
+    logic is_compressed;
+  } commit_t;
+  typedef struct packed {
+    logic [Cfg.XLEN-7:0] base;
+    logic [5:0] mode;
+  } jvt_t;
+  typedef struct packed {
+    xlen_t mie, mip, mideleg, hideleg;
+    logic sie, global_enable;
+  } irq_ctrl_t;
+  typedef `RVFI_PROBES_CSR_T(Cfg) rvfi_csr_t;
+
+  bit clk = 0;
+  bit rst_n = 0;
+  fu_op op;
+  logic [11:0] addr;
+  xlen_t wdata, rdata;
+  logic [Cfg.VLEN-1:0] pc;
+  logic [Cfg.NrCommitPorts-1:0] ack;
+  commit_t instruction;
+  exception_t exception_in, exception_out;
+  logic [1:0] irq;
+  logic ipi, debug_req;
+  logic halt, debug_mode, single_step, set_debug_pc, eret;
+  riscv::priv_lvl_t privilege;
+
+  csr_regfile #(
+      .CVA6Cfg(Cfg),
+      .exception_t(exception_t),
+      .jvt_t(jvt_t),
+      .irq_ctrl_t(irq_ctrl_t),
+      .scoreboard_entry_t(commit_t),
+      .rvfi_probes_csr_t(rvfi_csr_t)
+  ) dut (
+      .clk_i(clk),
+      .rst_ni(rst_n),
+      .time_irq_i(1'b0),
+      .halt_csr_o(halt),
+      .commit_instr_i(instruction),
+      .commit_ack_i(ack),
+      .boot_addr_i(Cfg.VLEN'('h80000000)),
+      .hart_id_i('0),
+      .ex_i(exception_in),
+      .csr_op_i(op),
+      .csr_addr_i(addr),
+      .csr_wdata_i(wdata),
+      .csr_rdata_o(rdata),
+      .dirty_fp_state_i(1'b0),
+      .csr_write_fflags_i(1'b0),
+      .dirty_v_state_i(1'b0),
+      .pc_i(pc),
+      .csr_exception_o(exception_out),
+      .eret_o(eret),
+      .priv_lvl_o(privilege),
+      .acc_fflags_ex_i('0),
+      .acc_fflags_ex_valid_i(1'b0),
+      .csr_hs_ld_st_inst_i(1'b0),
+      .irq_i(irq),
+      .ipi_i(ipi),
+      .debug_req_i(debug_req),
+      .set_debug_pc_o(set_debug_pc),
+      .debug_mode_o(debug_mode),
+      .single_step_o(single_step),
+      .perf_data_i('0),
+      .sdtrig_lsu_inputs_vaddr_i('0),
+      .sdtrig_lsu_inputs_data_i('0),
+      .sdtrig_lsu_inputs_fu_i(1'b0),
+      .sdtrig_lsu_inputs_valid_i(1'b0),
+      .sdtrig_load_data_i('0),
+      .sdtrig_load_valid_i(1'b0),
+      .fetch_sdtrig_pc_i('0),
+      .fetch_sdtrig_instr_i('0)
+  );
+
+  task automatic check(input bit condition, input string message);
+    if (!condition) $fatal(1, "FAIL DebugEn=%0d: %s", DebugEn, message);
+  endtask
+
+  task automatic tick();
+    #5ns;
+    clk = 1;
+    #5ns;
+    clk = 0;
+    #1ns;
+  endtask
+
+  task automatic idle();
+    op = ADD;
+    addr = '0;
+    wdata = '0;
+    pc = '0;
+    ack = '0;
+    instruction = '0;
+    exception_in = '0;
+    #1ns;
+  endtask
+
+  task automatic reset_dut();
+    rst_n = 0;
+    irq = '0;
+    ipi = 0;
+    debug_req = 0;
+    idle();
+    tick();
+    rst_n = 1;
+    tick();
+    check(!halt && !debug_mode && !single_step, "reset state");
+  endtask
+
+  task automatic write_csr(input logic [11:0] address, input xlen_t value);
+    check(!halt, "CSR write attempted while halted");
+    op = CSR_WRITE;
+    addr = address;
+    wdata = value;
+    ack[0] = 1;
+    #1ns;
+    check(!exception_out.valid, "unexpected CSR write exception");
+    tick();
+    idle();
+  endtask
+
+  task automatic read_csr(input logic [11:0] address, output xlen_t value);
+    check(!halt, "CSR read attempted while halted");
+    op   = CSR_READ;
+    addr = address;
+    #1ns;
+    check(!exception_out.valid, "unexpected CSR read exception");
+    value = rdata;
+    idle();
+  endtask
+
+  task automatic enter_debug();
+    debug_req = 1;
+    exception_in.valid = 1;
+    exception_in.cause = riscv::DEBUG_REQUEST;
+    pc = Cfg.VLEN'('h80000020);
+    #1ns;
+    check(set_debug_pc, "debug-request redirect");
+    tick();
+    debug_req = 0;
+    idle();
+    check(debug_mode && !halt, "debug-request entry");
+  endtask
+
+  task automatic configure_step(input bit step_enable, input bit stepie);
+    xlen_t dcsr;
+    read_csr(riscv::CSR_DCSR, dcsr);
+    dcsr[2]   = step_enable;
+    dcsr[11]  = stepie;
+    dcsr[1:0] = riscv::PRIV_LVL_M;
+    write_csr(riscv::CSR_DCSR, dcsr);
+    check(single_step == step_enable, "step CSR programming");
+  endtask
+
+  task automatic resume_mmode();
+    op = DRET;
+    ack[0] = 1;
+    #1ns;
+    check(eret, "DRET return indication");
+    tick();
+    idle();
+    check(!debug_mode && !halt && privilege == riscv::PRIV_LVL_M,
+          "DRET must resume running in M mode");
+  endtask
+
+  task automatic commit_wfi(input xlen_t address);
+    check(!halt, "WFI issued while already halted");
+    op = WFI;
+    pc = Cfg.VLEN'(address);
+    instruction.pc = Cfg.VLEN'(address);
+    instruction.fu = CSR;
+    instruction.is_compressed = 0;
+    ack[0] = 1;
+    #1ns;
+    if (DebugEn && single_step && !debug_mode)
+      check(set_debug_pc, "stepped WFI must request debug redirect");
+    tick();
+    idle();
+  endtask
+
+  task automatic normal_wfi_tests();
+    reset_dut();
+    write_csr(riscv::CSR_MIE, xlen_t'(1 << 3));
+    commit_wfi(xlen_t'('h80000040));
+    repeat (3) begin
+      check(halt && !debug_mode, "ordinary WFI must wait");
+      tick();
+    end
+    // mip is registered; allow its update and the following wake clock.
+    ipi = 1;
+    repeat (2) tick();
+    check(!halt, "enabled pending interrupt must wake WFI");
+
+    reset_dut();
+    commit_wfi(xlen_t'('h80000040));
+    irq[1] = 1;
+    tick();
+    check(!halt, "irq_i[1] must wake WFI");
+
+    reset_dut();
+    commit_wfi(xlen_t'('h80000040));
+    debug_req = 1;
+    tick();
+    check(halt == !DebugEn, "debug-request wake must respect DebugEn");
+
+    reset_dut();
+    // Exercise the CSR module's exception guard without retirement.
+    op = WFI;
+    exception_in.valid = 1;
+    exception_in.cause = riscv::ILLEGAL_INSTR;
+    tick();
+    idle();
+    check(!halt, "exceptional WFI must not set the wait state");
+    $display("PASS ordinary WFI/wake/exception DebugEn=%0d", DebugEn);
+  endtask
+
+  task automatic stepped_wfi_test(input bit stepie);
+    xlen_t value;
+    reset_dut();
+    enter_debug();
+    // WFI must remain non-stalling in Debug Mode with step clear or set.
+    commit_wfi(xlen_t'('h80000024));
+    check(debug_mode && !halt, "WFI in Debug Mode with step=0");
+    configure_step(1, stepie);
+    commit_wfi(xlen_t'('h80000028));
+    check(debug_mode && !halt, "WFI in Debug Mode with step=1");
+    resume_mmode();
+    check(irq == 0 && !ipi && !debug_req, "no wake event may mask the bug");
+    commit_wfi(xlen_t'('h80000040));
+    check(debug_mode, "stepped WFI must re-enter Debug Mode");
+    check(!halt, "ISSUE3497: stepped WFI leaked halt into Debug Mode");
+    read_csr(riscv::CSR_DCSR, value);
+    check(value[8:6] == CauseSingleStep, "single-step debug cause");
+    check(value[1:0] == riscv::PRIV_LVL_M, "single-step saved privilege");
+    read_csr(riscv::CSR_DPC, value);
+    check(value == xlen_t'('h80000044), "DPC must equal WFI PC + 4");
+    repeat (4) begin
+      tick();
+      check(debug_mode && !halt, "no delayed WFI halt in Debug Mode");
+    end
+    // Demonstrate continued CSR access; this does not execute a Debug ROM.
+    write_csr(riscv::CSR_DSCRATCH0, xlen_t'('h13579bdf));
+    read_csr(riscv::CSR_DSCRATCH0, value);
+    check(value == xlen_t'('h13579bdf), "debug CSR access after stepped WFI");
+    configure_step(0, stepie);
+    resume_mmode();
+    commit_wfi(xlen_t'('h80000044));
+    check(halt && !debug_mode, "clearing step must restore ordinary WFI");
+    $display("PASS stepped WFI stepie=%0d", stepie);
+  endtask
+
+  initial begin
+    done_o = 0;
+    check(!Cfg.Sdtrig, "test requires a configuration with triggers disabled");
+    normal_wfi_tests();
+    if (DebugEn) begin
+      stepped_wfi_test(0);
+      stepped_wfi_test(1);
+    end
+    done_o = 1;
+  end
+endmodule
+
+module csr_wfi_tb;
+  timeunit 1ns; timeprecision 1ps;
+  wire debug_done, no_debug_done;
+  csr_wfi_case #(.DebugEn(1)) debug_case (.done_o(debug_done));
+  csr_wfi_case #(.DebugEn(0)) no_debug_case (.done_o(no_debug_done));
+  initial begin
+    wait (debug_done && no_debug_done);
+    $display("PASS: CVA6 CSR WFI regression");
+    $finish;
+  end
+  initial begin
+    #100us;
+    $fatal(1, "FAIL: CSR WFI regression timeout");
+  end
+endmodule

--- a/verif/tests/unit/csr_wfi/run.sh
+++ b/verif/tests/unit/csr_wfi/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+set -euo pipefail
+# The expected pre-fix assertion must not leave a core dump.
+ulimit -c 0
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_dir=$(cd -- "$script_dir/../../../.." && pwd)
+build_dir=${1:-$(mktemp -d "${TMPDIR:-/tmp}/cva6-csr-wfi.XXXXXX")}
+csr_source=${2:-"$repo_dir/core/csr_regfile.sv"}
+mkdir -p -- "$build_dir"
+build_dir=$(cd -- "$build_dir" && pwd)
+csr_source=$(realpath -- "$csr_source")
+verilator_bin=${VERILATOR:-verilator}
+"$verilator_bin" --binary --timing --assert -j 1 -CFLAGS "-std=c++20" \
+  --top-module csr_wfi_tb --Mdir "$build_dir" \
+  -Wno-fatal -Wno-PINMISSING -Wno-TIMESCALEMOD \
+  -I"$repo_dir/core/include" \
+  "$repo_dir/core/include/config_pkg.sv" \
+  "$repo_dir/core/include/cv32a6_imac_sv32_config_pkg.sv" \
+  "$repo_dir/core/include/riscv_pkg.sv" \
+  "$repo_dir/core/cvfpu/src/fpnew_pkg.sv" \
+  "$repo_dir/core/include/ariane_pkg.sv" \
+  "$repo_dir/core/include/build_config_pkg.sv" \
+  "$csr_source" "$script_dir/csr_wfi_tb.sv"
+"$build_dir/Vcsr_wfi_tb"


### PR DESCRIPTION
* [x] I have searched for similar pull requests
* [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why is this change needed?

When `dcsr.step` is enabled, executing `WFI` currently sets the WFI wait state while the same committed instruction causes the core to enter Debug Mode.

On the following cycle, `wfi_q` remains asserted and drives `halt_csr_o`. Consequently, the hart remains halted after entering Debug Mode and cannot continue executing debug code.

The RISC-V Debug Specification requires a single-stepped `WFI` that would otherwise stall to behave as a NOP.

This change prevents the WFI wait state from being set when single-step is active. Ordinary WFI behavior remains unchanged when single-step is disabled, and configurations without debug support continue using the existing WFI path.

## Verification

A CSR-level Verilator regression was added that instantiates the real `csr_regfile` and checks:

* The unpatched RTL reproduces the stepped-WFI halt.
* The patched RTL re-enters Debug Mode without asserting `halt_csr_o`.
* `dcsr.cause` reports single-step.
* `dpc` contains the address following the WFI.
* Both `dcsr.stepie` values behave correctly.
* No delayed WFI halt appears after debug entry.
* Debug CSR accesses remain possible after the stepped WFI.
* Ordinary WFI stall and wake behavior remains unchanged.
* Exception handling and debug-disabled behavior remain unchanged.

The before/after comparison passed against the rebased parent commit:

```text
PASS: original RTL reproduced issue #3497
PASS ordinary WFI/wake/exception DebugEn=1
PASS ordinary WFI/wake/exception DebugEn=0
PASS stepped WFI stepie=0
PASS stepped WFI stepie=1
PASS: CVA6 CSR WFI regression
PASS: before/after CSR WFI regression comparison
```

A top-level Verilator model build for `cv32a6_imac_sv32` also completed successfully.

The existing VCS/UVM debug regression was not run locally because VCS is not available in my environment.

## Limitations

The added regression tests the behavior at the CSR boundary. It does not execute the WFI through the complete pipeline or execute the Debug ROM.

The regression is currently standalone and is not wired into an existing CI workflow. Maintainer guidance on the preferred test location and CI integration would be appreciated.

## Related issue

Fixes #3497
