### PR TITLE
Uga fpetrot 20260908

### DIFF
--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -858,7 +858,7 @@ module compressed_decoder #(
           end
 
           riscv::OpcodeC2Fsdsp: begin
-            if (CVA6Cfg.FpPresent) begin
+            if (CVA6Cfg.RVD && CVA6Cfg.RVC) begin
               // c.fsdsp -> fsd rs2, imm(x2)
               instr_o = {
                 3'b0,

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -208,8 +208,8 @@ package config_pkg;
     // DcacheInvalidateOnFlush causes dcache to also be invalidated when flushed
     // tradeoff between coherence and efficiency, depending on remaining configuration:
 
-    // DcacheFlushOnFenceI is required for write-back caches - otherwise, 
-    // no way to reliably write instruction memory with store instructions, 
+    // DcacheFlushOnFenceI is required for write-back caches - otherwise,
+    // no way to reliably write instruction memory with store instructions,
     // as data and instruction cache are currently not coherent
     // DcacheFlushOnFence is required for write-back caches to ensure coherency
     // with other harts or DMA devices --> a fence forces all stores to commit to memory

--- a/core/include/cv32a6_imac_zcmp_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_zcmp_sv32_config_pkg.sv
@@ -1,0 +1,184 @@
+// Copyright 2021 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON - Thales
+
+
+package cva6_config_pkg;
+
+  localparam CVA6ConfigXlen = 32;
+
+  localparam CVA6ConfigRVF = 0;
+  localparam CVA6ConfigRVD = 0;
+  localparam CVA6ConfigF16En = 0;
+  localparam CVA6ConfigF16AltEn = 0;
+  localparam CVA6ConfigF8En = 0;
+  localparam CVA6ConfigFVecEn = 0;
+
+  localparam CVA6ConfigCvxifEn = 0;
+  localparam CVA6ConfigCExtEn = 1;
+  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigZcmpExtEn = 1;
+  localparam CVA6ConfigAExtEn = 1;
+  localparam CVA6ConfigHExtEn = 0;  // always disabled
+  localparam CVA6ConfigVExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
+
+  localparam CVA6ConfigAxiIdWidth = 4;
+  localparam CVA6ConfigAxiAddrWidth = 64;
+  localparam CVA6ConfigAxiDataWidth = 64;
+  localparam CVA6ConfigFetchUserEn = 0;
+  localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
+  localparam CVA6ConfigDataUserEn = 0;
+  localparam CVA6ConfigDataUserWidth = CVA6ConfigXlen;
+
+  localparam CVA6ConfigIcacheByteSize = 16384;
+  localparam CVA6ConfigIcacheSetAssoc = 4;
+  localparam CVA6ConfigIcacheLineWidth = 128;
+  localparam CVA6ConfigDcacheByteSize = 32768;
+  localparam CVA6ConfigDcacheSetAssoc = 8;
+  localparam CVA6ConfigDcacheLineWidth = 128;
+
+  localparam CVA6ConfigDcacheIdWidth = 3;
+  localparam CVA6ConfigMemTidWidth = 4;
+
+  localparam CVA6ConfigWtDcacheWbufDepth = 8;
+
+  localparam CVA6ConfigNrScoreboardEntries = 8;
+
+  localparam CVA6ConfigNrLoadPipeRegs = 1;
+  localparam CVA6ConfigNrStorePipeRegs = 0;
+  localparam CVA6ConfigNrLoadBufEntries = 2;
+
+  localparam CVA6ConfigRASDepth = 2;
+  localparam CVA6ConfigBTBEntries = 32;
+  localparam CVA6ConfigBHTEntries = 128;
+
+  localparam CVA6ConfigTvalEn = 1;
+
+  localparam CVA6ConfigNrPMPEntries = 8;
+
+  localparam CVA6ConfigPerfCounterEn = 1;
+
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::HPDCACHE_WT;
+
+  localparam CVA6ConfigMmuPresent = 1;
+
+  localparam CVA6ConfigRvfiTrace = 1;
+
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
+      XLEN: unsigned'(CVA6ConfigXlen),
+      VLEN: unsigned'(32),
+      FpgaEn: bit'(0),  // for Xilinx and Altera
+      FpgaAlteraEn: bit'(0),  // for Altera (only)
+      TechnoCut: bit'(0),
+      SuperscalarEn: bit'(0),
+      ALUBypass: bit'(0),
+      NrCommitPorts: unsigned'(2),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      MemTidWidth: unsigned'(CVA6ConfigMemTidWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      RVF: bit'(CVA6ConfigRVF),
+      RVD: bit'(CVA6ConfigRVD),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(1),
+      ZKN: bit'(1),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVH: bit'(CVA6ConfigHExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      RVZCMT: bit'(0),
+      RVZCMP: bit'(CVA6ConfigZcmpExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::COPRO_NONE,
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
+      RVZiCbom: bit'(0),
+      RVZicntr: bit'(1),
+      RVZihpm: bit'(1),
+      NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
+      PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),
+      MmuPresent: bit'(CVA6ConfigMmuPresent),
+      RVS: bit'(1),
+      RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth: unsigned'(CVA6ConfigRASDepth),
+      BTBEntries: unsigned'(CVA6ConfigBTBEntries),
+      BPType: config_pkg::BHT,
+      BHTEntries: unsigned'(CVA6ConfigBHTEntries),
+      BHTHist: unsigned'(3),
+      DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
+      DirectVecOnly: bit'(0),
+      NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
+      PMPCfgRstVal: {64{64'h0}},
+      PMPAddrRstVal: {64{64'h0}},
+      PMPEntryReadOnly: 64'd0,
+      PMPNapotEn: bit'(1),
+      NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
+      NrNonIdempotentRules: unsigned'(1),
+      NonIdempotentAddrBase: 1024'({64'b0}),
+      NonIdempotentLength: 1024'({64'h8000_0000}),
+      NrExecuteRegionRules: unsigned'(3),
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
+      NrCachedRegionRules: unsigned'(1),
+      CachedRegionAddrBase: 1024'({64'h8000_0000}),
+      CachedRegionLength: 1024'({64'h40000000}),
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1),
+      Sdtrig: bit'(0),
+      SdtrigMcontrol6: bit'(0),
+      SdtrigMcontrol6ExecAddr: bit'(0),
+      SdtrigMcontrol6ExecData: bit'(0),
+      SdtrigMcontrol6Store: bit'(0),
+      SdtrigMcontrol6LoadAddr: bit'(0),
+      SdtrigMcontrol6LoadData: bit'(0),
+      SdtrigIcount: bit'(0),
+      SdtrigEtrigger: bit'(0),
+      SdtrigItrigger: bit'(0),
+      SdtrigNrTriggers: int'(4),
+      SdtrigTriggerChaining: bit'(0),
+      SdtrigSupportedActions: {2{2'b01}},
+      SdtrigSupportedMatch: {10{10'b00_0000_0001}},
+      SdtrigSupportTextra: bit'(0),
+      AxiBurstWriteEn: bit'(0),
+      IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
+      IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
+      IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: CVA6ConfigDcacheType,
+      DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
+      DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
+      DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),
+      DcacheFlushOnFence: bit'(0),
+      DcacheFlushOnFenceI: bit'(0),
+      DcacheInvalidateOnFlush: bit'(0),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
+      DataUserEn: unsigned'(CVA6ConfigDataUserEn),
+      WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
+      FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
+      FetchUserEn: unsigned'(CVA6ConfigFetchUserEn),
+      InstrTlbEntries: int'(2),
+      DataTlbEntries: int'(2),
+      UseSharedTlb: bit'(1),
+      SvnapotEn: bit'(0),
+      SharedTlbDepth: int'(64),
+      NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
+      NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
+      DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth)
+  };
+
+endpackage

--- a/core/include/cv64a6_imac_zcmp_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imac_zcmp_sv39_config_pkg.sv
@@ -1,0 +1,189 @@
+// Copyright 2021 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON - Thales
+
+
+package cva6_config_pkg;
+
+  localparam CVA6ConfigXlen = 64;
+
+  localparam CVA6ConfigRVF = 0;
+  localparam CVA6ConfigRVD = 0;
+  localparam CVA6ConfigF16En = 0;
+  localparam CVA6ConfigF16AltEn = 0;
+  localparam CVA6ConfigF8En = 0;
+  localparam CVA6ConfigFVecEn = 0;
+
+  localparam CVA6ConfigCvxifEn = 1;
+  localparam CVA6ConfigCExtEn = 1;
+  localparam CVA6ConfigZcbExtEn = 1;
+  localparam CVA6ConfigZcmpExtEn = 1;
+  localparam CVA6ConfigAExtEn = 1;
+  localparam CVA6ConfigHExtEn = 0;  // always disabled
+  localparam CVA6ConfigBExtEn = 1;
+  localparam CVA6ConfigVExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 1;
+
+  localparam CVA6ConfigAxiIdWidth = 4;
+  localparam CVA6ConfigAxiAddrWidth = 64;
+  localparam CVA6ConfigAxiDataWidth = 64;
+  localparam CVA6ConfigFetchUserEn = 0;
+  localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
+  localparam CVA6ConfigDataUserEn = 0;
+  localparam CVA6ConfigDataUserWidth = CVA6ConfigXlen;
+
+  localparam CVA6ConfigIcacheByteSize = 16384;
+  localparam CVA6ConfigIcacheSetAssoc = 4;
+  localparam CVA6ConfigIcacheLineWidth = 128;
+  localparam CVA6ConfigDcacheByteSize = 32768;
+  localparam CVA6ConfigDcacheSetAssoc = 8;
+  localparam CVA6ConfigDcacheLineWidth = 128;
+
+  localparam CVA6ConfigDcacheFlushOnFence = 1'b0;
+  localparam CVA6ConfigDcacheFlushOnFenceI = 1'b0;
+  localparam CVA6ConfigDcacheInvalidateOnFlush = 1'b0;
+
+  localparam CVA6ConfigDcacheIdWidth = 1;
+  localparam CVA6ConfigMemTidWidth = 2;
+
+  localparam CVA6ConfigWtDcacheWbufDepth = 8;
+
+  localparam CVA6ConfigNrScoreboardEntries = 8;
+
+  localparam CVA6ConfigNrLoadPipeRegs = 1;
+  localparam CVA6ConfigNrStorePipeRegs = 0;
+  localparam CVA6ConfigNrLoadBufEntries = 2;
+
+  localparam CVA6ConfigRASDepth = 2;
+  localparam CVA6ConfigBTBEntries = 32;
+  localparam CVA6ConfigBHTEntries = 128;
+
+  localparam CVA6ConfigTvalEn = 1;
+
+  localparam CVA6ConfigNrPMPEntries = 8;
+
+  localparam CVA6ConfigPerfCounterEn = 1;
+
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
+  localparam CVA6ConfigMmuPresent = 1;
+
+  localparam CVA6ConfigRvfiTrace = 1;
+
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
+      XLEN: unsigned'(CVA6ConfigXlen),
+      VLEN: unsigned'(64),
+      FpgaEn: bit'(0),  // for Xilinx and Altera
+      FpgaAlteraEn: bit'(0),  // for Altera (only)
+      TechnoCut: bit'(0),
+      SuperscalarEn: bit'(0),
+      ALUBypass: bit'(0),
+      NrCommitPorts: unsigned'(2),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      MemTidWidth: unsigned'(CVA6ConfigMemTidWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      RVF: bit'(CVA6ConfigRVF),
+      RVD: bit'(CVA6ConfigRVD),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
+      ZKN: bit'(1),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVH: bit'(CVA6ConfigHExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      RVZCMT: bit'(0),
+      RVZCMP: bit'(CVA6ConfigZcmpExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::COPRO_NONE,
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
+      RVZiCbom: bit'(0),
+      RVZicntr: bit'(1),
+      RVZihpm: bit'(1),
+      NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
+      PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),
+      MmuPresent: bit'(CVA6ConfigMmuPresent),
+      RVS: bit'(1),
+      RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth: unsigned'(CVA6ConfigRASDepth),
+      BTBEntries: unsigned'(CVA6ConfigBTBEntries),
+      BPType: config_pkg::BHT,
+      BHTEntries: unsigned'(CVA6ConfigBHTEntries),
+      BHTHist: unsigned'(3),
+      DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
+      DirectVecOnly: bit'(0),
+      NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
+      PMPCfgRstVal: {64{64'h0}},
+      PMPAddrRstVal: {64{64'h0}},
+      PMPEntryReadOnly: 64'd0,
+      PMPNapotEn: bit'(1),
+      NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
+      NrNonIdempotentRules: unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength: 1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules: unsigned'(3),
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
+      NrCachedRegionRules: unsigned'(1),
+      CachedRegionAddrBase: 1024'({64'h8000_0000}),
+      CachedRegionLength: 1024'({64'h40000000}),
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1),
+      Sdtrig: bit'(0),
+      SdtrigMcontrol6: bit'(0),
+      SdtrigMcontrol6ExecAddr: bit'(0),
+      SdtrigMcontrol6ExecData: bit'(0),
+      SdtrigMcontrol6Store: bit'(0),
+      SdtrigMcontrol6LoadAddr: bit'(0),
+      SdtrigMcontrol6LoadData: bit'(0),
+      SdtrigIcount: bit'(0),
+      SdtrigEtrigger: bit'(0),
+      SdtrigItrigger: bit'(0),
+      SdtrigNrTriggers: int'(4),
+      SdtrigTriggerChaining: bit'(0),
+      SdtrigSupportedActions: {2{2'b01}},
+      SdtrigSupportedMatch: {10{10'b00_0000_0001}},
+      SdtrigSupportTextra: bit'(0),
+      AxiBurstWriteEn: bit'(0),
+      IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
+      IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
+      IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: CVA6ConfigDcacheType,
+      DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
+      DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
+      DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),
+      DcacheFlushOnFence: unsigned'(CVA6ConfigDcacheFlushOnFence),
+      DcacheFlushOnFenceI: unsigned'(CVA6ConfigDcacheFlushOnFenceI),
+      DcacheInvalidateOnFlush: unsigned'(CVA6ConfigDcacheInvalidateOnFlush),
+      DcacheEccEnable: bit'(0),
+      DcacheEccScrubberEnable: bit'(0),
+      DataUserEn: unsigned'(CVA6ConfigDataUserEn),
+      WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
+      FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
+      FetchUserEn: unsigned'(CVA6ConfigFetchUserEn),
+      InstrTlbEntries: int'(16),
+      DataTlbEntries: int'(16),
+      UseSharedTlb: bit'(0),
+      SvnapotEn: bit'(1),
+      SharedTlbDepth: int'(64),
+      NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
+      NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
+      DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth)
+  };
+
+endpackage

--- a/core/macro_decoder.sv
+++ b/core/macro_decoder.sv
@@ -10,8 +10,8 @@
 //
 // Author: Rohan Arshid, 10xEngineers
 // Date: 22.01.2024
-// Description: Contains the logic for decoding cm.push, cm.pop, cm.popret, 
-//              cm.popretz, cm.mvsa01, and cm.mva01s instructions of the 
+// Description: Contains the logic for decoding cm.push, cm.pop, cm.popret,
+//              cm.popretz, cm.mvsa01, and cm.mva01s instructions of the
 //              Zcmp Extension
 
 module macro_decoder #(
@@ -38,10 +38,8 @@ module macro_decoder #(
     INIT,
     PUSH_ADDI,
     POPRETZ_1,
-    MOVE,
-    PUSH_POP_INSTR_2
-  }
-      state_d, state_q;
+    MOVE
+  } state_d, state_q;
 
   // Instruction Types
   enum logic [2:0] {
@@ -60,8 +58,9 @@ module macro_decoder #(
   logic [1:0] popretz_inst_q, popretz_inst_d;
   logic [11:0] offset_reg, offset_q, offset_d;
   logic [31:0] instr_o_reg;
+  localparam [11:0] xlen_bytes = CVA6Cfg.XLEN / 8;
+  localparam [2:0] funct3 = CVA6Cfg.IS_XLEN32 ? 3'b10 : 3'b11;
 
-  riscv::itype_t itype_inst;
   assign instr_o = instr_o_reg;
   always_comb begin
     illegal_instr_o            = 1'b0;
@@ -157,124 +156,23 @@ module macro_decoder #(
 
       // push/pop/popret/popretz instructions
       unique case (instr_i[7:4])
-        4'b0100: reg_numbers = 4'b0001;  // 4
-        4'b0101: reg_numbers = 4'b0010;  // 5
-        4'b0110: reg_numbers = 4'b0011;  // 6
-        4'b0111: reg_numbers = 4'b0100;  // 7
-        4'b1000: reg_numbers = 4'b0101;  // 8
-        4'b1001: reg_numbers = 4'b0110;  // 9
-        4'b1010: reg_numbers = 4'b0111;  // 10
-        4'b1011: reg_numbers = 4'b1000;  // 11
-        4'b1100: reg_numbers = 4'b1001;  // 12
-        4'b1101: reg_numbers = 4'b1010;  // 13
-        4'b1110: reg_numbers = 4'b1011;  // 14
-        4'b1111: reg_numbers = 4'b1100;  // 15
+        4'b0100: reg_numbers = 4'd1;
+        4'b0101: reg_numbers = 4'd2;
+        4'b0110: reg_numbers = 4'd3;
+        4'b0111: reg_numbers = 4'd4;
+        4'b1000: reg_numbers = 4'd5;
+        4'b1001: reg_numbers = 4'd6;
+        4'b1010: reg_numbers = 4'd7;
+        4'b1011: reg_numbers = 4'd8;
+        4'b1100: reg_numbers = 4'd9;
+        4'b1101: reg_numbers = 4'd10;
+        4'b1110: reg_numbers = 4'd11;
+        4'b1111: reg_numbers = 4'd13;
         default: reg_numbers = '0;
       endcase
 
-      if (CVA6Cfg.IS_XLEN32) begin
-        unique case (instr_i[7:4])
-          4'b0100, 4'b0101, 4'b0110, 4'b0111: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 16;
-              2'b01: stack_adj = 32;
-              2'b10: stack_adj = 48;
-              2'b11: stack_adj = 64;
-            endcase
-          end
-          4'b1000, 4'b1001, 4'b1010, 4'b1011: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 32;
-              2'b01: stack_adj = 48;
-              2'b10: stack_adj = 64;
-              2'b11: stack_adj = 80;
-            endcase
-          end
-          4'b1100, 4'b1101, 4'b1110: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 48;
-              2'b01: stack_adj = 64;
-              2'b10: stack_adj = 80;
-              2'b11: stack_adj = 96;
-            endcase
-          end
-          4'b1111: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 64;
-              2'b01: stack_adj = 80;
-              2'b10: stack_adj = 96;
-              2'b11: stack_adj = 112;
-            endcase
-          end
-          default: ;
-        endcase
-      end else begin
-        unique case (instr_i[7:4])
-          4'b0100, 4'b0101: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 16;
-              2'b01: stack_adj = 32;
-              2'b10: stack_adj = 48;
-              2'b11: stack_adj = 64;
-            endcase
-          end
-          4'b0110, 4'b0111: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 32;
-              2'b01: stack_adj = 48;
-              2'b10: stack_adj = 64;
-              2'b11: stack_adj = 80;
-            endcase
-          end
-          4'b1000, 4'b1001: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 48;
-              2'b01: stack_adj = 64;
-              2'b10: stack_adj = 80;
-              2'b11: stack_adj = 96;
-            endcase
-          end
-          4'b1010, 4'b1011: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 64;
-              2'b01: stack_adj = 80;
-              2'b10: stack_adj = 96;
-              2'b11: stack_adj = 112;
-            endcase
-          end
-          4'b1100, 4'b1101: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 80;
-              2'b01: stack_adj = 96;
-              2'b10: stack_adj = 112;
-              2'b11: stack_adj = 128;
-            endcase
-          end
-          4'b1110: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 96;
-              2'b01: stack_adj = 112;
-              2'b10: stack_adj = 128;
-              2'b11: stack_adj = 144;
-            endcase
-          end
-          4'b1111: begin
-            unique case (instr_i[3:2])
-              2'b00: stack_adj = 112;
-              2'b01: stack_adj = 128;
-              2'b10: stack_adj = 144;
-              2'b11: stack_adj = 160;
-            endcase
-          end
-        endcase
-      end
-
-      //Take 2's compliment in case of PUSH instruction
-      if (macro_instr_type == PUSH) begin
-        itype_inst.imm = ~stack_adj + 1'b1;
-      end else begin
-        itype_inst.imm = stack_adj - 12'h4;
-      end
+      stack_adj = (((reg_numbers * xlen_bytes) + 12'd15) & ~12'd15)
+                  + {6'b0, instr_i[3:2], 4'b0000};
     end else begin
       illegal_instr_o = illegal_instr_i;
       instr_o_reg     = instr_i;
@@ -287,11 +185,13 @@ module macro_decoder #(
           state_d = issue_ack_i ? INIT : IDLE;
           case (macro_instr_type)
             PUSH: begin
-              offset_d = 12'hFFC + 12'hFFC;
+              // We push 1 register in IDLE, so we prepare the next
+              // offset in case we have to go into INIT
+              offset_d = -(2 * xlen_bytes);
             end
             POP, POPRETZ, POPRET: begin
-              offset_d   = itype_inst.imm + 12'hFFC;
-              offset_reg = itype_inst.imm;
+              offset_d   = stack_adj - (2 * xlen_bytes);
+              offset_reg = stack_adj - xlen_bytes;
               case (macro_instr_type)
                 POPRETZ: begin
                   popretz_inst_d = 2'b11;
@@ -300,233 +200,69 @@ module macro_decoder #(
                   popretz_inst_d = 2'b01;
                 end
                 default: begin
-                  popretz_inst_d = 'b0;
+                  popretz_inst_d = 2'b00;
                 end
               endcase
             end
             default: ;
           endcase
           // when rlist is 4, max reg is x18 i.e. 14(const) + 4
-          // when rlist is 12, max reg is x27 i.e. 15(const) + 12 
-          if (reg_numbers == 4'b1100) begin
-            store_reg_d = 4'b1110 + reg_numbers;
-            store_reg   = 4'b1111 + reg_numbers;
-          end else begin
-            store_reg_d = 4'b1101 + reg_numbers;
-            store_reg   = 4'b1110 + reg_numbers;
-          end
+          // when rlist is 12, max reg is x27 i.e. 15(const) + 12
+          store_reg_d = 4'd13 + reg_numbers;
+          store_reg   = 4'd14 + reg_numbers;
 
           if (macro_instr_type == MVSA01) begin
             fetch_stall_o = 1;
             is_double_rd_macro_instr_o = 1;
             // addi xreg1, a0, 0
             instr_o_reg = {12'h0, 5'hA, 3'h0, xreg1, riscv::OpcodeOpImm};
-            state_d = MOVE;
-          end
-
-          if (macro_instr_type == MVA01S) begin
+            state_d = issue_ack_i ? MOVE : IDLE;
+          end else if (macro_instr_type == MVA01S) begin
             fetch_stall_o = 1;
             is_double_rd_macro_instr_o = 1;
             // addi a0, xreg1, 0
             instr_o_reg = {12'h0, xreg1, 3'h0, 5'hA, riscv::OpcodeOpImm};
-            state_d = MOVE;
-          end
-
-          if (macro_instr_type == PUSH) begin
-
+            state_d = issue_ack_i ? MOVE : IDLE;
+          end else begin
             fetch_stall_o = 1'b1;  // stall inst fetch
-
-            if (reg_numbers == 4'b0001) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {
-                  7'b1111111, 5'h1, 5'h2, 3'h3, 5'b11000, riscv::OpcodeStore
-                };  // sd store_reg, -4(sp)
-              end else begin
-                instr_o_reg = {
-                  7'b1111111, 5'h1, 5'h2, 3'h2, 5'b11100, riscv::OpcodeStore
-                };  // sw store_reg, -4(sp)
-              end
-              state_d = PUSH_ADDI;
-            end
-
-            if (reg_numbers == 4'b0010) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {7'b1111111, 5'h8, 5'h2, 3'h3, 5'b11000, riscv::OpcodeStore};
-              end else begin
-                instr_o_reg = {7'b1111111, 5'h8, 5'h2, 3'h2, 5'b11100, riscv::OpcodeStore};
-              end
-            end
-
-            if (reg_numbers == 4'b0011) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {7'b1111111, 5'h9, 5'h2, 3'h3, 5'b11000, riscv::OpcodeStore};
-              end else begin
-                instr_o_reg = {7'b1111111, 5'h9, 5'h2, 3'h2, 5'b11100, riscv::OpcodeStore};
-              end
-
-            end
-
-            if (reg_numbers >= 4 && reg_numbers <= 12) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {7'b1111111, store_reg, 5'h2, 3'h3, 5'b11000, riscv::OpcodeStore};
-              end else begin
-                instr_o_reg = {7'b1111111, store_reg, 5'h2, 3'h2, 5'b11100, riscv::OpcodeStore};
-              end
-
-              if (reg_numbers == 12) begin
-                state_d = PUSH_POP_INSTR_2;
-              end
-            end
-          end
-
-          if ((macro_instr_type == POP || macro_instr_type == POPRETZ || macro_instr_type == POPRET)) begin
-            fetch_stall_o = 1;  // stall inst fetch
-            if (reg_numbers == 1) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {
-                  offset_reg - 12'h4, 5'h2, 3'h3, 5'h1, riscv::OpcodeLoad
-                };  // ld store_reg, Imm(sp)
-              end else begin
-                instr_o_reg = {
-                  offset_reg, 5'h2, 3'h2, 5'h1, riscv::OpcodeLoad
-                };  // lw store_reg, Imm(sp)
-              end
+            if (reg_numbers == 4'd1) begin
+              store_reg = 5'h1;
               unique case (macro_instr_type)
                 PUSH, POP, POPRET: begin
-                  state_d = PUSH_ADDI;
+                  state_d = issue_ack_i ? PUSH_ADDI : IDLE;
                 end
                 POPRETZ: begin
-                  state_d = POPRETZ_1;
+                  state_d = issue_ack_i ? POPRETZ_1 : IDLE;
                 end
                 default: ;
               endcase
+            end else if (reg_numbers == 4'd2) begin
+              store_reg = 5'h8;
+            end else if (reg_numbers == 4'd3) begin
+              store_reg = 5'h9;
             end
 
-            if (reg_numbers == 2) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {offset_reg - 12'h4, 5'h2, 3'h3, 5'h8, riscv::OpcodeLoad};
-              end else begin
-                instr_o_reg = {offset_reg, 5'h2, 3'h2, 5'h8, riscv::OpcodeLoad};
+            unique case (macro_instr_type)
+              PUSH: begin
+                logic [11:0] minus = -xlen_bytes;
+                instr_o_reg = {
+                  minus[11:5], store_reg, 5'h2, funct3, minus[4:0], riscv::OpcodeStore
+                };
               end
-            end
-
-            if (reg_numbers == 3) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {offset_reg - 12'h4, 5'h2, 3'h3, 5'h9, riscv::OpcodeLoad};
-              end else begin
-                instr_o_reg = {offset_reg, 5'h2, 3'h2, 5'h9, riscv::OpcodeLoad};
+              POP, POPRET, POPRETZ: begin
+                instr_o_reg = {offset_reg, 5'h2, funct3, store_reg, riscv::OpcodeLoad};
               end
-            end
-
-            if (reg_numbers >= 4 && reg_numbers <= 12) begin
-              if (CVA6Cfg.IS_XLEN64) begin
-                instr_o_reg = {offset_reg - 12'h4, 5'h2, 3'h3, store_reg, riscv::OpcodeLoad};
-              end else begin
-                instr_o_reg = {offset_reg, 5'h2, 3'h2, store_reg, riscv::OpcodeLoad};
-              end
-
-              if (reg_numbers == 12) begin
-                state_d = PUSH_POP_INSTR_2;
-              end
-            end
+              default: ;
+            endcase
           end
         end
       end
+
       INIT: begin
         fetch_stall_o = is_macro_instr_i;  // stall inst fetch
-        if (issue_ack_i && is_macro_instr_i && macro_instr_type == PUSH) begin
-          if (reg_numbers_q == 4'b0001) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:5],
-                5'h1,
-                5'h2,
-                3'h3,
-                offset_d[4:3],
-                1'b0,
-                offset_d[1:0],
-                riscv::OpcodeStore
-              };
-            end else begin
-              instr_o_reg = {offset_d[11:5], 5'h1, 5'h2, 3'h2, offset_d[4:0], riscv::OpcodeStore};
-            end
-            state_d = PUSH_ADDI;
-          end
-
-          if (reg_numbers_q == 4'b0010) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:5],
-                5'h8,
-                5'h2,
-                3'h3,
-                offset_d[4:3],
-                1'b0,
-                offset_d[1:0],
-                riscv::OpcodeStore
-              };
-            end else begin
-              instr_o_reg = {offset_d[11:5], 5'h8, 5'h2, 3'h2, offset_d[4:0], riscv::OpcodeStore};
-            end
-            reg_numbers_d = reg_numbers_q - 1;
-            offset_d = offset_q + 12'hFFC;  // decrement offset by -4 i.e. add 2's complement of 4
-          end
-
-          if (reg_numbers_q == 4'b0011) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:5],
-                5'h9,
-                5'h2,
-                3'h3,
-                offset_d[4:3],
-                1'b0,
-                offset_d[1:0],
-                riscv::OpcodeStore
-              };
-            end else begin
-              instr_o_reg = {offset_d[11:5], 5'h9, 5'h2, 3'h2, offset_d[4:0], riscv::OpcodeStore};
-            end
-            reg_numbers_d = reg_numbers_q - 1;
-            offset_d = offset_q + 12'hFFC;
-          end
-
-          if (reg_numbers_q >= 4 && reg_numbers_q <= 12) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:5],
-                store_reg_q,
-                5'h2,
-                3'h3,
-                offset_d[4:3],
-                1'b0,
-                offset_d[1:0],
-                riscv::OpcodeStore
-              };
-            end else begin
-              instr_o_reg = {
-                offset_d[11:5], store_reg_q, 5'h2, 3'h2, offset_d[4:0], riscv::OpcodeStore
-              };
-            end
-            reg_numbers_d = reg_numbers_q - 1;
-            store_reg_d = store_reg_q - 1;
-            offset_d = offset_q + 12'hFFC;
-            if (reg_numbers_q == 12) begin
-              state_d = PUSH_POP_INSTR_2;
-            end
-          end
-        end
-
-        if (issue_ack_i && is_macro_instr_i && (macro_instr_type == POP || macro_instr_type == POPRETZ || macro_instr_type == POPRET)) begin
-
-          if (reg_numbers_q == 1) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:3], 1'b0, offset_d[1:0], 5'h2, 3'h3, 5'h1, riscv::OpcodeLoad
-              };
-            end else begin
-              instr_o_reg = {offset_d[11:0], 5'h2, 3'h2, 5'h1, riscv::OpcodeLoad};
-            end
+        if (issue_ack_i) begin
+          store_reg = 5'h1;
+          if (reg_numbers_q == 4'd1) begin
             unique case (macro_instr_type)
               PUSH, POP, POPRET: begin
                 state_d = PUSH_ADDI;
@@ -536,47 +272,28 @@ module macro_decoder #(
               end
               default: ;
             endcase
-          end
-
-          if (reg_numbers_q == 2) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:3], 1'b0, offset_d[1:0], 5'h2, 3'h3, 5'h8, riscv::OpcodeLoad
-              };
-            end else begin
-              instr_o_reg = {offset_d[11:0], 5'h2, 3'h2, 5'h8, riscv::OpcodeLoad};
-            end
-            reg_numbers_d = reg_numbers_q - 1;
-            offset_d = offset_q + 12'hFFC;  // decrement offset by -4 i.e. add 2's compilment of 4
-          end
-
-          if (reg_numbers_q == 3) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:3], 1'b0, offset_d[1:0], 5'h2, 3'h3, 5'h9, riscv::OpcodeLoad
-              };
-            end else begin
-              instr_o_reg = {offset_d[11:0], 5'h2, 3'h2, 5'h9, riscv::OpcodeLoad};
-            end
-            reg_numbers_d = reg_numbers_q - 1;
-            offset_d = offset_q + 12'hFFC;
-          end
-
-          if (reg_numbers_q >= 4 && reg_numbers_q <= 12) begin
-            if (CVA6Cfg.IS_XLEN64) begin
-              instr_o_reg = {
-                offset_d[11:3], 1'b0, offset_d[1:0], 5'h2, 3'h3, store_reg_q, riscv::OpcodeLoad
-              };
-            end else begin
-              instr_o_reg = {offset_d[11:0], 5'h2, 3'h2, store_reg_q, riscv::OpcodeLoad};
-            end
-            reg_numbers_d = reg_numbers_q - 1;
+          end else if (reg_numbers_q == 4'd2) begin
+            store_reg = 5'h8;
+          end else if (reg_numbers_q == 4'd3) begin
+            store_reg = 5'h9;
+          end else if (reg_numbers_q >= 4'd4 && reg_numbers_q <= 4'd13) begin
+            store_reg = store_reg_q;
             store_reg_d = store_reg_q - 1;
-            offset_d = offset_q + 12'hFFC;
-            if (reg_numbers_q == 12) begin
-              state_d = PUSH_POP_INSTR_2;
-            end
           end
+
+          unique case (macro_instr_type)
+            PUSH: begin
+              instr_o_reg = {
+                offset_d[11:5], store_reg, 5'h2, funct3, offset_d[4:0], riscv::OpcodeStore
+              };
+            end
+            POP, POPRET, POPRETZ: begin
+              instr_o_reg = {offset_d, 5'h2, funct3, store_reg, riscv::OpcodeLoad};
+            end
+            default: ;
+          endcase
+          reg_numbers_d = reg_numbers_q - 1;
+          offset_d = offset_q - xlen_bytes;  // decrement offset
         end
       end
 
@@ -610,128 +327,39 @@ module macro_decoder #(
       end
 
       PUSH_ADDI: begin
-        if (CVA6Cfg.IS_XLEN64) begin
-          if (issue_ack_i && is_macro_instr_i && macro_instr_type == PUSH) begin
-            // addi sp, sp, stack_adj
-            instr_o_reg = {itype_inst.imm - 12'h4, 5'h2, 3'h0, 5'h2, riscv::OpcodeOpImm};
+        if (issue_ack_i) begin
+          if (macro_instr_type == PUSH) begin
+            instr_o_reg = {-stack_adj, 5'h2, 3'h0, 5'h2, riscv::OpcodeOpImm};
           end else begin
-            if (issue_ack_i) begin
-              instr_o_reg = {stack_adj - 12'h4, 5'h2, 3'h0, 5'h2, riscv::OpcodeOpImm};
-            end
+            instr_o_reg = {stack_adj, 5'h2, 3'h0, 5'h2, riscv::OpcodeOpImm};
           end
-          if (issue_ack_i && is_macro_instr_i && (macro_instr_type == POPRETZ || macro_instr_type == POPRET)) begin
-            state_d = POPRETZ_1;
-            fetch_stall_o = 1;
-          end else begin
-            if (issue_ack_i) begin
-              state_d = IDLE;
-              fetch_stall_o = 0;
-              is_last_macro_instr_o = 1;
-            end else begin
-              fetch_stall_o = 1;
-            end
-          end
-        end else begin
-          if (issue_ack_i && is_macro_instr_i && macro_instr_type == PUSH) begin
-            // addi sp, sp, stack_adj
-            instr_o_reg = {itype_inst.imm, 5'h2, 3'h0, 5'h2, riscv::OpcodeOpImm};
-          end else begin
-            if (issue_ack_i) begin
-              instr_o_reg = {stack_adj, 5'h2, 3'h0, 5'h2, riscv::OpcodeOpImm};
-            end
-          end
-          if (issue_ack_i && is_macro_instr_i && (macro_instr_type == POPRETZ || macro_instr_type == POPRET)) begin
-            state_d = POPRETZ_1;
-            fetch_stall_o = 1;
-          end else begin
-            if (issue_ack_i) begin
-              state_d = IDLE;
-              fetch_stall_o = 0;
-              is_last_macro_instr_o = 1;
-            end else begin
-              fetch_stall_o = 1;
-            end
-          end
-        end
-      end
 
-      PUSH_POP_INSTR_2: begin
-        if (CVA6Cfg.IS_XLEN64) begin
-          case (macro_instr_type)
-            PUSH: begin
-              if (issue_ack_i) begin
-                instr_o_reg = {
-                  offset_d[11:5],
-                  store_reg_q,
-                  5'h2,
-                  3'h3,
-                  offset_d[4:3],
-                  1'b0,
-                  offset_d[1:0],
-                  riscv::OpcodeStore
-                };
-                offset_d = offset_q + 12'hFFC;
-                store_reg_d = store_reg_q - 1;
-                state_d = INIT;
-              end
-            end
-            POP, POPRETZ, POPRET: begin
-              if (issue_ack_i) begin
-                instr_o_reg = {
-                  offset_d[11:3], 1'b0, offset_d[1:0], 5'h2, 3'h3, store_reg_q, riscv::OpcodeLoad
-                };
-                offset_d = offset_q + 12'hFFC;
-                store_reg_d = store_reg_q - 1;
-                state_d = INIT;
-              end
-            end
-            default: begin
-              illegal_instr_o = 1'b1;
-              instr_o_reg     = instr_i;
-            end
-          endcase
+          if (macro_instr_type == PUSH || macro_instr_type == POP) begin
+            state_d = IDLE;
+            fetch_stall_o = 0;
+            is_last_macro_instr_o = 1;
+          end else if (macro_instr_type == POPRETZ || macro_instr_type == POPRET) begin
+            state_d = POPRETZ_1;
+            fetch_stall_o = 1;
+          end
         end else begin
-          case (macro_instr_type)
-            PUSH: begin
-              if (issue_ack_i) begin
-                instr_o_reg = {
-                  offset_d[11:5], store_reg_q, 5'h2, 3'h2, offset_d[4:0], riscv::OpcodeStore
-                };
-                offset_d = offset_q + 12'hFFC;
-                store_reg_d = store_reg_q - 1;
-                state_d = INIT;
-              end
-            end
-            POP, POPRETZ, POPRET: begin
-              if (issue_ack_i) begin
-                instr_o_reg = {offset_d[11:0], 5'h2, 3'h2, store_reg_q, riscv::OpcodeLoad};
-                offset_d = offset_q + 12'hFFC;
-                store_reg_d = store_reg_q - 1;
-                state_d = INIT;
-              end
-            end
-            default: begin
-              illegal_instr_o = 1'b1;
-              instr_o_reg     = instr_i;
-            end
-          endcase
+          fetch_stall_o = 1;
         end
-        fetch_stall_o = 1;
       end
 
       POPRETZ_1: begin
         unique case (popretz_inst_q)
           2'b11: begin
             if (issue_ack_i) begin
-              instr_o_reg = {20'h0, 5'hA, riscv::OpcodeLui};  //lui a0, 0x0
-              popretz_inst_d = popretz_inst_q - 1;
+              instr_o_reg = {12'h0, 5'h0, 3'h0, 5'hA, riscv::OpcodeOpImm};  //addi a0, zero, 0x0
+              popretz_inst_d = 2'b01;
             end
             fetch_stall_o = 1;
           end
           2'b10: begin
             if (issue_ack_i) begin
               instr_o_reg = {12'h0, 5'hA, 3'h0, 5'hA, riscv::OpcodeOpImm};  //addi a0, a0, 0x0
-              popretz_inst_d = popretz_inst_q - 1;
+              popretz_inst_d = 2'b01;
               state_d = PUSH_ADDI;
             end
             fetch_stall_o = 1;
@@ -742,7 +370,7 @@ module macro_decoder #(
               state_d = IDLE;
               fetch_stall_o = 0;
               is_last_macro_instr_o = 1;
-              popretz_inst_d = popretz_inst_q - 1;
+              popretz_inst_d = 2'b00;
             end
           end
           default: begin

--- a/verif/tests/custom/Zcmp/cm_mva01s_test.S
+++ b/verif/tests/custom/Zcmp/cm_mva01s_test.S
@@ -1,32 +1,30 @@
 #include "riscv_test.h"
+#include "load_store.h"
 
-RVTEST_RV32U
 RVTEST_CODE_BEGIN
-    
+
     li s1, 5
     li s2, 7
     cm.mva01s s1, s2
-    
+
     bne a0, s1, failure
     beq a1, s2, success
+
 failure:
     li x1, 1
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop_2: j self_loop_2
-    
+    j 1f
 success:
     li x1, 0
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop: j self_loop
+1:
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, t5
+1:  j 1b
 
 RVTEST_CODE_END
 
 .data
-    
+
 RVTEST_DATA_BEGIN
 
 RVTEST_DATA_END

--- a/verif/tests/custom/Zcmp/cm_mvsa01_test.S
+++ b/verif/tests/custom/Zcmp/cm_mvsa01_test.S
@@ -1,32 +1,30 @@
 #include "riscv_test.h"
+#include "load_store.h"
 
-RVTEST_RV32U
 RVTEST_CODE_BEGIN
-    
+
     li a0, 5
     li a1, 7
     cm.mvsa01 s1, s2
-    
+
     bne a0, s1, failure
     beq a1, s2, success
+
 failure:
     li x1, 1
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop_2: j self_loop_2
-    
+    j 1f
 success:
     li x1, 0
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop: j self_loop
+1:
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, t5
+1:  j 1b
 
 RVTEST_CODE_END
 
 .data
-    
+
 RVTEST_DATA_BEGIN
 
 RVTEST_DATA_END

--- a/verif/tests/custom/Zcmp/cm_popret_test.S
+++ b/verif/tests/custom/Zcmp/cm_popret_test.S
@@ -1,58 +1,54 @@
 #include "riscv_test.h"
+#include "load_store.h"
 
-RVTEST_RV32U
 RVTEST_CODE_BEGIN
     //Initialize the stack
     la sp, stack
 
     // Load the first number into register a0
-    lw s0, num1
-    
-    // Load the second number into register a1
-    lw s1, num2
-    
-    //Load the result into register a2
-    lw a2, result
+    lx s0, num1
 
-    //Two consecutive move instructions replaced by the compressed move instruction
-    //mv s0, a0
-    //mv s1, a1
+    // Load the second number into register a1
+    lx s1, num2
+
+    //Load the result into register a2
+    lx a2, result
 
     //Push the registers to stack
     jal push_pop
 
     // Add the numbers and store the result in register t2
     add t2, s0, s1
-    
+
     // Store the result in the memory location reserved for it
     beq t2, a2, success
+
 failure:
     li x1, 1
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop_2: j self_loop_2
-    
+    j 1f
 success:
     li x1, 0
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop: j self_loop
+1:
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, t5
+1:  j 1b
 
 push_pop:
-    cm.push {ra, s0-s1}, -16
+    cm.push {ra, s0-s1}, - (3 + 1) * xlen_bytes
     nop
-    cm.popret {ra, s0-s1}, 16
+    cm.popret {ra, s0-s1}, (3 + 1) * xlen_bytes
 
 RVTEST_CODE_END
 
 .data
-    num1:   .word 5      // First number
-    num2:   .word 7      // Second number
-    result: .word 12      // Result
-    stack:  .space 100
-    
+    .align 16
+    num1:   xdata 5     // First number
+    num2:   xdata 7     // Second number
+    result: xdata 12    // Result
+    .align 16
+    stack:  .space 16 * xlen_bytes
+
 RVTEST_DATA_BEGIN
 
 RVTEST_DATA_END

--- a/verif/tests/custom/Zcmp/cm_popretz_test.S
+++ b/verif/tests/custom/Zcmp/cm_popretz_test.S
@@ -1,57 +1,53 @@
 #include "riscv_test.h"
+#include "load_store.h"
 
-RVTEST_RV32U
 RVTEST_CODE_BEGIN
     //Initialize the stack
     la sp, stack
 
     // Load the first number into register a0
-    lw s0, num1
-    
-    // Load the second number into register a1
-    lw s1, num2
-    
-    //Load the result into register a2
-    lw a2, result
+    lx s0, num1
 
-    //Two consecutive move instructions replaced by the compressed move instruction
-    //mv s0, a0
-    //mv s1, a1
+    // Load the second number into register a1
+    lx s1, num2
+
+    //Load the result into register a2
+    lx a2, result
 
     //Push the registers to stack
     jal push_pop
 
     // Add the numbers and store the result in register t2
     add t2, s0, s1
-    
+
     // Store the result in the memory location reserved for it
     beq t2, a2, success
+
 failure:
-    	li x1, 1
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop_2: j self_loop_2
-    
+    li x1, 1
+    j 1f
 success:
-    	li x1, 0
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop: j self_loop
+    li x1, 0
+1:
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, t5
+1:  j 1b
 
 push_pop:
-	cm.push {ra, s0-s1}, -16
-	nop
-	cm.popretz {ra, s0-s1}, 16
+    cm.push {ra, s0-s1}, - (3 + 1) * xlen_bytes
+    nop
+    cm.popretz {ra, s0-s1}, (3 + 1) * xlen_bytes
 RVTEST_CODE_END
 
 .data
-    num1:   .word 5      // First number
-    num2:   .word 7      // Second number
-    result: .word 12      // Result
-    stack:  .space 100
-    
+    .align 16
+    num1:   xdata 5     // First number
+    num2:   xdata 7     // Second number
+    result: xdata 12    // Result
+    .align 16
+    stack:  .space 16 * xlen_bytes
+
 RVTEST_DATA_BEGIN
 
 RVTEST_DATA_END

--- a/verif/tests/custom/Zcmp/cm_push_pop_test.S
+++ b/verif/tests/custom/Zcmp/cm_push_pop_test.S
@@ -1,59 +1,164 @@
 #include "riscv_test.h"
+#include "load_store.h"
 
-RVTEST_RV32U
 RVTEST_CODE_BEGIN
     //Initialize the stack
     la sp, stack
 
-    // Load the first number into register a0
-    lw s0, num1
-    
-    // Load the second number into register a1
-    lw s1, num2
-    
-    //Load the result into register a2
-    lw a2, result
+    jal push_pop_1
+    // If ra is not poped correctly we're anyway going wild
 
-    //Two consecutive move instructions replaced by the compressed move instruction
-    //mv s0, a0
-    //mv s1, a1
+    // Load the first number into register s0
+    lx s0, num1
+
+    // Load the second number into register s1
+    lx s1, num2
+
+    // Load the third number into register s2
+    lx s2, num3
 
     //Push the registers to stack
-    jal push_pop
+    jal push_pop_3
+
+    //Load the result into register a2
+    lx a2, result_3
 
     // Add the numbers and store the result in register t2
     add t2, s0, s1
-    
-    // Store the result in the memory location reserved for it
-    beq t2, a2, success
+    add t2, t2, s2
+
+    // Check that we retrieved the correct values
+    bne t2, a2, failure
+
+    // Load the values to check with
+    lx s3, num4
+    lx s4, num5
+    lx s5, num6
+    lx s6, num7
+    lx s7, num8
+    lx s8, num9
+    lx s9, num10
+    //Push the registers to stack
+    jal push_pop_10
+    //Load the result into register a2
+    lx a2, result_10
+    // Add the numbers and store the result in register t2
+    add t2, s0, s1
+    add t2, t2, s2
+    add t2, t2, s3
+    add t2, t2, s4
+    add t2, t2, s5
+    add t2, t2, s6
+    add t2, t2, s7
+    add t2, t2, s8
+    add t2, t2, s9
+    // Check that we retrieved the correct values
+    bne t2, a2, failure
+
+    lx s10, num11
+    lx s11, num12
+    //Push the registers to stack
+    jal push_pop_all
+    //Load the result into register a2
+    lx a2, result_all
+    // Add the numbers and store the result in register t2
+    add t2, s0, s1
+    add t2, t2, s2
+    add t2, t2, s3
+    add t2, t2, s4
+    add t2, t2, s5
+    add t2, t2, s6
+    add t2, t2, s7
+    add t2, t2, s8
+    add t2, t2, s9
+    add t2, t2, s10
+    add t2, t2, s11
+    // Check that we retrieved the correct values
+    bne t2, a2, failure
+    jal push_pop_check_frame
+    j success
+
 failure:
     li x1, 1
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop_2: j self_loop_2
-    
+    j 1f
 success:
     li x1, 0
-	slli x1, x1, 1
-	addi x1, x1, 1
-	sw x1, tohost, t5
-	self_loop: j self_loop
+1:
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, t5
+1:  j 1b
 
-push_pop:
-    cm.push {ra, s0-s1}, -16
-    nop
-    cm.pop {ra, s0-s1}, 16
+push_pop_1:
+    cm.push {ra}, -align_16up(1 * xlen_bytes)
+    c.nop
+    cm.pop {ra}, align_16up(1 * xlen_bytes)
     jr ra
+
+    // For a reason I can't explain, this seems necessary, although unrelated
+    // to zcmp
+    .align 2
+push_pop_3:
+    cm.push {ra, s0-s2}, -align_16up((1 + 3) * xlen_bytes)
+    c.nop
+    cm.pop {ra, s0-s2}, align_16up((1 + 3) * xlen_bytes)
+    jr ra
+
+push_pop_10:
+    cm.push {ra, s0-s9}, -align_16up((1 + 10) * xlen_bytes)
+    c.nop
+    cm.pop {ra, s0-s9}, align_16up((1 + 10) * xlen_bytes)
+    jr ra
+
+push_pop_all:
+    cm.push {ra, s0-s11}, -align_16up((1 + 15) * xlen_bytes)
+    c.nop
+    cm.pop {ra, s0-s11}, align_16up((1 + 15) * xlen_bytes)
+    jr ra
+
+push_pop_check_frame:
+    mv a0, sp
+    cm.push  {ra, s0-s5}, -align_16up((7 + 1) * xlen_bytes)
+    lx  t1, -7 * xlen_bytes(a0)
+    bne t1, ra, failure
+    lx  t1, -6 * xlen_bytes(a0)
+    bne t1, s0, failure
+    lx  t1, -5 * xlen_bytes(a0)
+    bne t1, s1, failure
+    lx  t1, -4 * xlen_bytes(a0)
+    bne t1, s2, failure
+    lx  t1, -3 * xlen_bytes(a0)
+    bne t1, s3, failure
+    lx  t1, -2 * xlen_bytes(a0)
+    bne t1, s4, failure
+    lx  t1, -1 * xlen_bytes(a0)
+    bne t1, s5, failure
+    // Last slot(s) are 16-byte padding
+    cm.pop  {ra, s0-s5}, align_16up((7 + 1) * xlen_bytes)
+    jr  ra
 
 RVTEST_CODE_END
 
 .data
-    num1:   .word 5      // First number
-    num2:   .word 7      // Second number
-    result: .word 12      // Result
-    stack:  .space 100
-    
+    .align 16
+    num1:       xdata 1   // First number
+    num2:       xdata 2   // Second number
+    num3:       xdata 3
+    result_3:   xdata 6   // Result
+    num4:       xdata 4
+    num5:       xdata 5
+    num6:       xdata 6
+    num7:       xdata 7
+    num8:       xdata 8
+    num9:       xdata 9
+    num10:      xdata 10
+    result_10:  xdata 55
+    num11:      xdata 11
+    num12:      xdata 12
+    result_all: xdata 78
+    .align 16
+    stack:  .space 32 * xlen_bytes
+
 RVTEST_DATA_BEGIN
 
 RVTEST_DATA_END

--- a/verif/tests/custom/Zcmp/compile.sh
+++ b/verif/tests/custom/Zcmp/compile.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv32imf_zcmp_zicsr -mabi=ilp32 -o cm_push_pop_test_rv32.elf cm_push_pop_test.S -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv32imf_zcmp_zicsr -mabi=ilp32 -o cm_popret_test_rv32.elf   cm_popret_test.S   -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv32imf_zcmp_zicsr -mabi=ilp32 -o cm_popretz_test_rv32.elf  cm_popretz_test.S  -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv32imf_zcmp_zicsr -mabi=ilp32 -o cm_mva01s_test_rv32.elf   cm_mva01s_test.S   -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv32imf_zcmp_zicsr -mabi=ilp32 -o cm_mvsa01_test_rv32.elf   cm_mvsa01_test.S   -I ../env
+
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv64imd_zcmp_zicsr -mabi=lp64d -o cm_push_pop_test_rv64.elf cm_push_pop_test.S -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv64imd_zcmp_zicsr -mabi=lp64d -o cm_popret_test_rv64.elf   cm_popret_test.S   -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv64imd_zcmp_zicsr -mabi=lp64d -o cm_popretz_test_rv64.elf  cm_popretz_test.S  -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv64imd_zcmp_zicsr -mabi=lp64d -o cm_mva01s_test_rv64.elf   cm_mva01s_test.S   -I ../env
+riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -g syscalls.c -lgcc -Tlink.ld -march=rv64imd_zcmp_zicsr -mabi=lp64d -o cm_mvsa01_test_rv64.elf   cm_mvsa01_test.S   -I ../env
+
+

--- a/verif/tests/custom/Zcmp/load_store.h
+++ b/verif/tests/custom/Zcmp/load_store.h
@@ -1,0 +1,15 @@
+#if __riscv_xlen == 32
+# define lx lw
+# define sx sw
+# define xdata .word
+RVTEST_RV32U
+#elif __riscv_xlen == 64
+# define lx ld
+# define sx sd
+# define xdata .dword
+RVTEST_RV64U
+#else
+# error "Unsupported __riscv_xlen size"
+#endif
+#define xlen_bytes    (__riscv_xlen / 8)
+#define align_16up(x) (((x) + 15) & ~15)

--- a/verif/tests/custom/Zcmp/util.h
+++ b/verif/tests/custom/Zcmp/util.h
@@ -7,8 +7,6 @@ extern void setStats(int enable);
 
 #include <stdint.h>
 
-#define static_assert(cond) switch(0) { case 0: case !!(long)(cond): ; }
-
 static int verify(int n, const volatile int* test, const int* verify)
 {
   int i;


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [ x] I have searched for similar pull requests
  There is one PR (Gate Zcmp IDLE transitions on issue) that is fixing #3543  but I believe it solves neither the 64-bit issue nor simplifies logic, as this PR does. 
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

<!-- Please indicate why this PR is needed for the project -->
This PR simplifies the support of the zcmp insns by factoring the code and removing a lot of logic that was introduced by duplication. It also works for 64-bit processors, by using the XLEN and not 4 to compute offsets, so clearly the current state doesn't work with 64-bit machines. This PR also provides more  thorough tests (using xlen parameterization) to check that the insns behave as expected, for both 32 and 64 bit processors.

<!-- Is this PR related to existing issues? If so, link to them below -->
A side effect of this PR is that it fixes issue #3543

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

