### PR TITLE
vendor/axi_riscv_atomics: backport burst-per-word reservation invalidation and write-overtake fix

### DIFF
--- a/vendor/pulp-platform/axi_riscv_atomics/src/axi_riscv_lrsc.sv
+++ b/vendor/pulp-platform/axi_riscv_atomics/src/axi_riscv_lrsc.sv
@@ -27,6 +27,16 @@
 //  -   The adapter does not support bursts in exclusive accessing.  Only single words can be
 //      reserved.
 //
+// Backport note (cva6, 2026-09): This file is upstream revision 550881f (v0.2.2, 2019-02-28)
+// plus two minimally-ported upstream fixes:
+//   1. Burst invalidation: reservations are now invalidated for every word covered by a write
+//      burst, not only at the burst base address (backport of the walker introduced by upstream
+//      PR #26, v0.8.0, and its termination fix in upstream PR #31 / issue #30, v0.8.2).
+//   2. RVWMO ordering: an exclusive read no longer (re-)establishes a reservation while a write
+//      overlapping the reservation word is in flight downstream (backport of the
+//      in-flight-write exists-check introduced by the upstream v0.3.0 rewrite, upstream issue
+//      #4).
+//
 // Maintainer: Andreas Kurth <akurth@iis.ee.ethz.ch>
 
 module axi_riscv_lrsc #(
@@ -39,7 +49,8 @@ module axi_riscv_lrsc #(
     parameter int unsigned AXI_ID_WIDTH = 0,
     parameter int unsigned AXI_USER_WIDTH = 0,
     /// Derived Parameters (do NOT change manually!)
-    localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
+    localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8,
+                            AXI_STRB_AW    = $clog2(AXI_STRB_WIDTH)
 ) (
     input logic                         clk_i,
     input logic                         rst_ni,
@@ -158,7 +169,14 @@ module axi_riscv_lrsc #(
                                     art_set_addr,
                                     rd_clr_addr,
                                     wr_clr_addr,
-                                    w_addr_d,                   w_addr_q;
+                                    w_addr_d,                   w_addr_q,
+                                    w_end_d,                    w_end_q,
+                                    w_clr_first,
+                                    w_clr_next,
+                                    w_clr_addr_d,               w_clr_addr_q;
+
+    // Write-in-flight flag for the exclusive-read ordering guard (backport of upstream #4).
+    logic                           excl_ar_stall;
 
     logic                           art_check_req,              art_check_gnt,
                                     art_clr_req,                art_clr_gnt,
@@ -175,7 +193,7 @@ module axi_riscv_lrsc #(
     r_state_t                       r_state_d,                  r_state_q;
 
     typedef enum logic [2:0]    {AW_IDLE, W_FORWARD, W_BYPASS, W_WAIT_ART_CLR, W_DROP, B_FORWARD,
-                                B_INJECT} w_state_t;
+                                B_INJECT, W_CLR_WALK} w_state_t;
     w_state_t                       w_state_d,                  w_state_q;
 
     // AR and R Channel
@@ -215,12 +233,14 @@ module axi_riscv_lrsc #(
         case (r_state_q)
 
             R_IDLE: begin
-                if (slv_ar_valid_i) begin
+                if (slv_ar_valid_i && !excl_ar_stall) begin
                     if (slv_ar_addr_i >= ADDR_BEGIN && slv_ar_addr_i <= ADDR_END && slv_ar_lock_i &&
                             slv_ar_len_i == 8'h00) begin
                         // Inside exclusively-accessible address range and exclusive access and no
-                        // burst
-                        art_set_addr    = slv_ar_addr_i;
+                        // burst.  Backport of upstream >= v0.8.0 granularity: reserve the whole
+                        // word containing the address.
+                        art_set_addr    = AXI_ADDR_WIDTH'(64'(slv_ar_addr_i) >> AXI_STRB_AW
+                                                            << AXI_STRB_AW);
                         art_set_id      = slv_ar_id_i;
                         art_set_req     = 1'b1;
                         r_excl_d        = 1'b1;
@@ -295,12 +315,44 @@ module axi_riscv_lrsc #(
     assign mst_w_user_o     = slv_w_user_i;
     assign mst_w_last_o     = slv_w_last_i;
 
+    // Backport of upstream #30/#31: besides the base address, latch the last word address
+    // covered by the accepted write burst.
     always_comb begin
         w_addr_d    = w_addr_q;
         w_id_d      = w_id_q;
+        w_end_d     = w_end_q;
         if (slv_aw_valid_i && slv_aw_ready_o) begin
             w_addr_d    = slv_aw_addr_i;
             w_id_d      = slv_aw_id_i;
+            // Last word (reservation granule) address covered by this write burst:
+            // ((len+1) << size) bytes starting at the base address, rounded down to whole words.
+            w_end_d     = AXI_ADDR_WIDTH'(((64'(slv_aw_addr_i) +
+                            ((64'(slv_aw_len_i) + 64'd1) << slv_aw_size_i) - 64'd1) >>
+                            AXI_STRB_AW) << AXI_STRB_AW);
+        end
+    end
+
+    // Backport of upstream #30/#31: reservation granularity is one AXI data word (as in upstream
+    // >= v0.8.0, parameter AXI_ADDR_LSB): reservations are set and checked at word-aligned
+    // addresses, and a write invalidates every word it covers.
+    assign w_clr_first = AXI_ADDR_WIDTH'(64'(w_addr_q) >> AXI_STRB_AW << AXI_STRB_AW);
+    assign w_clr_next  = AXI_ADDR_WIDTH'(((64'(w_addr_q) >> AXI_STRB_AW) + 64'd1) << AXI_STRB_AW);
+
+    // Backport of upstream #4: do not let an exclusive read (re-)establish a reservation while a
+    // write overlapping the word of the exclusive read is still in flight downstream (i.e.,
+    // between acceptance of AW and reception of B).  Otherwise the LR could overtake the write at
+    // the downstream slave, read pre-write data, and reserve the word after the write's
+    // reservation clear, so a subsequent SC would succeed on stale data.
+    always_comb begin
+        excl_ar_stall = 1'b0;
+        if (w_state_q != AW_IDLE && slv_ar_valid_i && slv_ar_lock_i && slv_ar_len_i == 8'h00 &&
+                slv_ar_addr_i >= ADDR_BEGIN && slv_ar_addr_i <= ADDR_END) begin
+            if (AXI_ADDR_WIDTH'(64'(slv_ar_addr_i) >> AXI_STRB_AW) >=
+                    AXI_ADDR_WIDTH'(64'(w_addr_q) >> AXI_STRB_AW) &&
+                    AXI_ADDR_WIDTH'(64'(slv_ar_addr_i) >> AXI_STRB_AW) <=
+                    AXI_ADDR_WIDTH'(64'(w_end_q) >> AXI_STRB_AW)) begin
+                excl_ar_stall = 1'b1;
+            end
         end
     end
 
@@ -322,6 +374,7 @@ module axi_riscv_lrsc #(
         wr_clr_req      = 1'b0;
         b_excl_d        = b_excl_q;
         w_state_d       = w_state_q;
+        w_clr_addr_d    = w_clr_addr_q;
 
         case (w_state_q)
 
@@ -331,8 +384,11 @@ module axi_riscv_lrsc #(
                     if (slv_aw_addr_i >= ADDR_BEGIN && slv_aw_addr_i <= ADDR_END) begin
                         // Inside exclusively-accessible address range
                         if (slv_aw_lock_i && slv_aw_len_i == 8'h00) begin
-                            // Exclusive access and no burst, so check if reservation exists
-                            art_check_addr  = slv_aw_addr_i;
+                            // Exclusive access and no burst, so check if reservation exists.
+                            // Backport of upstream >= v0.8.0 granularity: check the whole word
+                            // containing the address.
+                            art_check_addr  = AXI_ADDR_WIDTH'(64'(slv_aw_addr_i) >> AXI_STRB_AW
+                                                                << AXI_STRB_AW);
                             art_check_id    = slv_aw_id_i;
                             art_check_req   = 1'b1;
                             if (art_check_gnt) begin
@@ -374,10 +430,18 @@ module axi_riscv_lrsc #(
                 mst_w_valid_o = slv_w_valid_i;
                 slv_w_ready_o = mst_w_ready_i;
                 if (slv_w_valid_i && slv_w_ready_o && slv_w_last_i) begin
-                    wr_clr_addr = w_addr_q;
+                    wr_clr_addr = w_clr_first;
                     wr_clr_req  = 1'b1;
                     if (wr_clr_gnt) begin
-                        w_state_d = B_FORWARD;
+                        // Backport of upstream #30/#31: after clearing at the exact base address
+                        // (preserving the behavior of the 2019 code for the first word), keep
+                        // clearing every remaining word covered by the burst.
+                        if (w_clr_next <= w_end_q) begin
+                            w_clr_addr_d = w_clr_next;
+                            w_state_d = W_CLR_WALK;
+                        end else begin
+                            w_state_d = B_FORWARD;
+                        end
                     end else begin
                         w_state_d = W_WAIT_ART_CLR;
                     end
@@ -393,10 +457,33 @@ module axi_riscv_lrsc #(
             end
 
             W_WAIT_ART_CLR: begin
-                wr_clr_addr = w_addr_q;
+                wr_clr_addr = w_clr_first;
                 wr_clr_req  = 1'b1;
                 if (wr_clr_gnt) begin
-                    w_state_d = B_FORWARD;
+                    // Backport of upstream #30/#31: identical continuation decision as in
+                    // W_FORWARD.
+                    if (w_clr_next <= w_end_q) begin
+                        w_clr_addr_d = w_clr_next;
+                        w_state_d = W_CLR_WALK;
+                    end else begin
+                        w_state_d = B_FORWARD;
+                    end
+                end
+            end
+
+            // Backport of upstream #30/#31: walk over the remaining words covered by the write
+            // burst and invalidate reservations at each of them, one word per cycle, until the
+            // last word address (w_end_q) has been cleared.
+            W_CLR_WALK: begin
+                wr_clr_addr = w_clr_addr_q;
+                wr_clr_req  = 1'b1;
+                if (wr_clr_gnt) begin
+                    if (w_clr_addr_q + AXI_ADDR_WIDTH'(AXI_STRB_WIDTH) <= w_end_q) begin
+                        w_clr_addr_d = w_clr_addr_q + AXI_ADDR_WIDTH'(AXI_STRB_WIDTH);
+                        w_state_d = W_CLR_WALK;
+                    end else begin
+                        w_state_d = B_FORWARD;
+                    end
                 end
             end
 
@@ -479,6 +566,8 @@ module axi_riscv_lrsc #(
             r_state_q   <= R_IDLE;
             w_addr_q    <= '0;
             w_id_q      <= '0;
+            w_end_q     <= '0;
+            w_clr_addr_q <= '0;
             w_state_q   <= AW_IDLE;
         end else begin
             b_excl_q    <= b_excl_d;
@@ -486,6 +575,8 @@ module axi_riscv_lrsc #(
             r_state_q   <= r_state_d;
             w_addr_q    <= w_addr_d;
             w_id_q      <= w_id_d;
+            w_end_q     <= w_end_d;
+            w_clr_addr_q <= w_clr_addr_d;
             w_state_q   <= w_state_d;
         end
     end


### PR DESCRIPTION
# PR DRAFT BODY — openhwgroup/cva6 (not posted; orchestrator approval required)

Title: `vendor/pulp-platform/axi_riscv_atomics: backport burst-invalidation and RVWMO-ordering fixes to axi_riscv_lrsc`

## Summary

The vendored `axi_riscv_atomics` (rev `550881f`, upstream v0.2.2 of 2019-02-28, vendored in
#3183) implements AXI-exclusive-monitor reservation invalidation for writes at **only the AW
base address**, and lets an exclusive read establish a reservation **while an overlapping write
is still in flight downstream**. Both behaviors violate the RISC-V LR/SC contract on the DRAM
ports of the FPGA wraps (`cva6_altera.sv`, `ariane_xilinx.sv`), where multiple masters share the
port:

- A write burst whose non-base beat overwrites a reserved word does not invalidate the
  reservation, so the victim's SC **succeeds on foreign-overwritten data** (upstream issue #30;
  fixed upstream by the v0.8.0 burst walker + v0.8.2 termination fix, PRs #26/#31).
- Sub-word reservations (`LR.W` at a 4-byte-aligned address on the 64-bit port) are never
  invalidated by writes covering their word (fixed upstream by word-granular reservations,
  `AXI_ADDR_LSB`, v0.8.0).
- An LR racing an in-flight overlapping SW can read pre-write data and re-reserve after the
  SW's clear, producing a **lost update** (upstream issue #4; fixed upstream in v0.3.0).

This PR **minimally backports** the upstream fixes onto the vendored 2019 code instead of a
full re-vendor (7 years of upstream delta incl. interface changes); a full bump can follow.

## Changes (only `vendor/pulp-platform/axi_riscv_atomics/src/axi_riscv_lrsc.sv`)

1. **Word-granular reservations + full-burst invalidation** (port of upstream PRs #26/#31
   semantics): latch the last word covered by an accepted AW
   (`w_end_q`); after the last W beat, clear the word containing the base address, then walk
   every remaining covered word (one per cycle, new state `W_CLR_WALK`) until `w_end_q` is
   cleared; `art_set`/`art_check` use word-aligned addresses (upstream `AXI_ADDR_LSB`
   semantics). Single-beat aligned writes behave exactly as before (single clear, no extra B
   latency).
2. **RVWMO ordering guard** (port of upstream #4 semantics to this single-write-in-flight
   FSM): while a write is in flight (`w_state_q != AW_IDLE`, i.e. AW accepted .. B received),
   an exclusive AR whose word overlaps the write's word range `[w_addr_q word, w_end_q]` is
   stalled in `R_IDLE` instead of being forwarded and re-reserving. Non-overlapping and
   non-exclusive reads are unaffected.

No port, parameter, or dependency changes; `axi_res_tbl.sv` and the other vendored files are
untouched; the #3057 big-endian change to `axi_riscv_amos.sv` is preserved as-is.

## Test

Added `corev_apu/tb/... ` — *(placement per maintainer preference; the standalone reproducer
lives in the issue/package as `tb/tb_lrsc_burst.sv`)* — focused Verilator testbench against the
shim's flat ports with a commit-on-B memory model:

| Check | OLD | NEW |
|---|---|---|
| T1 SC after burst overwrite of reserved non-base word | EXOKAY (**bug**) | OKAY |
| T1b SC.W after full-word overwrite of its word | EXOKAY (**bug**) | OKAY |
| T2 LR vs in-flight SW (data observed) | stale pre-write (**bug**) | fresh post-write |
| T3a/b/c/d/e regressions (pairing, single-beat SW, base-beat burst, SC consumes reservation, bypass) | pass | pass |

Red/green logs: `logs/run-old-red.log`, `logs/run-new-green.log`
(Verilator 5.050 `--timing`; `make redgreen` in `tb/`).

## Notes for reviewers

- Direct in-tree edit of the vendored file follows the precedent of #3057 (big-endian change,
  also applied in-tree). If preferred, the same diff can be reworked as a `util/vendor` patch
  under `vendor/patches/pulp-platform/axi_riscv_atomics/` (the patch dir is already declared in
  `pulp-platform_axi_riscv_atomics.vendor.hjson` but currently empty) — happy to switch.
- The walker adds one clear cycle per additional covered word between the last W beat and B
  (<= burst length in words); reservations-clear-before-B ordering is thereby strengthened.
- #3474 (failed SC does not consume the reservation, upstream #32) is a distinct defect in the
  same file and intentionally out of scope here.
- Longer term, re-vendoring to upstream v0.8.3+ (and re-applying #3057) would retire this
  defect class; this backport is intentionally minimal for easy review.

Fixes: (new issue) "Vendored axi_riscv_lrsc: write bursts invalidate reservations only at the
burst base address; SC succeeds on burst-overwritten data"
Refs: pulp-platform/axi_riscv_atomics#30, #31, #26, #4; cva6 #3183, #3057, #3474
