### PR TITLE
Preserve RAS push/pop for an upper-slot call/return behind a not-taken branch

### DIFF
--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -23,7 +23,7 @@ valid_cycles = {
     "dhrystone_single": 23866,
     "coremark_dual": 199928,
     "coremark_single": 290690,
-    "dhrystone_cv32a65x": 27329,
+    "dhrystone_cv32a65x": 27328,
     "dhrystone_cv32a60x": 36629,
 }
 

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -279,7 +279,7 @@ module frontend
             cf_type[i] = ariane_pkg::Branch;
             // clear the RAS ops only for a taken branch. a not-taken branch falls
             // through, so it must keep the upper slot's ras_push/ras_pop
-            ras_pop  = 1'b0;
+            ras_pop = 1'b0;
             ras_push = 1'b0;
           end
         end

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -265,8 +265,6 @@ module frontend
         end
         // branch prediction
         4'b1000: begin
-          ras_pop  = 1'b0;
-          ras_push = 1'b0;
           // if we have a valid dynamic prediction use it
           if (bht_prediction_shifted[i].valid) begin
             taken_rvi_cf[i] = rvi_branch[i] & bht_prediction_shifted[i].taken;
@@ -279,6 +277,10 @@ module frontend
           end
           if (taken_rvi_cf[i] || taken_rvc_cf[i]) begin
             cf_type[i] = ariane_pkg::Branch;
+            // clear the RAS ops only for a taken branch. a not-taken branch falls
+            // through, so it must keep the upper slot's ras_push/ras_pop
+            ras_pop  = 1'b0;
+            ras_push = 1'b0;
           end
         end
         default: ;


### PR DESCRIPTION
### Description

In `frontend`, the prediction `always_comb` computes `ras_push`/`ras_pop`/`ras_update` as single scalars in a loop that runs the fetch slots from the highest index down to slot 0, so the lowest slot's write wins. The branch arm (`4'b1000`) cleared `ras_push`/`ras_pop` unconditionally.

When the lower fetch slot is a not-taken conditional branch, it falls through, so the upper slot behind it is on-path and consumed. Because slot 0 is processed last, its not-taken branch arm overwrote the `ras_push`/`ras_pop` that the upper slot's call or return had set:

*   an upper-slot call never pushes its return address, so the eventual `ret` mispredicts.
*   an upper-slot return never pops, so the stale entry corrupts the next return.

`predict_address` is unaffected, so the redirect this cycle is correct. Only the RAS state update is lost.

### Fix

Move the two clears into the taken branch of the arm, so only a taken branch (which redirects and squashes the upper slot) clears the RAS ops. A not-taken branch keeps the upper slot's `ras_push`/`ras_pop`. The jump, jalr and return arms keep their unconditional clears, since those instructions always transfer control and their successor is off-path.

```verilog
if (taken_rvi_cf[i] || taken_rvc_cf[i]) begin
  cf_type[i] = ariane_pkg::Branch;
  ras_pop  = 1'b0;
  ras_push = 1'b0;
end
```

### Related Issue

#3545 

### Verification

Checked with JasperGold formal on config cv32a6_imac_sv32. With the fix both are proven unreachable, no counterexamples.

<img width="906" height="482" alt="image" src="https://github.com/user-attachments/assets/ead64012-8110-4b4a-a15c-165b2a5872d2" />

<img width="898" height="463" alt="image" src="https://github.com/user-attachments/assets/0dcf54b7-bc09-4e91-9ab8-534cbdfccb40" />


Prediction-quality only, no functional change: it changes when the RAS is written, not the fetched instruction stream.
