### PR TITLE
Raise illegal instruction exception for `HFENCE.VVMA`/`HFENCE.GVMA` when in `V=1` mode and `rd!=0`

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -317,6 +317,7 @@ module decoder
                       // check privilege level, HFENCE.VVMA can only be executed in M/S mode
                       // otherwise decode an illegal instruction or virtual illegal instruction
                       if (v_i) begin
+                        illegal_instr = (instr.itype.rd == '0) ? illegal_instr : 1'b1;
                         virtual_illegal_instr = 1'b1;
                       end else begin
                         illegal_instr    = ((priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) && instr.itype.rd == '0) ? 1'b0 : 1'b1;
@@ -326,6 +327,7 @@ module decoder
                       // check privilege level, HFENCE.GVMA can only be executed in M/S mode
                       // otherwise decode an illegal instruction or virtual illegal instruction
                       if (v_i) begin
+                        illegal_instr = (instr.itype.rd == '0) ? illegal_instr : 1'b1;
                         virtual_illegal_instr = 1'b1;
                       end else begin
                         illegal_instr    = ((priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) && instr.itype.rd == '0) ? 1'b0 : 1'b1;

--- a/verif/tests/custom/issues/hfence-rd-non-zero-rv64.S
+++ b/verif/tests/custom/issues/hfence-rd-non-zero-rv64.S
@@ -1,0 +1,52 @@
+  .section  .text
+  .align    2
+  .option   norvc
+  .globl    main
+
+main:
+  la    t0, trap_handler
+  csrw  mtvec, t0
+  csrw  medeleg, zero
+
+  li    t0, -1
+  csrw  pmpaddr0, t0
+  li    t0, 0x1f
+  csrw  pmpcfg0, t0
+
+  li    t0, 0x1800
+  csrc  mstatus, t0
+  li    t0, 0x800
+  csrs  mstatus, t0
+  li    t0, 1
+  slli  t0, t0, 39
+  csrs  mstatus, t0
+
+  li    s1, 0
+  la    t0, test
+  csrw  mepc, t0
+  mret
+
+test:
+  .word 0x220000f3  # hfence.vvma (rd = 1)
+  .word 0x620000f3  # hfence.gvma (rd = 1)
+
+  hfence.vvma       # well formed hfence
+  hfence.gvma
+
+  xori  a0, s1, 4
+  snez  a0, a0
+  j     finish
+
+  .align 2
+trap_handler:
+  csrr  t0, mcause
+
+  addi  s1, s1, 1
+  csrr  t0, mepc
+  addi  t0, t0, 4
+  csrw  mepc, t0
+  mret
+
+finish:
+  jal exit
+

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -82,6 +82,13 @@ testlist:
     iterations: 1
     asm_tests: <path_var>/custom/issues/decoder-zip-unzip-rv64.S
 
+  - test: hfence-rd-non-zero-rv64
+    <<: *common_test_config
+    description: >
+      Check that HFENCE.VVMA/HFENCE.GVMA trap as illigal instructions (mcause 2), instead of virtual instruction (mcause 22).
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/hfence-rd-non-zero-rv64.S
+
   - test: pmp-misalign-priority-over-access-fault
     description: >
       Misaligned hsv.d/hlv.d to a PMP-denied paddr must report


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
# Summary

As indicated by https://github.com/openhwgroup/cva6/issues/3462 - the `HFENCE.VVMA`/`HFENCE.GVMA` instructions having non-zero `rd` bits currently trigger virtual instruction exception (mcause 22) instead of illegal instruction (mcause 2) in `V=1` mode.

The changes in this PR make `HFENCE.*` raise `mcause=2` exception in the above case, which is consistent with Spike. The assumption being that [non-zero `rd` bits would cause the instruction to be ill-formed](https://docs.riscv.org/reference/isa/v20260120/priv/hypervisor.html#hfence.vma) (not [HS-qualified](https://docs.riscv.org/reference/isa/v20260120/priv/hypervisor.html#sec:hcauses)). 

Well formed `HFENCE.*` instructions are unaffected and still raise a virtual instruction exception under `V=1`.

The test can be run via:
```
export DV_SIMULATORS=veri-testharness,spike
cd verif/sim
source setup-env.sh
python3 cva6.py --testlist=../tests/testlist_issues.yaml --test hfence-rd-non-zero-rv64 --iss_yaml cva6.yaml --target cv64a6_imafdch_sv39 --iss=$DV_SIMULATORS
```


<!-- Is this PR related to existing issues? If so, link to them below -->

# Related issues

Fixes https://github.com/openhwgroup/cva6/issues/3462

<!-- Are there limitations with the current state of this contribution? -->


<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->
