### PR TITLE
Gate Zcmp IDLE transitions on issue ack

### DIFF
--- a/core/macro_decoder.sv
+++ b/core/macro_decoder.sv
@@ -321,7 +321,9 @@ module macro_decoder #(
             is_double_rd_macro_instr_o = 1;
             // addi xreg1, a0, 0
             instr_o_reg = {12'h0, 5'hA, 3'h0, xreg1, riscv::OpcodeOpImm};
-            state_d = MOVE;
+            if (issue_ack_i) begin
+              state_d = MOVE;
+            end
           end
 
           if (macro_instr_type == MVA01S) begin
@@ -329,7 +331,9 @@ module macro_decoder #(
             is_double_rd_macro_instr_o = 1;
             // addi a0, xreg1, 0
             instr_o_reg = {12'h0, xreg1, 3'h0, 5'hA, riscv::OpcodeOpImm};
-            state_d = MOVE;
+            if (issue_ack_i) begin
+              state_d = MOVE;
+            end
           end
 
           if (macro_instr_type == PUSH) begin
@@ -346,7 +350,9 @@ module macro_decoder #(
                   7'b1111111, 5'h1, 5'h2, 3'h2, 5'b11100, riscv::OpcodeStore
                 };  // sw store_reg, -4(sp)
               end
-              state_d = PUSH_ADDI;
+              if (issue_ack_i) begin
+                state_d = PUSH_ADDI;
+              end
             end
 
             if (reg_numbers == 4'b0010) begin
@@ -373,7 +379,7 @@ module macro_decoder #(
                 instr_o_reg = {7'b1111111, store_reg, 5'h2, 3'h2, 5'b11100, riscv::OpcodeStore};
               end
 
-              if (reg_numbers == 12) begin
+              if (reg_numbers == 12 && issue_ack_i) begin
                 state_d = PUSH_POP_INSTR_2;
               end
             end
@@ -391,15 +397,17 @@ module macro_decoder #(
                   offset_reg, 5'h2, 3'h2, 5'h1, riscv::OpcodeLoad
                 };  // lw store_reg, Imm(sp)
               end
-              unique case (macro_instr_type)
-                PUSH, POP, POPRET: begin
-                  state_d = PUSH_ADDI;
-                end
-                POPRETZ: begin
-                  state_d = POPRETZ_1;
-                end
-                default: ;
-              endcase
+              if (issue_ack_i) begin
+                unique case (macro_instr_type)
+                  PUSH, POP, POPRET: begin
+                    state_d = PUSH_ADDI;
+                  end
+                  POPRETZ: begin
+                    state_d = POPRETZ_1;
+                  end
+                  default: ;
+                endcase
+              end
             end
 
             if (reg_numbers == 2) begin
@@ -425,7 +433,7 @@ module macro_decoder #(
                 instr_o_reg = {offset_reg, 5'h2, 3'h2, store_reg, riscv::OpcodeLoad};
               end
 
-              if (reg_numbers == 12) begin
+              if (reg_numbers == 12 && issue_ack_i) begin
                 state_d = PUSH_POP_INSTR_2;
               end
             end

--- a/verif/regress/cv32a6_tests.sh
+++ b/verif/regress/cv32a6_tests.sh
@@ -46,6 +46,10 @@ cd verif/sim/
 
 errors=0
 
+# Regression for #3535: Zcmp macro expansion must wait for issue acknowledgement.
+make -C ../tb/macro_decoder_unit
+[[ $? > 0 ]] && ((errors++))
+
 # 32-bit configurations without MMU
 riscv_tests_list=(
   rv32ui-p-add

--- a/verif/tb/macro_decoder_unit/Makefile
+++ b/verif/tb/macro_decoder_unit/Makefile
@@ -1,0 +1,33 @@
+ROOT := ../../..
+BUILD := .build/macro_decoder_issue_ack_test
+
+SOURCES := \
+	$(ROOT)/core/include/config_pkg.sv \
+	$(ROOT)/core/include/cv32a6_imac_sv32_config_pkg.sv \
+	$(ROOT)/core/include/build_config_pkg.sv \
+	$(ROOT)/core/include/riscv_pkg.sv \
+	$(ROOT)/core/macro_decoder.sv \
+	macro_decoder_issue_ack_test.sv
+
+.PHONY: all macro_decoder_issue_ack_test clean
+
+all: macro_decoder_issue_ack_test
+
+macro_decoder_issue_ack_test:
+	mkdir -p .build
+	verilator \
+		--binary \
+		--assert \
+		--timing \
+		-Wno-fatal \
+		-Wno-PINMISSING \
+		-Wno-WIDTHTRUNC \
+		-Wno-WIDTHEXPAND \
+		-I$(ROOT)/core/include \
+		--top-module macro_decoder_issue_ack_test \
+		--Mdir $(BUILD) \
+		$(SOURCES)
+	$(BUILD)/Vmacro_decoder_issue_ack_test
+
+clean:
+	rm -rf .build

--- a/verif/tb/macro_decoder_unit/macro_decoder_issue_ack_test.sv
+++ b/verif/tb/macro_decoder_unit/macro_decoder_issue_ack_test.sv
@@ -1,0 +1,166 @@
+module macro_decoder_issue_ack_test;
+
+  localparam config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(
+      cva6_config_pkg::cva6_cfg
+  );
+
+  // macro_decoder FSM encoding.
+  localparam logic [2:0] ST_IDLE = 3'd0;
+  localparam logic [2:0] ST_PUSH_ADDI = 3'd2;
+  localparam logic [2:0] ST_POPRETZ_1 = 3'd3;
+  localparam logic [2:0] ST_MOVE = 3'd4;
+  localparam logic [2:0] ST_PUSH_POP_INSTR_2 = 3'd5;
+
+  logic        clk_i;
+  logic        rst_ni;
+  logic [31:0] instr_i;
+  logic        is_macro_instr_i;
+  logic        illegal_instr_i;
+  logic        is_compressed_i;
+  logic        issue_ack_i;
+
+  logic [31:0] instr_o;
+  logic        illegal_instr_o;
+  logic        is_compressed_o;
+  logic        fetch_stall_o;
+  logic        is_last_macro_instr_o;
+  logic        is_double_rd_macro_instr_o;
+
+  always #5 clk_i = ~clk_i;
+
+  macro_decoder #(
+      .CVA6Cfg(CVA6Cfg)
+  ) dut (
+      .instr_i,
+      .clk_i,
+      .rst_ni,
+      .is_macro_instr_i,
+      .illegal_instr_i,
+      .is_compressed_i,
+      .issue_ack_i,
+      .instr_o,
+      .illegal_instr_o,
+      .is_compressed_o,
+      .fetch_stall_o,
+      .is_last_macro_instr_o,
+      .is_double_rd_macro_instr_o
+  );
+
+  task automatic reset_dut;
+    begin
+      is_macro_instr_i = 1'b0;
+      illegal_instr_i  = 1'b0;
+      is_compressed_i  = 1'b1;
+      issue_ack_i      = 1'b0;
+      instr_i          = '0;
+
+      rst_ni           = 1'b0;
+      repeat (2) @(posedge clk_i);
+
+      // Deassert reset away from the active clock edge.
+      @(negedge clk_i);
+      rst_ni = 1'b1;
+      #1;
+
+      assert (dut.state_q == ST_IDLE)
+      else $fatal(1, "decoder did not reset to IDLE");
+    end
+  endtask
+
+  task automatic check_stalled_first_uop(
+      input logic [15:0] encoding, input logic [2:0] expected_next_state, input string test_name);
+    logic [31:0] first_uop;
+
+    begin
+      reset_dut();
+
+      // Drive the macro between clock edges and explicitly hold the
+      // issue acknowledgement low.
+      instr_i          = {16'h0000, encoding};
+      is_macro_instr_i = 1'b1;
+      issue_ack_i      = 1'b0;
+
+      // Allow combinational decoder outputs to settle before sampling.
+      #1;
+
+      assert (!illegal_instr_o)
+      else $fatal(1, "%s decoded as illegal", test_name);
+
+      assert (dut.state_q == ST_IDLE)
+      else $fatal(1, "%s did not start in IDLE", test_name);
+
+      assert (fetch_stall_o)
+      else $fatal(1, "%s did not stall instruction fetch", test_name);
+
+      first_uop = instr_o;
+
+      // Cross exactly one active clock edge with issue_ack_i low.
+      @(posedge clk_i);
+      @(negedge clk_i);
+      #1;
+
+      assert (dut.state_q == ST_IDLE)
+      else $fatal(1, "%s left IDLE without issue_ack_i (state=%0d)", test_name, dut.state_q);
+
+      assert (instr_o === first_uop)
+      else $fatal(1, "%s changed the first micro-op while issue_ack_i was low", test_name);
+
+      // Acknowledge the first micro-op well before the next positive edge.
+      issue_ack_i = 1'b1;
+      #1;
+
+      // Cross exactly one active edge and sample before another active edge.
+      @(posedge clk_i);
+      @(negedge clk_i);
+      #1;
+
+      assert (dut.state_q == expected_next_state)
+      else
+        $fatal(
+            1,
+            "%s did not advance after issue_ack_i (state=%0d expected=%0d)",
+            test_name,
+            dut.state_q,
+            expected_next_state
+        );
+
+      $display("PASS: %s", test_name);
+    end
+  endtask
+
+  initial begin
+    clk_i            = 1'b0;
+    rst_ni           = 1'b0;
+    instr_i          = '0;
+    is_macro_instr_i = 1'b0;
+    illegal_instr_i  = 1'b0;
+    is_compressed_i  = 1'b1;
+    issue_ack_i      = 1'b0;
+
+    // Encodings generated with GNU binutils Zcmp support.
+    //
+    // Each of these instructions has a special transition directly
+    // from IDLE which must occur only after issue_ack_i is asserted.
+
+    check_stalled_first_uop(16'hacaa, ST_MOVE, "cm.mvsa01");
+
+    check_stalled_first_uop(16'hacea, ST_MOVE, "cm.mva01s");
+
+    check_stalled_first_uop(16'hb842, ST_PUSH_ADDI, "cm.push {ra}, -16");
+
+    check_stalled_first_uop(16'hba42, ST_PUSH_ADDI, "cm.pop {ra}, 16");
+
+    check_stalled_first_uop(16'hbe42, ST_PUSH_ADDI, "cm.popret {ra}, 16");
+
+    check_stalled_first_uop(16'hbc42, ST_POPRETZ_1, "cm.popretz {ra}, 16");
+
+    check_stalled_first_uop(16'hb8f2, ST_PUSH_POP_INSTR_2, "cm.push {ra, s0-s11}, -64");
+
+    check_stalled_first_uop(16'hbaf2, ST_PUSH_POP_INSTR_2, "cm.pop {ra, s0-s11}, 64");
+
+    $display("PASS: macro decoder holds every affected first micro-op until issue_ack_i");
+
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Description

The Zcmp macro decoder contains special transitions from IDLE that can advance the FSM without waiting for `issue_ack_i`.

If the issue stage stalls while the first expanded micro-op is being presented, the decoder can move to the next state before the first micro-op is accepted. This can drop the first load, store, or move operation.

The affected cases include:

- `cm.mvsa01`
- `cm.mva01s`
- single-register `cm.push`
- single-register `cm.pop`
- single-register `cm.popret`
- single-register `cm.popretz`
- rlist=15 `cm.push`
- rlist=15 `cm.pop`

This change gates the affected state transitions with `issue_ack_i` so that the decoder remains in IDLE until the first expanded micro-op has been accepted.

## Changes

- Gate the `cm.mvsa01` transition to `MOVE` with `issue_ack_i`.
- Gate the `cm.mva01s` transition to `MOVE` with `issue_ack_i`.
- Gate single-register `cm.push` transition to `PUSH_ADDI`.
- Gate single-register `cm.pop` and `cm.popret` transition to `PUSH_ADDI`.
- Gate single-register `cm.popretz` transition to `POPRETZ_1`.
- Gate rlist=15 push/pop transition to `PUSH_POP_INSTR_2`.
- Add a focused macro decoder unit regression.
- Run the regression from `verif/regress/cv32a6_tests.sh`.

## Verification

A focused unit test was added in:

    verif/tb/macro_decoder_unit/

The test holds `issue_ack_i` low while the first expanded micro-op is presented and verifies that:

- the decoder remains in IDLE;
- the first micro-op remains stable;
- the FSM advances only after `issue_ack_i` is asserted.

The following cases are covered:

- `cm.mvsa01`
- `cm.mva01s`
- `cm.push {ra}, -16`
- `cm.pop {ra}, 16`
- `cm.popret {ra}, 16`
- `cm.popretz {ra}, 16`
- `cm.push {ra, s0-s11}, -64`
- `cm.pop {ra, s0-s11}, 64`

### Before the fix

The regression fails on the original RTL with:

    cm.mvsa01 left IDLE without issue_ack_i (state=4)

The baseline unit test returns a non-zero status.

### After the fix

The regression passes all affected cases:

    PASS: cm.mvsa01
    PASS: cm.mva01s
    PASS: cm.push {ra}, -16
    PASS: cm.pop {ra}, 16
    PASS: cm.popret {ra}, 16
    PASS: cm.popretz {ra}, 16
    PASS: cm.push {ra, s0-s11}, -64
    PASS: cm.pop {ra, s0-s11}, 64
    PASS: macro decoder holds every affected first micro-op until issue_ack_i

Final unit-test result:

    macro_decoder_unit_rc=0

Additional checks performed:

    verible-verilog-format
    git diff --check
    git diff --cached --check
    bash -n verif/regress/cv32a6_tests.sh

The branch was also checked against the latest `upstream/master`.

Fixes #3535

## Limitations

None known.
