### PR TITLE
Fix RV32 legality checks for FCVT L/LU conversions

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -1532,12 +1532,14 @@ module decoder
                 imm_select       = IIMM;  // rs2 holds part of the instruction
                 if (|instr.rftype.rs2[24:22])
                   illegal_instr = 1'b1;  // bits [21:20] used, other bits must be 0
+                if (CVA6Cfg.IS_XLEN32 && instr.rftype.rs2[21]) illegal_instr = 1'b1;
               end
               5'b11010: begin
                 instruction_o.op = ariane_pkg::FCVT_I2F;  // fcvt.fmt.ifmt - Int to FP Conversion
                 imm_select       = IIMM;  // rs2 holds part of the instruction
                 if (|instr.rftype.rs2[24:22])
                   illegal_instr = 1'b1;  // bits [21:20] used, other bits must be 0
+                if (CVA6Cfg.IS_XLEN32 && instr.rftype.rs2[21]) illegal_instr = 1'b1;
               end
               5'b11100: begin
                 instruction_o.rs2 = instr.rftype.rs1; // set rs2 = rs1 so we can map FMV to SGNJ in the unit

--- a/verif/tests/custom/issues/fcvt-rv64-only-rv32.S
+++ b/verif/tests/custom/issues/fcvt-rv64-only-rv32.S
@@ -1,0 +1,97 @@
+# Copyright 2026
+#
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+.section .text
+
+.globl main
+main:
+    la t0, trap_count
+    sw zero, 0(t0)
+
+    # Legal RV32 F conversions. These must not trap.
+    #
+    # fcvt.w.s x0, f0
+    .word 0xc0000053
+
+    # fcvt.wu.s x0, f0
+    .word 0xc0100053
+
+    # fcvt.s.w f0, x0
+    .word 0xd0000053
+
+    # fcvt.s.wu f0, x0
+    .word 0xd0100053
+
+    # RV64-only conversions. Each must raise an
+    # illegal-instruction exception when XLEN=32.
+    #
+rv64_only_begin:
+    # fcvt.l.s x0, f0
+    .word 0xc0200053
+
+    # fcvt.lu.s x0, f0
+    .word 0xc0300053
+
+    # fcvt.s.l f0, x0
+    .word 0xd0200053
+
+    # fcvt.s.lu f0, x0
+    .word 0xd0300053
+
+    # Exactly the four RV64-only instructions above
+    # must have trapped.
+    la t0, trap_count
+    lw t1, 0(t0)
+    li t2, 4
+    bne t1, t2, failure
+
+    li a0, 0
+    ret
+
+failure:
+    li a0, 1
+    ret
+
+
+.globl handle_trap
+handle_trap:
+    # crt.S passes:
+    #   a0 = mcause
+    #   a1 = mepc
+    #
+    # Only illegal-instruction exceptions are expected.
+    li t0, 2
+    bne a0, t0, unexpected_trap
+
+    la t0, trap_count
+    lw t1, 0(t0)
+
+    # Reject extra traps and traps from any other instruction.
+    li t2, 4
+    bgeu t1, t2, unexpected_trap
+
+    # The four expected instructions occupy consecutive 4-byte slots.
+    la t2, rv64_only_begin
+    slli t3, t1, 2
+    add t2, t2, t3
+    bne a1, t2, unexpected_trap
+
+    addi t1, t1, 1
+    sw t1, 0(t0)
+
+    # Skip the injected 32-bit instruction.
+    addi a0, a1, 4
+    ret
+
+unexpected_trap:
+    # Resume at the failure path.
+    la a0, failure
+    ret
+
+
+.section .data
+.align 2
+
+trap_count:
+    .word 0

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -159,3 +159,11 @@ testlist:
       -nostdlib
       -nostartfiles
       -I../tests/custom/env
+
+  - test: fcvt-rv64-only-rv32
+    <<: *common_test_config
+    description: >
+      Check that RV64-only FCVT L/LU conversions raise
+      illegal-instruction exceptions on RV32.
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/fcvt-rv64-only-rv32.S


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

### Description

On RV32 configurations with floating-point support, the decoder accepts the RV64-only FCVT L/LU integer conversion encodings instead of raising an illegal-instruction exception.

This change adds an XLEN check in both the floating-point-to-integer and integer-to-floating-point conversion branches. When XLEN is 32, instructions selecting the L/LU integer formats are marked illegal. Existing reserved-bit checks are preserved.

### Regression test

Adds `fcvt-rv64-only-rv32.S` and registers it in `testlist_issues.yaml`.

The test checks that:
- The four single-precision W/WU conversion encodings execute without trapping.
- FCVT.L.S, FCVT.LU.S, FCVT.S.L and FCVT.S.LU raise illegal-instruction exceptions with cause 2.
- Each exception occurs at the expected instruction address.
- Exactly four expected traps occur; unexpected or extra traps fail the test.

### Validation

The strengthened directed test passed independently with:
- Spike 1.1.1-dev.
- CVA6 Verilator simulation using an RV32+F configuration derived from `cv32a6_imac_sv32` with `RVF=1`. The simulator reported success after 2550 cycles.

`git diff --check` also passed before committing.

### Limitations

Simulation validation covers RV32 single-precision conversions. Double-precision variants and RV64 behavior have not been simulation-tested for this change.

The test is registered in the YAML test list; automatic invocation from `issue-tests.sh` is not included. The Spike and RTL runs were validated independently, without an automated trace comparison.

Fixes #3536.
