### PR TITLE
Add valid bit to branch prediction structure

### DIFF
--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -100,7 +100,7 @@ module branch_unit #(
       end
       if (fu_data_i.operation == ariane_pkg::JALR
           // check if the address of the jump register is correct and that we actually predicted
-          && (branch_predict_i.cf == ariane_pkg::NoCF || target_address != branch_predict_i.predict_address)) begin
+          && (!branch_predict_i.valid || target_address != branch_predict_i.predict_address)) begin
         resolved_branch_o.is_mispredict = 1'b1;
         // update BTB only if this wasn't a return
         if (branch_predict_i.cf != ariane_pkg::Return)

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -35,6 +35,7 @@ module cva6
     // this is the struct which we will inject into the pipeline to guide the various
     // units towards the correct branch decision and resolve
     localparam type branchpredict_sbe_t = struct packed {
+      logic                    valid;            // valid control flow prediction
       cf_t                     cf;               // type of control flow prediction
       logic [CVA6Cfg.VLEN-1:0] predict_address;  // target address at which to jump, or not
     },

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -152,6 +152,7 @@ module frontend
   // Instruction FIFO
   logic [           CVA6Cfg.VLEN-1:0] predict_address;
   cf_t  [CVA6Cfg.INSTR_PER_FETCH-1:0] cf_type;
+  logic [CVA6Cfg.INSTR_PER_FETCH-1:0] cf_valid;
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] taken_rvi_cf;
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] taken_rvc_cf;
 
@@ -200,7 +201,6 @@ module frontend
   // for the return address stack it doesn't matter as we have the
   // address of the call/return already
   logic bp_valid;
-
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] is_branch;
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] is_call;
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] is_jump;
@@ -227,6 +227,7 @@ module frontend
     predict_address = '0;
 
     for (int i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++) cf_type[i] = ariane_pkg::NoCF;
+    for (int i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++) cf_valid[i] = 1'b0;
 
     ras_push = 1'b0;
     ras_pop = 1'b0;
@@ -240,11 +241,12 @@ module frontend
         4'b0000: ;  // regular instruction e.g.: no branch
         // unconditional jump to register, we need the BTB to resolve this
         4'b0001: begin
-          ras_pop  = 1'b0;
+          ras_pop = 1'b0;
           ras_push = 1'b0;
+          cf_type[i] = ariane_pkg::JumpR;
           if (CVA6Cfg.BTBEntries != 0 && btb_prediction_shifted[i].valid) begin
             predict_address = btb_prediction_shifted[i].target_address;
-            cf_type[i] = ariane_pkg::JumpR;
+            cf_valid[i] = 1'b1;
           end
         end
         // its an unconditional jump to an immediate
@@ -254,6 +256,7 @@ module frontend
           taken_rvi_cf[i] = rvi_jump[i];
           taken_rvc_cf[i] = rvc_jump[i];
           cf_type[i] = ariane_pkg::Jump;
+          cf_valid[i] = rvi_jump[i] || rvc_jump[i];
         end
         // return
         4'b0100: begin
@@ -262,6 +265,7 @@ module frontend
           ras_push = 1'b0;
           predict_address = ras_predict.ra;
           cf_type[i] = ariane_pkg::Return;
+          cf_valid[i] = ras_predict.valid;
         end
         // branch prediction
         4'b1000: begin
@@ -278,7 +282,8 @@ module frontend
             taken_rvc_cf[i] = rvc_branch[i] & rvc_imm[i][CVA6Cfg.VLEN-1];
           end
           if (taken_rvi_cf[i] || taken_rvc_cf[i]) begin
-            cf_type[i] = ariane_pkg::Branch;
+            cf_type[i]  = ariane_pkg::Branch;
+            cf_valid[i] = 1'b1;
           end
         end
         default: ;
@@ -296,15 +301,8 @@ module frontend
       end
     end
   end
-  // or reduce struct
-  always_comb begin
-    bp_valid = 1'b0;
-    // BP cannot be valid if we have a return instruction and the RAS is not giving a valid address
-    // Check that we encountered a control flow and that for a return the RAS
-    // contains a valid prediction.
-    for (int i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++)
-    bp_valid |= ((cf_type[i] != NoCF & cf_type[i] != Return) | ((cf_type[i] == Return) & ras_predict.valid));
-  end
+  // Or reduce struct
+  assign bp_valid = |cf_valid;
   assign is_mispredict = resolved_branch_i.valid & resolved_branch_i.is_mispredict;
 
   // Cache interface
@@ -580,6 +578,7 @@ module frontend
       .exception_gva_i    (icache_gva_q),
       .predict_address_i  (predict_address),
       .cf_type_i          (cf_type),
+      .cf_valid_i         (cf_valid),
       .valid_i            (instruction_valid),     // from re-aligner
       .consumed_o         (instr_queue_consumed),
       .ready_o            (instr_queue_ready),

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -74,8 +74,10 @@ module instr_queue
     input logic exception_gva_i,
     // Branch predict - FRONTEND
     input logic [CVA6Cfg.VLEN-1:0] predict_address_i,
-    // Instruction predict address - FRONTEND
+    // Instruction control-flow prediction type - FRONTEND
     input ariane_pkg::cf_t [CVA6Cfg.INSTR_PER_FETCH-1:0] cf_type_i,
+    // Instruction control-flow prediction valid - FRONTEND
+    input logic [CVA6Cfg.INSTR_PER_FETCH-1:0] cf_valid_i,
     // Replay instruction because one of the FIFO was full - FRONTEND
     output logic replay_o,
     // Address at which to replay the fetch - FRONTEND
@@ -93,7 +95,8 @@ module instr_queue
 
   typedef struct packed {
     logic [31:0]                     instr;      // instruction word
-    ariane_pkg::cf_t                 cf;         // branch was taken
+    ariane_pkg::cf_t                 cf;         // branch prediction type
+    logic                            cf_valid;   // valid branch prediction
     ariane_pkg::frontend_exception_t ex;         // exception happened
     logic [CVA6Cfg.VLEN-1:0]         ex_vaddr;   // lower VLEN bits of tval for exception
     logic [CVA6Cfg.GPLEN-1:0]        ex_gpaddr;  // lower GPLEN bits of tval2 for exception
@@ -143,6 +146,7 @@ module instr_queue
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] fifo_pos;
   logic [CVA6Cfg.INSTR_PER_FETCH*2-1:0][31:0] instr;
   ariane_pkg::cf_t [CVA6Cfg.INSTR_PER_FETCH*2-1:0] cf;
+  logic [CVA6Cfg.INSTR_PER_FETCH*2-1:0] cf_valid;
   // replay interface
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] instr_overflow_fifo;
 
@@ -151,7 +155,7 @@ module instr_queue
   if (CVA6Cfg.RVC) begin : gen_multiple_instr_per_fetch_with_C
 
     for (genvar i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++) begin : gen_unpack_taken
-      assign taken[i] = cf_type_i[i] != ariane_pkg::NoCF;
+      assign taken[i] = cf_valid_i[i];
     end
 
     // calculate a branch mask, e.g.: get the first taken branch
@@ -208,6 +212,8 @@ module instr_queue
       assign instr[i+CVA6Cfg.INSTR_PER_FETCH] = instr_i[i];
       assign cf[i] = cf_type_i[i];
       assign cf[i+CVA6Cfg.INSTR_PER_FETCH] = cf_type_i[i];
+      assign cf_valid[i] = cf_valid_i[i];
+      assign cf_valid[i+CVA6Cfg.INSTR_PER_FETCH] = cf_valid_i[i];
     end
 
     // shift the inputs
@@ -215,6 +221,7 @@ module instr_queue
       /* verilator lint_off WIDTH */
       assign instr_data_in[i].instr = instr[CVA6Cfg.INSTR_PER_FETCH+i-idx_is_q];
       assign instr_data_in[i].cf = cf[CVA6Cfg.INSTR_PER_FETCH+i-idx_is_q];
+      assign instr_data_in[i].cf_valid = cf_valid[CVA6Cfg.INSTR_PER_FETCH+i-idx_is_q];
       assign instr_data_in[i].ex = exception_i;  // exceptions hold for the whole fetch packet
       assign instr_data_in[i].ex_vaddr = exception_addr_i;
       if (CVA6Cfg.RVH) begin : gen_hyp_ex_with_C
@@ -333,6 +340,7 @@ module instr_queue
         fetch_entry_o[i].ex.timing = '0;
         fetch_entry_o[i].branch_predict.predict_address = address_out;
         fetch_entry_o[i].branch_predict.cf = ariane_pkg::NoCF;
+        fetch_entry_o[i].branch_predict.valid = 1'b0;
       end
 
       // output mux select
@@ -358,6 +366,7 @@ module instr_queue
             fetch_entry_o[0].ex.gva   = instr_data_out[i].ex_gva;
           end
           fetch_entry_o[0].branch_predict.cf = instr_data_out[i].cf;
+          fetch_entry_o[0].branch_predict.valid = instr_data_out[i].cf_valid;
           pop_instr[i] = fetch_entry_fire[0];
         end
 
@@ -372,6 +381,7 @@ module instr_queue
             fetch_entry_o[NID].ex.valid = instr_data_out[i].ex != ariane_pkg::FE_NONE;
             fetch_entry_o[NID].ex.tval = {{64 - CVA6Cfg.VLEN{1'b0}}, instr_data_out[i].ex_vaddr};
             fetch_entry_o[NID].branch_predict.cf = instr_data_out[i].cf;
+            fetch_entry_o[NID].branch_predict.valid = instr_data_out[i].cf_valid;
             // Cannot output two CF the same cycle.
             pop_instr[i] = fetch_entry_fire[NID];
           end
@@ -414,13 +424,14 @@ module instr_queue
 
       fetch_entry_o[0].branch_predict.predict_address = address_out;
       fetch_entry_o[0].branch_predict.cf = instr_data_out[0].cf;
+      fetch_entry_o[0].branch_predict.valid = instr_data_out[0].cf_valid;
 
       pop_instr[0] = fetch_entry_valid_o[0] & fetch_entry_ready_i[0];
     end
   end
 
   for (genvar i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
-    assign fetch_entry_is_cf[i] = fetch_entry_o[i].branch_predict.cf != ariane_pkg::NoCF;
+    assign fetch_entry_is_cf[i] = fetch_entry_o[i].branch_predict.valid;
     assign fetch_entry_fire[i]  = fetch_entry_valid_o[i] & fetch_entry_ready_i[i];
   end
 
@@ -486,7 +497,7 @@ module instr_queue
     push_address = 1'b0;
     // check if we are pushing a ctrl flow change, if so save the address
     for (int i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++) begin
-      push_address |= push_instr[i] & (instr_data_in[i].cf != ariane_pkg::NoCF);
+      push_address |= push_instr[i] & instr_data_in[i].cf_valid;
     end
   end
 


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

I’ve added a `valid` bit to the prediction structure that is used throughout the pipeline.

This offers the following benefits:

-  Decoupling the control-flow instruction type from the validity of the prediction (code simplification)
-  Simplified handling of prediction validity (area savings; on an FPGA and in 32-bit mode, this represents 200 LUTs, or a 1% gain on the CV32A6)
-  Fixes #3023

Note that I have not verified the third point, but with this change, the bug should no longer occur.

I tested this change a few weeks ago, previous commit was [6cb2001](https://github.com/openhwgroup/cva6/tree/6cb200105fb9441d170e45786125a737fab98e91). Using the cv32a65x configuration, this modification improves the CoreMark score from 4.22 to 4.23 (only 14 cycles in reality) in simulation.