### PR TITLE
config_pkg: reject RVZCMP+RVD configs at check_cfg time

### DIFF
--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -486,10 +486,11 @@ package config_pkg;
     assert (!(Cfg.RVS && !Cfg.SoftwareInterruptEn));
     assert (!(Cfg.RVH && !Cfg.SoftwareInterruptEn));
     assert (!(Cfg.RVZCMT && ~Cfg.MmuPresent));
-    // Zcmp is incompatible with Zcd (compressed double-precision FP loads/stores),
-    // which is part of D, due to opcode collisions.
-    if (Cfg.RVZCMP && Cfg.RVD) begin
-      $fatal(1, "[config] RVZCMP (Zcmp) and RVD (D) are mutually exclusive");
+    // Zcmp is incompatible with Zcd (compressed double-precision FP loads/stores,
+    // automatically present whenever both C and D are implemented), due to
+    // opcode collisions.
+    if (Cfg.RVZCMP && Cfg.RVC && Cfg.RVD) begin
+      $fatal(1, "[config] RVZCMP (Zcmp) and RVC+RVD (Zcd = C+D) are mutually exclusive");
     end
     // pragma translate_on
   endfunction

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -486,6 +486,11 @@ package config_pkg;
     assert (!(Cfg.RVS && !Cfg.SoftwareInterruptEn));
     assert (!(Cfg.RVH && !Cfg.SoftwareInterruptEn));
     assert (!(Cfg.RVZCMT && ~Cfg.MmuPresent));
+    // Zcmp is incompatible with Zcd (compressed double-precision FP loads/stores),
+    // which is part of D, due to opcode collisions.
+    if (Cfg.RVZCMP && Cfg.RVD) begin
+      $fatal(1, "[config] RVZCMP (Zcmp) and RVD (D) are mutually exclusive");
+    end
     // pragma translate_on
   endfunction
 


### PR DESCRIPTION
Fixes #3483. 
RVZCMP (Zcmp) and RVD (D) collide at the opcode level: Zcmp reuses the encodings of `c.fsdsp`/`c.fsd`, which are part of Zcd and therefore implied by D. A core implementing D must not implement Zcmp. `check_cfg()` had no build-time guard against enabling both.

This adds a `$fatal` in the existing `check_cfg()` sanity-check function, following the same pattern as the adjacent `RVZCMT`/`MmuPresent` check one line above. It sits inside the `// pragma translate_off` block, so it is elaboration-only and strips out at synthesis .

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

- Invalid config (`CVA6ConfigZcmpExtEn=1`, default `RVD=1`): elaboration now
  aborts with
  `%Error: config_pkg.sv:485: Assertion failed in check_cfg: [config] RVZCMP (Zcmp) and RVD (D) are mutually exclusive`.
- Default valid config `cv64a6_imafdc_sv39` (`RVD=1, RVZCMP=0`): elaborates
  and runs unchanged.

<!-- Please indicate why this PR is needed for the project -->


<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

Patch drafted with LLM assistance; reviewed, spec-checked and Verilator-verified by me.