### PR TITLE
pmp_data_if: misaligned trap outranks PMP access fault

### DIFF
--- a/core/pmp/src/pmp_data_if.sv
+++ b/core/pmp/src/pmp_data_if.sv
@@ -126,7 +126,11 @@ module pmp_data_if
     pmp_access_type = lsu_is_store_i ? riscv::ACCESS_WRITE : riscv::ACCESS_READ;
 
     // If translation is not enabled, check the paddr immediately against PMPs
-    if (lsu_valid_i && !data_allow_o) begin
+    // A misaligned exception has higher priority than an access fault, so don't
+    // overwrite it (RISC-V privilege spec, simultaneous trap cause priority).
+    if (lsu_valid_i && !data_allow_o &&
+        !(lsu_exception_i.valid &&
+          (lsu_exception_i.cause inside {riscv::LD_ADDR_MISALIGNED, riscv::ST_ADDR_MISALIGNED}))) begin
       lsu_exception_o.valid = 1'b1;
 
       if (CVA6Cfg.TvalEn) begin

--- a/verif/tests/custom/issues/pmp-misalign-priority-over-access-fault.S
+++ b/verif/tests/custom/issues/pmp-misalign-priority-over-access-fault.S
@@ -1,0 +1,41 @@
+  .section .text
+  .align 2
+  .option norvc
+  .globl main
+main:
+  la t0, th
+  csrw mtvec, t0
+  csrw medeleg, zero
+  csrw vsatp, zero
+  li s4, 0
+  li a2, 0x80100003
+  li a3, 0x1122334455667788
+  hsv.d a3, (a2)
+  li a0, 10
+  j fin
+phase1:
+  li s4, 1
+  hlv.d a4, (a2)
+  li a0, 0
+  j fin
+  .align 2
+th:
+  csrr t0, mcause
+  csrr t1, mepc
+  addi t1, t1, 4
+  csrw mepc, t1
+  bnez s4, 1f
+  li t2, 6
+  bne t0, t2, bad
+  la t1, phase1
+  csrw mepc, t1
+  mret
+1:
+  li t2, 4
+  bne t0, t2, bad
+  li a0, 0
+  j fin
+bad:
+  ori a0, t0, 0x40
+fin:
+  jal exit

--- a/verif/tests/custom/issues/pmp-misalign-priority-over-access-fault.S
+++ b/verif/tests/custom/issues/pmp-misalign-priority-over-access-fault.S
@@ -16,7 +16,7 @@ main:
 phase1:
   li s4, 1
   hlv.d a4, (a2)
-  li a0, 0
+  li a0, 11
   j fin
   .align 2
 th:

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -62,3 +62,16 @@ testlist:
       -fvisibility=hidden
       -nostdlib
       -nostartfiles
+
+  - test: pmp-misalign-priority-over-access-fault
+    description: >
+      Misaligned hsv.d/hlv.d to a PMP-denied paddr must report
+      address-misaligned (mcause 6/4), not access-fault (5/7).
+    iterations: 1
+    path_var: TESTS_PATH
+    asm_tests: <path_var>/custom/issues/pmp-misalign-priority-over-access-fault.S
+    gcc_opts: >-
+      -static -misa-spec=2.2 -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+      <path_var>/custom/common/crt.S
+      -I<path_var>/custom/env -I<path_var>/custom/common
+      -T ../../config/gen_from_riscv_config/linker/link.ld -lgcc -march=rv64gh


### PR DESCRIPTION
Fixes #3147 (and the closely related #3146). 
Per the RISC-V privileged synchronous-exception priority table, a load/store address-misaligned exception outranks an access fault. The PMP data interface unconditionally overwrote lsu_exception_o with an access-fault cause address-misaligned exception (e.g. a misaligned hsv.d reported scause=5 instead of 6). Guard the PMP fault assignment so it does not fire when lsu_exception_i already carries LD_ADDR_MISALIGNED / ST_ADDR_MISALIGNED.

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x ] I have searched for similar pull requests
- [x ] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
Fixes #3147 (and the closely related #3146).

<!-- Is this PR related to existing issues? If so, link to them below -->
`verif/tests/custom/issues/pmp-misalign-priority-over-access-fault.S`(`cv64a6_imafdch_sv39`, rv64gh, `--iss=veri-testharness`): a misaligned `hsv.d` must report `mcause=6` and a misaligned `hlv.d` must report
`mcause=4`.

- baseline: reports the PMP access-fault cause → test FAILS
- patched: reports the address-misaligned cause (6 / 4) → `*** SUCCESS ***`

<!-- Are there limitations with the current state of this contribution? -->
- The guard only suppresses the PMP overwrite when an address-misaligned exception is already latched; a pure PMP fault on an aligned access is unchanged.
- The directed test needs the H config (`cv64a6_imafdch_sv39`, rv64gh) and a bare `crt.S` (not the riscv-tests `env/p` runtime, whose permissive PMP init masks the bug). A maintainer may prefer to fold the check into an existing PMP/hypervisor directed-test file rather than the standalone  entry I added to `testlist_issues.yaml`.

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

