### PR TITLE
decoder: zip/unzip are RV32-only, decode as illegal on RV64

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -1170,7 +1170,7 @@ module decoder
                   instruction_o.op = ariane_pkg::BSETI;
                 else if (CVA6Cfg.IS_XLEN32 && instr.instr[31:25] == 7'b0010100)
                   instruction_o.op = ariane_pkg::BSETI;
-                else if (CVA6Cfg.ZKN && instr.instr[31:20] == 12'b000010001111)
+                else if (CVA6Cfg.ZKN && CVA6Cfg.IS_XLEN32 && instr.instr[31:20] == 12'b000010001111)
                   instruction_o.op = ariane_pkg::ZIP;
                 else if (CVA6Cfg.ZKN && instr.instr[31:24] == 8'b00110001) begin
                   instruction_o.op = ariane_pkg::AES64KS1I;
@@ -1220,7 +1220,7 @@ module decoder
                   instruction_o.op = ariane_pkg::RORI;
                 else if (CVA6Cfg.ZKN && instr.instr[31:20] == 12'b011010000111)
                   instruction_o.op = ariane_pkg::BREV8;
-                else if (CVA6Cfg.ZKN && instr.instr[31:20] == 12'b000010001111)
+                else if (CVA6Cfg.ZKN && CVA6Cfg.IS_XLEN32 && instr.instr[31:20] == 12'b000010001111)
                   instruction_o.op = ariane_pkg::UNZIP;
                 else illegal_instr_bm = 1'b1;
               end

--- a/verif/tests/custom/issues/decoder-zip-unzip-rv64.S
+++ b/verif/tests/custom/issues/decoder-zip-unzip-rv64.S
@@ -1,0 +1,35 @@
+# SUCCESS(a0=0) iff BOTH zip (0x08f31293) and unzip (0x08f35293) trap with
+# mcause==2 on RV64. FAIL if either retires (bug) or wrong cause.
+  .section .text
+  .align 2
+  .option norvc
+  .globl main
+main:
+  la t0, th
+  csrw mtvec, t0
+  csrw medeleg, zero
+  li s1, 0                  # 0 = expecting zip trap, 1 = expecting unzip trap
+  .word 0x08f31293          # zip x5,x6
+  li a0, 10                 # retired -> bug
+  j fin
+phase1:
+  li s1, 1
+  .word 0x08f35293          # unzip x5,x6
+  li a0, 11                 # retired -> bug
+  j fin
+  .align 2
+th:
+  csrr t0, mcause
+  li t1, 2
+  bne t0, t1, wc
+  bnez s1, pass_all         # unzip trapped correctly -> done
+  la t1, phase1
+  csrw mepc, t1
+  mret
+pass_all:
+  li a0, 0
+  j fin
+wc:
+  ori a0, t0, 0x40
+fin:
+  jal exit

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -62,3 +62,13 @@ testlist:
       -fvisibility=hidden
       -nostdlib
       -nostartfiles
+
+  - test: decoder-zip-unzip-rv64
+    <<: *common_test_config
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/decoder-zip-unzip-rv64.S
+
+  - test: decoder-zip-unzip-rv64
+    <<: *common_test_config
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/decoder-zip-unzip-rv64.S

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -82,10 +82,6 @@ testlist:
     iterations: 1
     asm_tests: <path_var>/custom/issues/decoder-zip-unzip-rv64.S
 
-  - test: decoder-zip-unzip-rv64
-    <<: *common_test_config
-    iterations: 1
-    asm_tests: <path_var>/custom/issues/decoder-zip-unzip-rv64.S
   - test: pmp-misalign-priority-over-access-fault
     description: >
       Misaligned hsv.d/hlv.d to a PMP-denied paddr must report


### PR DESCRIPTION
Fixes #3306. 
Per the RISC-V Bitmanip (Zbkb) spec, zip/unzip are available only on RV32. The CVA6 ALU already guards result generation with CVA6Cfg.IS_XLEN32, but core/decoder.sv matched the two encodings (instr[31:20] == 12'b000010001111) on CVA6Cfg.ZKN alone, so on RV64 the encoding decoded to a real ZIP/UNZIP op and retired without raising illegal-instruction (the vendored Spike reference raises mcause=2). Add the missing CVA6Cfg.IS_XLEN32 term to both decoder match conditions.

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x ] I have searched for similar pull requests
- [x ] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
Fixes  #3306 .
<!-- Is this PR related to existing issues? If so, link to them below -->
`verif/tests/custom/issues/decoder-zip-unzip-rv64.S` (added, registered in
`testlist_issues.yaml`), `cv64a6_imafdc_sv39`, `--iss=veri-testharness`:

- baseline: `zip` (`0x08f31293`) / `unzip` (`0x08f35293`) retire → test FAILS
- patched: both raise illegal-instruction (`mcause=2`); a valid form is
  unaffected → `*** SUCCESS ***`
<!-- Are there limitations with the current state of this contribution? -->
- RV32 decode of zip/unzip is unchanged (`IS_XLEN32` is 1 there).
- Only the decoder is touched; the ALU already had the `IS_XLEN32` guard, so this just makes the decoder consistent with it.
<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->
Patch drafted with LLM assistance; reviewed, spec-checked and Verilator-verified by me.
