### PR TITLE
Fix duplicate cache store grant

### DIFF
--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -423,7 +423,8 @@ module cache_ctrl
             if (gnt_i) begin
               state_d = WAIT_TAG;
               mem_req_d.bypass = 1'b0;
-              req_port_o.data_gnt = 1'b1;
+              // only for a read
+              if (!req_port_i.data_we) req_port_o.data_gnt = 1'b1;
             end
           end else begin
             state_d = IDLE;


### PR DESCRIPTION
* [x] I have searched for similar pull requests
* [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

* `cache_ctrl` can generate two grants for the same write request.
* The problematic path occurs in the `WAIT_CRITICAL_WORD` state.
* A store can incorrectly receive an early `data_gnt`.
* The same store can later receive its normal grant through the miss/refill path.
* This can desynchronize the requester and cache and potentially cause a deadlock.

## What changed

* `WAIT_CRITICAL_WORD` now behaves consistently with the normal `IDLE` request-acceptance path.
* Early `data_gnt` is generated only when `!req_port_i.data_we`.
* Stores therefore wait for their normal final acceptance/grant.
* No changes were made to the legitimate later grant paths.

## Related issue

Fixes #3502

## Validation

* `verible-verilog-format`: passed
* `git diff --check` / `git show --check`: passed
* `make verilate target=cv64a6_imafdc_sv39`: passed
* `make verilate target=cv64a6_imafdc_sv39_wb`: passed
* WB configuration successfully elaborated `cache_ctrl.sv`

## Limitations

* The dedicated `tb_wb_dcache` testbench was not run locally.
* Questa/ModelSim tools `vlib`, `vlog`, and `vsim` are not installed in the local environment.
