### PR TITLE
load_unit: warn on misaligned load offsets

### DIFF
--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -682,12 +682,12 @@ module load_unit
   assert property (@(posedge clk_i) disable iff (~rst_ni)
         ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LW, ariane_pkg::LWU})
         |-> ldbuf_wdata.vaddr[CVA6Cfg.XLEN_ALIGN_BYTES-1:0] < 5)
-  else $fatal(1, "invalid address offset used with {LW, LWU}");
+  else $warning("invalid address offset used with {LW, LWU}");
   addr_offset1 :
   assert property (@(posedge clk_i) disable iff (~rst_ni)
         ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LH, ariane_pkg::LHU})
         |-> ldbuf_wdata.vaddr[CVA6Cfg.XLEN_ALIGN_BYTES-1:0] < 7)
-  else $fatal(1, "invalid address offset used with {LH, LHU}");
+  else $warning("invalid address offset used with {LH, LHU}");
   addr_offset2 :
   assert property (@(posedge clk_i) disable iff (~rst_ni)
         ldbuf_w |->  (ldbuf_wdata.operation inside {ariane_pkg::LB, ariane_pkg::LBU})

--- a/verif/tests/custom/issues/load-misaligned-warning.S
+++ b/verif/tests/custom/issues/load-misaligned-warning.S
@@ -1,0 +1,72 @@
+.section .text
+
+.globl main
+main:
+    la      t0, data_buf
+
+    # Word load at byte offset 5.
+    # This is architecturally misaligned and also triggers addr_offset0.
+    addi    t1, t0, 5
+    lw      t2, 0(t1)
+
+    # Unsigned word load at the same offset.
+    addi    t1, t0, 5
+    lwu     t2, 0(t1)
+
+    # Halfword load at byte offset 7.
+    # This is architecturally misaligned and also triggers addr_offset1.
+    addi    t1, t0, 7
+    lh      t2, 0(t1)
+
+    # Unsigned halfword load at the same offset.
+    addi    t1, t0, 7
+    lhu     t2, 0(t1)
+
+    # All four loads must have trapped.
+    la      t0, trap_count
+    lw      t1, 0(t0)
+    li      t2, 4
+    bne     t1, t2, fail
+
+    li      a0, 0
+    ret
+
+fail:
+    li      a0, 1
+    ret
+
+
+.globl handle_trap
+handle_trap:
+    # crt.S passes:
+    #   a0 = mcause
+    #   a1 = mepc
+    # and expects the return value in a0 to be the resume PC.
+
+    li      t0, 4
+    bne     a0, t0, unexpected_trap
+
+    la      t0, trap_count
+    lw      t1, 0(t0)
+    addi    t1, t1, 1
+    sw      t1, 0(t0)
+
+    # All faulting loads in this test are 32-bit instructions.
+    addi    a0, a1, 4
+    ret
+
+unexpected_trap:
+    li      a0, 2
+    j       _exit
+
+
+.section .data
+.align 3
+
+data_buf:
+    .dword  0x1122334455667788
+    .dword  0x99aabbccddeeff00
+
+.align 2
+trap_count:
+    .word   0

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -115,3 +115,12 @@ testlist:
       -fvisibility=hidden
       -nostdlib
       -nostartfiles
+
+  - test: load-misaligned-warning
+    <<: *common_test_config
+    description: >
+      Check that misaligned word and halfword loads raise load-address-
+      misaligned exceptions without terminating simulation in load_unit
+      offset assertions.
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/load-misaligned-warning.S


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

The simulation-only `addr_offset0` and `addr_offset1` assertions in
`core/load_unit.sv` terminate simulation for certain architecturally
misaligned word and halfword loads.

These accesses are expected to be handled through the normal
load-address-misaligned exception path. The existing comment above the
assertions states that these conditions should only issue a warning, but
the assertion actions currently use `$fatal`.

As a result, simulation can terminate before the architectural
load-address-misaligned exception is handled.

## Changes

- Change the `addr_offset0` assertion action for `LW` and `LWU` from
  `$fatal` to `$warning`.
- Change the `addr_offset1` assertion action for `LH` and `LHU` from
  `$fatal` to `$warning`.
- Keep the existing assertion predicates unchanged.
- Leave `addr_offset2` unchanged.
- Add a directed RV64 regression covering misaligned `LW`, `LWU`,
  `LH`, and `LHU`.
- Verify that all four accesses raise the expected
  `LD_ADDR_MISALIGNED` exception.
- Register the regression in `verif/tests/testlist_issues.yaml`.

## Validation

Tested using the `cv64a6_imafdc_sv39` configuration.

- `load-misaligned-warning` directed regression: PASS.
- `veri-testharness`: PASS.
- Regression driver exit status: 0.
- The regression is matched exactly once from
  `verif/tests/testlist_issues.yaml`.
- The test checks four expected `LD_ADDR_MISALIGNED` traps covering
  `LW`, `LWU`, `LH`, and `LHU`.
- An assertion-enabled Verilator run confirms the affected load-unit
  assertions report warnings instead of terminating simulation.
- `git diff --check`: clean.

## Scope / limitations

This change is limited to the severity of two simulation-only assertion
actions.

The assertion predicates, synthesized RTL, LSU datapath, and
architectural misalignment detection are unchanged.

The `addr_offset2` assertion remains unchanged.

Fixes #3512
