### PR TITLE
Fix SC exclusive lock in WAIT_AW_READY

### DIFF
--- a/core/cache_subsystem/axi_adapter.sv
+++ b/core/cache_subsystem/axi_adapter.sv
@@ -250,6 +250,7 @@ module axi_adapter #(
       // ~> from single write
       WAIT_AW_READY: begin
         axi_req_o.aw_valid = 1'b1;
+        axi_req_o.aw.lock  = amo_i == ariane_pkg::AMO_SC;
 
         if (axi_resp_i.aw_ready) begin
           gnt_o   = 1'b1;


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why is this PR needed?

Store-conditional (SC) transactions set the AXI exclusive access bit (`aw.lock`) when the write request is initially issued.

If the write data channel is accepted before the write address channel (`w_ready = 1`, `aw_ready = 0`), the AXI adapter transitions to `WAIT_AW_READY`. In this state, `aw.lock` was not reasserted and therefore fell back to its default value of `0`.

As a result, when the write address was accepted later, the transaction could be sent without the exclusive attribute even though it originated from an SC operation.

This change preserves the SC exclusive write indication while waiting for the delayed AXI write-address handshake.

## What does this PR change?

Reassert `axi_req_o.aw.lock` in `WAIT_AW_READY` when the current AMO operation is `AMO_SC`.

The fix uses `amo_i` because, in the path where the write data handshake occurs before the write address handshake, the saved AMO state is not guaranteed to have been updated yet.

The change is limited to:

`core/cache_subsystem/axi_adapter.sv`

and consists of one RTL line.

Fixes #3473

## Verification

The following checks were completed successfully:

- `verible-verilog-format --inplace core/cache_subsystem/axi_adapter.sv`
- `git diff --check`
- `bash util/sanitize/systemverilog/xlen_misuse.sh`
- `rv64ua-p-lrsc` using the write-back cache configuration:
  - Target: `cv64a6_imafdc_sv39_wb`
  - Simulator: `veri-testharness`
  - Result: `*** SUCCESS *** (tohost = 0)`
  - Completed after 1,080,989 cycles

## Limitations

The existing LR/SC regression verifies that LR/SC behavior continues to operate correctly with the write-back cache configuration.

However, the current test environment does not deterministically force the exact AXI timing sequence where the W channel handshakes before the AW channel. The RTL change directly addresses that `WAIT_AW_READY` state transition.
