### PR TITLE
Fix G-stage host PPN truncation

### DIFF
--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -474,7 +474,7 @@ module cva6_ptw
                     state_d = WAIT_GRANT;
                     ptw_stage_d = S_STAGE;
                     ptw_lvl_n[0] = ptw_lvl_q[HYP_EXT];
-                    pptr = {pte.ppn[CVA6Cfg.GPPNW-1:0], gptw_pptr_q[11:0]};
+                    pptr = {pte.ppn, gptw_pptr_q[11:0]};
                     if (ptw_lvl_q[0] == 1) pptr[20:0] = gptw_pptr_q[20:0];
                     if (ptw_lvl_q[0] == 0) pptr[29:0] = gptw_pptr_q[29:0];
                     ptw_pptr_n = pptr;


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

Issue #3538 identifies an incorrect width used when constructing the host physical pointer for a G-stage leaf encountered while translating a VS-stage page-table address.

In `G_INTERMED_STAGE`, the current code limits the G-stage PTE PPN to `CVA6Cfg.GPPNW`. On RV64, `GPPNW` represents the guest-physical PPN width, while the PTE at this point contains a host physical PPN.

As a result, the upper host physical address bits can be lost when the VS-stage page table is located above the guest-physical address range.

This change uses the complete `pte.ppn` when constructing `pptr`.

The existing superpage substitutions remain unchanged.

## Related issue

Fixes #3538

## Validation

Validated with the existing RV64 H-extension/G-stage directed tests using `cv64a6_imafdch_sv39`:

- `rv64h-p-hlvx-gstage`
  - Spike: PASS
  - Verilator testharness: PASS

- `rv64h-p-hlvx-gstage-ctrl`
  - Spike: PASS
  - Verilator testharness: PASS

Additional checks:

- `git diff --check`: PASS
- `verible-verilog-format --verify core/cva6_mmu/cva6_ptw.sv`: PASS
- `bash util/sanitize/systemverilog/xlen_misuse.sh`: PASS

## Limitations

The existing G-stage tests exercise the affected two-stage PTW path and provide no-regression coverage.

They do not directly reproduce a VS-stage page table located at a host physical address above 2^41, because the existing simulation memory setup does not provide a distinct backing-memory region at those high host physical addresses.
