### PR TITLE
csr_regfile: mask htval and mtval2 WARL writes

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1536,7 +1536,7 @@ module csr_regfile
         end
         riscv::CSR_HTVAL: begin
           if (CVA6Cfg.RVH) begin
-            htval_d = csr_wdata;
+            htval_d = {{CVA6Cfg.XLEN - CVA6Cfg.GPLEN + 2{1'b0}}, csr_wdata[CVA6Cfg.GPLEN-3:0]};
           end else begin
             update_access_exception = 1'b1;
           end
@@ -1751,7 +1751,8 @@ module csr_regfile
         if (CVA6Cfg.RVH) mtinst_d = {{CVA6Cfg.XLEN - 32{1'b0}}, csr_wdata[31:0]};
         else update_access_exception = 1'b1;
         riscv::CSR_MTVAL2:
-        if (CVA6Cfg.RVH) mtval2_d = csr_wdata;
+        if (CVA6Cfg.RVH)
+          mtval2_d = {{CVA6Cfg.XLEN - CVA6Cfg.GPLEN + 2{1'b0}}, csr_wdata[CVA6Cfg.GPLEN-3:0]};
         else update_access_exception = 1'b1;
         riscv::CSR_MIP: begin
           if (CVA6Cfg.RVH) begin

--- a/verif/tests/custom/issues/htval-mtval2-warl-rv64.S
+++ b/verif/tests/custom/issues/htval-mtval2-warl-rv64.S
@@ -1,0 +1,65 @@
+# Copyright 2026 Keerthivasan
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+# Regression test for CVA6 issue #3537.
+#
+# On RV64 Sv39x4, guest physical addresses are 41 bits. htval and
+# mtval2 store the guest physical address shifted right by two, so
+# only bits [38:0] of these CSRs are meaningful.
+
+  .section .text
+  .align 2
+
+  .equ CSR_MTVAL2, 0x34b
+  .equ CSR_HTVAL,  0x643
+
+  .equ SHIFTED_GPA_MASK_SV39X4, 0x0000007fffffffff
+
+  .globl main
+
+main:
+  li      t0, -1
+  li      t2, SHIFTED_GPA_MASK_SV39X4
+
+  # htval must legalize values outside the implemented shifted-GPA width.
+  csrw    CSR_HTVAL, t0
+  csrr    t1, CSR_HTVAL
+  bne     t1, t2, fail_htval
+
+  # mtval2 must follow the same WARL behavior.
+  csrw    CSR_MTVAL2, t0
+  csrr    t1, CSR_MTVAL2
+  bne     t1, t2, fail_mtval2
+
+  # Both WARL registers must be capable of holding zero.
+  csrw    CSR_HTVAL, zero
+  csrr    t1, CSR_HTVAL
+  bnez    t1, fail_htval_zero
+
+  csrw    CSR_MTVAL2, zero
+  csrr    t1, CSR_MTVAL2
+  bnez    t1, fail_mtval2_zero
+
+pass:
+  li      a0, 0
+  j       finish
+
+fail_htval:
+  li      a0, 1
+  j       finish
+
+fail_mtval2:
+  li      a0, 2
+  j       finish
+
+fail_htval_zero:
+  li      a0, 3
+  j       finish
+
+fail_mtval2_zero:
+  li      a0, 4
+
+finish:
+  jal     exit

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -178,3 +178,11 @@ testlist:
       illegal-instruction exceptions on RV32.
     iterations: 1
     asm_tests: <path_var>/custom/issues/fcvt-rv64-only-rv32.S
+
+  - test: htval-mtval2-warl-rv64
+    <<: *common_test_config
+    description: >
+      Check that RV64 Sv39x4 htval and mtval2 retain only the implemented
+      2-bit-shifted guest-physical-address bits.
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/htval-mtval2-warl-rv64.S


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why

The `htval` and `mtval2` CSR software write paths currently store the complete XLEN-wide `csr_wdata` value.

Both CSRs are WARL registers and represent a guest physical address shifted right by two bits. For the RV64 Sv39x4 configuration, `GPLEN` is 41 bits, which means only 39 bits of the shifted guest physical address are implemented.

As a result, writing an arbitrary XLEN-wide value such as all ones is currently preserved and read back unchanged instead of being restricted to the implemented legal value range.

## What

This change:

- Restricts software writes to `htval` and `mtval2` to `csr_wdata[CVA6Cfg.GPLEN-3:0]`.
- Zero-extends the retained shifted guest-physical-address bits to XLEN.
- Keeps the existing hardware trap write paths unchanged.
- Adds a directed RV64 regression covering both `htval` and `mtval2`.
- Checks that values outside the implemented shifted-GPA width are discarded.
- Checks that both WARL registers can still hold zero.

For `cv64a6_imafdch_sv39`, `GPLEN = 41`, so an all-ones CSR write is legalized to:

`0x0000007fffffffff`

The same implementation is behavior-neutral for RV32, where `GPLEN = 34` and the shifted guest physical address occupies the full 32-bit CSR width.

## Verification

Tested with:

`cv64a6_imafdch_sv39`

Directed regression:

`htval-mtval2-warl-rv64`

Before the fix:

`*** FAILED *** (tohost = 1) after 972 cycles`

After the fix:

`*** SUCCESS *** (tohost = 0) after 977 cycles`

The modified RTL was formatted using `verible-verilog-format`.

`git diff --check` reports no whitespace errors.

Fixes #3537
