### PR TITLE
Fix CVXIF illegal-instruction GVA

### DIFF
--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -73,7 +73,7 @@ module cvxif_fu
     // Hypervisor exception fields
     x_exception_o.tval2 = {CVA6Cfg.GPLEN{1'b0}};
     x_exception_o.tinst = '0;
-    x_exception_o.gva   = CVA6Cfg.RVH ? v_i : 1'b0;
+    x_exception_o.gva   = 1'b0;
   end
 
 endmodule


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

`cvxif_fu` currently sets the GVA field of an illegal-instruction exception from the current virtualization mode.

For an illegal CVXIF instruction, `tval` contains the rejected instruction encoding rather than a guest virtual address. Therefore, GVA must remain clear even when the exception is raised while virtualization mode is active.

With the current behavior, an illegal CVXIF instruction executed with V=1 sets GVA=1, causing the trap metadata to incorrectly indicate that `tval` contains a guest virtual address.

## Changes

- Set `x_exception_o.gva` to `1'b0` for illegal-instruction exceptions generated by `cvxif_fu`.
- Keep the existing exception cause, `tval`, `tval2`, and `tinst` handling unchanged.
- No other CVXIF or exception behavior is modified.

## Validation

Validated using the `cv64a6_imafdch_sv39` configuration, which enables both CVXIF and the Hypervisor extension.

- Reporter-provided illegal-instruction reproducer:
  - CVA6/RTL and Spike retired identical instruction streams.
  - GVA remains clear for the illegal CVXIF instruction executed in virtualized mode.
- Reporter-provided negative control:
  - CVA6/RTL and Spike retired identical instruction streams.
- Verilator build for `cv64a6_imafdch_sv39`: PASS.
- Repeated the Verilator build after rebasing onto the current `upstream/master`: PASS.
- `git diff --check`: clean.

## Scope / limitations

This change is intentionally limited to the GVA metadata generated by `cvxif_fu` for rejected CVXIF instructions that raise an illegal-instruction exception.

No decoder, CSR, configuration, or other exception handling behavior is changed.

Validation uses the reproducer supplied with the issue; this PR does not add a new permanent regression test.

Fixes #3493
